### PR TITLE
V26-283: add return and exchange operations

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1308 files · ~0 words
+- 1312 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3082 nodes · 2601 edges · 1223 communities detected
+- 3098 nodes · 2616 edges · 1227 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1233,6 +1233,10 @@
 - [[_COMMUNITY_Community 1220|Community 1220]]
 - [[_COMMUNITY_Community 1221|Community 1221]]
 - [[_COMMUNITY_Community 1222|Community 1222]]
+- [[_COMMUNITY_Community 1223|Community 1223]]
+- [[_COMMUNITY_Community 1224|Community 1224]]
+- [[_COMMUNITY_Community 1225|Community 1225]]
+- [[_COMMUNITY_Community 1226|Community 1226]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1365,20 +1369,20 @@ Cohesion: 0.24
 Nodes (6): createApp(), createHandlers(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern()
 
 ### Community 26 - "Community 26"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 27 - "Community 27"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 28 - "Community 28"
+### Community 27 - "Community 27"
 Cohesion: 0.33
 Nodes (9): usePOSActiveSession(), usePOSSessionComplete(), usePOSSessionCreate(), usePOSSessionHold(), usePOSSessionManager(), usePOSSessionResume(), usePOSSessionUpdate(), usePOSSessionVoid() (+1 more)
 
-### Community 29 - "Community 29"
+### Community 28 - "Community 28"
 Cohesion: 0.18
 Nodes (0):
+
+### Community 29 - "Community 29"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 30 - "Community 30"
 Cohesion: 0.18
@@ -1521,16 +1525,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 65 - "Community 65"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 66 - "Community 66"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 67 - "Community 67"
+### Community 66 - "Community 66"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 67 - "Community 67"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 68 - "Community 68"
 Cohesion: 0.52
@@ -1561,20 +1565,20 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 75 - "Community 75"
+Cohesion: 0.4
+Nodes (2): appendTransition(), applyOnlineOrderUpdate()
+
+### Community 76 - "Community 76"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.4
 Nodes (2): buildUsername(), normalizeNameSegment()
-
-### Community 78 - "Community 78"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 79 - "Community 79"
 Cohesion: 0.33
@@ -1589,16 +1593,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 82 - "Community 82"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 83 - "Community 83"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 84 - "Community 84"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 85 - "Community 85"
 Cohesion: 0.33
@@ -1609,51 +1613,51 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 87 - "Community 87"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 88 - "Community 88"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 89 - "Community 89"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 88 - "Community 88"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 89 - "Community 89"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
 ### Community 90 - "Community 90"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 91 - "Community 91"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 92 - "Community 92"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 93 - "Community 93"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 93 - "Community 93"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
 ### Community 94 - "Community 94"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 95 - "Community 95"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 97 - "Community 97"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 98 - "Community 98"
-Cohesion: 0.4
+Cohesion: 0.33
 Nodes (0):
 
 ### Community 99 - "Community 99"
@@ -1669,44 +1673,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 102 - "Community 102"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 103 - "Community 103"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.5
 Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.5
 Nodes (2): buildPaymentAllocation(), recordPaymentAllocationWithCtx()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.6
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
+Cohesion: 0.6
+Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
+
+### Community 109 - "Community 109"
 Cohesion: 0.6
 Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 108 - "Community 108"
+### Community 110 - "Community 110"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 109 - "Community 109"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 110 - "Community 110"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 111 - "Community 111"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 112 - "Community 112"
 Cohesion: 0.4
@@ -1717,12 +1721,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 114 - "Community 114"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 115 - "Community 115"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 115 - "Community 115"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 116 - "Community 116"
 Cohesion: 0.4
@@ -1738,7 +1742,7 @@ Nodes (0):
 
 ### Community 119 - "Community 119"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 120 - "Community 120"
 Cohesion: 0.4
@@ -1757,20 +1761,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 124 - "Community 124"
-Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 125 - "Community 125"
 Cohesion: 0.4
-Nodes (1): MockImage
+Nodes (0):
 
 ### Community 126 - "Community 126"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
 ### Community 127 - "Community 127"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 128 - "Community 128"
 Cohesion: 0.4
@@ -1781,36 +1785,36 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 130 - "Community 130"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 131 - "Community 131"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 132 - "Community 132"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 133 - "Community 133"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 134 - "Community 134"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 135 - "Community 135"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 135 - "Community 135"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
 ### Community 136 - "Community 136"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0):
 
 ### Community 137 - "Community 137"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 138 - "Community 138"
 Cohesion: 0.5
@@ -1821,40 +1825,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 140 - "Community 140"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 141 - "Community 141"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 142 - "Community 142"
 Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 143 - "Community 143"
-Cohesion: 0.67
-Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
 ### Community 144 - "Community 144"
 Cohesion: 0.67
-Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 145 - "Community 145"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
 ### Community 146 - "Community 146"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
 ### Community 147 - "Community 147"
 Cohesion: 0.67
-Nodes (2): appendTransition(), applyOnlineOrderUpdate()
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 148 - "Community 148"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 149 - "Community 149"
 Cohesion: 0.5
@@ -1873,16 +1877,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 153 - "Community 153"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 154 - "Community 154"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 155 - "Community 155"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 156 - "Community 156"
 Cohesion: 0.5
@@ -1893,56 +1897,56 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 158 - "Community 158"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 159 - "Community 159"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 160 - "Community 160"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), parseDateTimeLocal()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 161 - "Community 161"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 162 - "Community 162"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 163 - "Community 163"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 163 - "Community 163"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), parseDateTimeLocal()
 
 ### Community 164 - "Community 164"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 165 - "Community 165"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
+
+### Community 166 - "Community 166"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 167 - "Community 167"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 168 - "Community 168"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 166 - "Community 166"
+### Community 169 - "Community 169"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 167 - "Community 167"
+### Community 170 - "Community 170"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 168 - "Community 168"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 169 - "Community 169"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 170 - "Community 170"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 171 - "Community 171"
 Cohesion: 0.5
@@ -1957,59 +1961,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 174 - "Community 174"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 175 - "Community 175"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 176 - "Community 176"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 177 - "Community 177"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 175 - "Community 175"
+### Community 178 - "Community 178"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 176 - "Community 176"
+### Community 179 - "Community 179"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 177 - "Community 177"
+### Community 180 - "Community 180"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 178 - "Community 178"
+### Community 181 - "Community 181"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 179 - "Community 179"
+### Community 182 - "Community 182"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 180 - "Community 180"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
-
-### Community 181 - "Community 181"
-Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
-
-### Community 182 - "Community 182"
-Cohesion: 0.83
-Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
 ### Community 183 - "Community 183"
 Cohesion: 0.67
-Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 184 - "Community 184"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
 ### Community 185 - "Community 185"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
 ### Community 186 - "Community 186"
 Cohesion: 0.67
-Nodes (0):
+Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
 ### Community 187 - "Community 187"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 188 - "Community 188"
@@ -2029,52 +2033,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 192 - "Community 192"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 193 - "Community 193"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 194 - "Community 194"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 195 - "Community 195"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 196 - "Community 196"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 197 - "Community 197"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 198 - "Community 198"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 199 - "Community 199"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 200 - "Community 200"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 201 - "Community 201"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 202 - "Community 202"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 203 - "Community 203"
-Cohesion: 0.67
-Nodes (1): FadeIn()
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 204 - "Community 204"
 Cohesion: 0.67
@@ -2086,7 +2090,7 @@ Nodes (0):
 
 ### Community 206 - "Community 206"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (1): FadeIn()
 
 ### Community 207 - "Community 207"
 Cohesion: 0.67
@@ -2098,7 +2102,7 @@ Nodes (0):
 
 ### Community 209 - "Community 209"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 210 - "Community 210"
 Cohesion: 0.67
@@ -2134,83 +2138,83 @@ Nodes (0):
 
 ### Community 218 - "Community 218"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 219 - "Community 219"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 220 - "Community 220"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (0):
 
 ### Community 221 - "Community 221"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 222 - "Community 222"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 223 - "Community 223"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 224 - "Community 224"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): DashboardSkeleton()
 
 ### Community 225 - "Community 225"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): TableSkeleton()
 
 ### Community 226 - "Community 226"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 227 - "Community 227"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): NotFound()
 
 ### Community 228 - "Community 228"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 229 - "Community 229"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): AppContextMenu()
 
 ### Community 230 - "Community 230"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): Badge()
 
 ### Community 231 - "Community 231"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): LoadingButton()
 
 ### Community 232 - "Community 232"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): onChange()
 
 ### Community 233 - "Community 233"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): AlertModal()
 
 ### Community 234 - "Community 234"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): OverlayModal()
 
 ### Community 235 - "Community 235"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Skeleton()
 
 ### Community 236 - "Community 236"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 237 - "Community 237"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 238 - "Community 238"
 Cohesion: 0.67
@@ -2230,7 +2234,7 @@ Nodes (0):
 
 ### Community 242 - "Community 242"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 243 - "Community 243"
 Cohesion: 0.67
@@ -2242,7 +2246,7 @@ Nodes (0):
 
 ### Community 245 - "Community 245"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 246 - "Community 246"
 Cohesion: 0.67
@@ -2250,7 +2254,7 @@ Nodes (0):
 
 ### Community 247 - "Community 247"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 248 - "Community 248"
 Cohesion: 0.67
@@ -2258,71 +2262,71 @@ Nodes (0):
 
 ### Community 249 - "Community 249"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 250 - "Community 250"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 251 - "Community 251"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 252 - "Community 252"
-Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 253 - "Community 253"
 Cohesion: 0.67
-Nodes (1): hashPassword()
+Nodes (0):
 
 ### Community 254 - "Community 254"
 Cohesion: 0.67
-Nodes (1): useAppSession()
+Nodes (0):
 
 ### Community 255 - "Community 255"
-Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 256 - "Community 256"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): hashPassword()
 
 ### Community 257 - "Community 257"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAppSession()
 
 ### Community 258 - "Community 258"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (1): createVersionChecker()
 
 ### Community 259 - "Community 259"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 260 - "Community 260"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 261 - "Community 261"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 263 - "Community 263"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 264 - "Community 264"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 265 - "Community 265"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 266 - "Community 266"
 Cohesion: 0.67
@@ -2333,12 +2337,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 268 - "Community 268"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 269 - "Community 269"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 270 - "Community 270"
 Cohesion: 0.67
@@ -2349,8 +2353,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 272 - "Community 272"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 273 - "Community 273"
 Cohesion: 0.67
@@ -2421,52 +2425,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 290 - "Community 290"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 291 - "Community 291"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 292 - "Community 292"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 293 - "Community 293"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 294 - "Community 294"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 295 - "Community 295"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 296 - "Community 296"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 297 - "Community 297"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 298 - "Community 298"
 Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 299 - "Community 299"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 300 - "Community 300"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 301 - "Community 301"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 302 - "Community 302"
 Cohesion: 1.0
@@ -6152,1854 +6156,1872 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1223 - "Community 1223"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1224 - "Community 1224"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1225 - "Community 1225"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1226 - "Community 1226"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 299`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 302`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 303`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 304`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 305`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 306`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `authenticateHandler()`, `cashier.ts`
+- **Thin community `Community 307`** (2 nodes): `authenticateHandler()`, `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 308`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 309`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 310`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 311`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 312`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 313`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 314`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (2 nodes): `buildApprovalRequest()`, `approvalRequests.ts`
+- **Thin community `Community 315`** (2 nodes): `buildApprovalRequest()`, `approvalRequests.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 316`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (2 nodes): `registerSessions.ts`, `buildRegisterSession()`
+- **Thin community `Community 317`** (2 nodes): `registerSessions.ts`, `buildRegisterSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
+- **Thin community `Community 318`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
+- **Thin community `Community 319`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 320`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 321`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 322`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 323`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 324`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 325`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 326`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 327`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 328`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 329`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 330`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 331`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 329`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 332`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 333`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 331`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 334`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 332`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 335`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 336`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 334`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 337`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 335`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 338`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 336`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 339`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 337`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 340`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 338`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 341`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 339`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 342`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 340`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 343`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 341`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 344`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 342`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 345`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 343`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 346`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 344`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 347`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 345`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 348`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 346`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 349`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 347`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 350`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 348`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 351`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 349`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 352`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 350`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 353`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 351`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 354`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 352`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 355`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 356`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 357`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 358`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 359`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 360`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 361`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 362`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 363`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 364`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 365`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 366`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 367`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 368`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 369`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 370`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 371`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 372`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 373`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 374`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 375`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 376`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 377`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 378`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 379`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 380`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
+- **Thin community `Community 381`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 382`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 383`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 384`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 385`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 386`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
+- **Thin community `Community 387`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 388`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 389`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 390`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 391`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 392`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 393`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 394`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
+- **Thin community `Community 395`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 396`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 397`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 398`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `usePOSCashier()`, `hooks.ts`
+- **Thin community `Community 399`** (2 nodes): `usePOSCashier()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
+- **Thin community `Community 400`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
+- **Thin community `Community 401`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 402`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 403`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 404`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 405`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 406`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 407`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 408`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 409`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 410`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 411`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 412`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 413`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 414`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 415`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 416`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 417`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 418`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 419`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
+- **Thin community `Community 420`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 421`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 422`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 423`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 424`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 425`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 426`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 427`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 428`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 429`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 430`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 431`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 432`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 433`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 434`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 435`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
+- **Thin community `Community 436`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 437`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 438`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 439`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 440`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 441`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 442`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 443`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 444`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 445`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 446`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 447`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 448`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 449`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 450`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 451`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 452`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 453`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 454`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 455`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 456`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 457`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 458`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 459`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 460`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 461`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 462`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
+- **Thin community `Community 463`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 464`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 465`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
+- **Thin community `Community 466`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 467`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 468`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 469`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 470`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 471`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 472`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 473`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 474`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 475`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 476`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 477`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 478`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 479`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 480`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
+- **Thin community `Community 481`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 482`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
+- **Thin community `Community 483`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 484`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 485`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 486`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 487`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 488`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 489`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 490`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 491`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 492`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 493`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `LoginLayout()`, `_layout.tsx`
+- **Thin community `Community 494`** (2 nodes): `LoginLayout()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 495`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 496`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 497`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 498`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 499`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 500`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 501`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 502`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 503`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 504`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 505`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 506`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 507`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 508`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 509`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 510`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 511`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 512`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 513`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 514`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 515`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 516`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 517`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 518`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 519`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 520`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 521`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 522`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 523`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 524`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 525`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 526`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 527`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 528`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 529`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 530`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 531`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 532`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 533`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 534`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 535`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 536`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 537`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 538`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 539`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 540`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 541`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 542`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 543`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 544`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 545`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 546`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 547`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 548`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 549`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 550`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 551`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 552`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 553`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 554`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 555`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 556`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 557`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 558`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 559`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 560`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 561`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 562`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 563`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 564`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 565`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 566`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 567`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 568`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 569`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 570`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 571`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 572`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 573`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 574`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 575`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 576`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 577`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 578`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 579`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 580`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 581`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 582`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 583`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 584`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 585`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 586`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 587`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 588`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 589`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 590`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 591`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 592`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 593`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 594`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 595`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 596`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 597`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 598`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 599`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 600`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 601`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 602`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 603`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 604`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 605`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 606`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 607`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 608`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 609`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 610`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 611`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 612`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 613`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 614`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 615`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 616`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 617`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 618`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 619`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 620`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 621`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 622`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 623`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (1 nodes): `api.d.ts`
+- **Thin community `Community 624`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (1 nodes): `api.js`
+- **Thin community `Community 625`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 626`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (1 nodes): `server.d.ts`
+- **Thin community `Community 627`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (1 nodes): `server.js`
+- **Thin community `Community 628`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (1 nodes): `app.ts`
+- **Thin community `Community 629`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (1 nodes): `auth.config.js`
+- **Thin community `Community 630`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (1 nodes): `auth.ts`
+- **Thin community `Community 631`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (1 nodes): `countries.ts`
+- **Thin community `Community 632`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (1 nodes): `email.ts`
+- **Thin community `Community 633`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (1 nodes): `ghana.ts`
+- **Thin community `Community 634`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (1 nodes): `payment.ts`
+- **Thin community `Community 635`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (1 nodes): `crons.ts`
+- **Thin community `Community 636`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 637`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 638`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 639`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 640`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (1 nodes): `env.ts`
+- **Thin community `Community 641`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (1 nodes): `analytics.ts`
+- **Thin community `Community 642`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (1 nodes): `auth.ts`
+- **Thin community `Community 643`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 644`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (1 nodes): `categories.ts`
+- **Thin community `Community 645`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (1 nodes): `colors.ts`
+- **Thin community `Community 646`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (1 nodes): `index.ts`
+- **Thin community `Community 647`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (1 nodes): `organizations.ts`
+- **Thin community `Community 648`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (1 nodes): `products.ts`
+- **Thin community `Community 649`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (1 nodes): `stores.ts`
+- **Thin community `Community 650`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (1 nodes): `subcategories.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (1 nodes): `index.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (1 nodes): `bag.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (1 nodes): `guest.ts`
+- **Thin community `Community 651`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 652`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (1 nodes): `me.ts`
+- **Thin community `Community 653`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (1 nodes): `offers.ts`
+- **Thin community `Community 654`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 655`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (1 nodes): `paystack.ts`
+- **Thin community `Community 656`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (1 nodes): `reviews.ts`
+- **Thin community `Community 657`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (1 nodes): `rewards.ts`
+- **Thin community `Community 658`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 659`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (1 nodes): `security.test.ts`
+- **Thin community `Community 660`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (1 nodes): `storefront.ts`
+- **Thin community `Community 661`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (1 nodes): `upsells.ts`
+- **Thin community `Community 662`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (1 nodes): `user.ts`
+- **Thin community `Community 663`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 664`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (1 nodes): `health.test.ts`
+- **Thin community `Community 665`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (1 nodes): `http.ts`
+- **Thin community `Community 666`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 667`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (1 nodes): `auth.ts`
+- **Thin community `Community 668`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 669`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 670`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `categories.ts`
+- **Thin community `Community 671`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `colors.ts`
+- **Thin community `Community 672`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 673`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 674`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 675`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 676`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 677`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 678`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `organizations.ts`
+- **Thin community `Community 679`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 680`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 681`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 682`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `productSku.ts`
+- **Thin community `Community 683`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 684`** (1 nodes): `posSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 685`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 686`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 687`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 688`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 689`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 690`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 691`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 692`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `client.test.ts`
+- **Thin community `Community 693`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `config.test.ts`
+- **Thin community `Community 694`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 695`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `types.ts`
+- **Thin community `Community 696`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `approvalRequests.test.ts`
+- **Thin community `Community 697`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 698`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 699`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 700`** (1 nodes): `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `staffProfiles.test.ts`
+- **Thin community `Community 701`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `ResendOTP.ts`
+- **Thin community `Community 702`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `schema.ts`
+- **Thin community `Community 703`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 704`** (1 nodes): `staffProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 705`** (1 nodes): `ResendOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 706`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 707`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `cashier.ts`
+- **Thin community `Community 708`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `category.ts`
+- **Thin community `Community 709`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `color.ts`
+- **Thin community `Community 710`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 711`** (1 nodes): `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 712`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `index.ts`
+- **Thin community `Community 713`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 714`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `organization.ts`
+- **Thin community `Community 715`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 716`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `product.ts`
+- **Thin community `Community 717`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 718`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 719`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `store.ts`
+- **Thin community `Community 720`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 721`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 722`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 723`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `index.ts`
+- **Thin community `Community 724`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 725`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 726`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 727`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 728`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 729`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 730`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 731`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 732`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `customer.ts`
+- **Thin community `Community 733`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 734`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 735`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 736`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 737`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `index.ts`
+- **Thin community `Community 738`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `posSession.ts`
+- **Thin community `Community 739`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 740`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 741`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 742`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 743`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `index.ts`
+- **Thin community `Community 744`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 745`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 746`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 747`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 748`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 749`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `analytics.ts`
+- **Thin community `Community 750`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `bag.ts`
+- **Thin community `Community 751`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 752`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 753`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 754`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `customer.ts`
+- **Thin community `Community 755`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `guest.ts`
+- **Thin community `Community 756`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `index.ts`
+- **Thin community `Community 757`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `offer.ts`
+- **Thin community `Community 758`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 759`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 760`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `review.ts`
+- **Thin community `Community 761`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `rewards.ts`
+- **Thin community `Community 762`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 763`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 764`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 765`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 766`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 767`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 768`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 769`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `bag.ts`
+- **Thin community `Community 770`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 771`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `customer.ts`
+- **Thin community `Community 772`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `guest.ts`
+- **Thin community `Community 773`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 774`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 775`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `payment.ts`
+- **Thin community `Community 776`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 777`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `rewards.ts`
+- **Thin community `Community 778`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 779`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 780`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `users.ts`
+- **Thin community `Community 781`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `payment.ts`
+- **Thin community `Community 782`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 783`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `index.ts`
+- **Thin community `Community 784`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 785`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 786`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 787`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 788`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 789`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 790`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 791`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `constants.ts`
+- **Thin community `Community 792`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 793`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 794`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 795`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `types.ts`
+- **Thin community `Community 796`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 797`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 798`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 799`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 800`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 801`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 802`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 803`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 804`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `columns.tsx`
+- **Thin community `Community 805`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 806`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 807`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 808`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 809`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `columns.tsx`
+- **Thin community `Community 810`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 811`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 812`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `chart.tsx`
+- **Thin community `Community 813`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `columns.tsx`
+- **Thin community `Community 814`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 815`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 816`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 817`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `constants.ts`
+- **Thin community `Community 818`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 819`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 820`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 821`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `data.ts`
+- **Thin community `Community 822`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `columns.tsx`
+- **Thin community `Community 823`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 824`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 825`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 826`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 827`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 828`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 829`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 830`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 831`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 832`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 833`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `constants.ts`
+- **Thin community `Community 834`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 835`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 836`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 837`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `data.ts`
+- **Thin community `Community 838`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 839`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 840`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `columns.tsx`
+- **Thin community `Community 841`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 842`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 843`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 844`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 845`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 846`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `columns.tsx`
+- **Thin community `Community 847`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `constants.ts`
+- **Thin community `Community 848`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 849`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 850`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 851`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 852`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `index.tsx`
+- **Thin community `Community 853`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `columns.tsx`
+- **Thin community `Community 854`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 855`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 856`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 857`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 858`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 859`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `OperationsQueueView.tsx`
+- **Thin community `Community 860`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 861`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 862`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 863`** (1 nodes): `OperationsQueueView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 864`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `constants.ts`
+- **Thin community `Community 865`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 866`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 867`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 868`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `data.ts`
+- **Thin community `Community 869`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 870`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `constants.ts`
+- **Thin community `Community 871`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 872`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 873`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 874`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 875`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `data.ts`
+- **Thin community `Community 876`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 877`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `constants.ts`
+- **Thin community `Community 878`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 879`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 880`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 881`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 882`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `data.ts`
+- **Thin community `Community 883`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 884`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 885`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 886`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 887`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 888`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 889`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 890`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 891`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 892`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 893`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `types.ts`
+- **Thin community `Community 894`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 895`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 896`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 897`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 898`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 899`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 900`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 901`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `Products.tsx`
+- **Thin community `Community 902`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 903`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 904`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 905`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 906`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 907`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 908`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 909`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 910`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 911`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `data.ts`
+- **Thin community `Community 912`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 913`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `PromoCodePreview.tsx`
+- **Thin community `Community 914`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 915`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 916`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 917`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `columns.tsx`
+- **Thin community `Community 918`** (1 nodes): `PromoCodePreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 919`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 920`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 921`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 922`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 923`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `columns.tsx`
+- **Thin community `Community 924`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `constants.ts`
+- **Thin community `Community 925`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 926`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 927`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 928`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `data.ts`
+- **Thin community `Community 929`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `types.ts`
+- **Thin community `Community 930`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 931`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 932`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 933`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 934`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `ServiceAppointmentsView.test.tsx`
+- **Thin community `Community 935`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `ServiceCasesView.test.tsx`
+- **Thin community `Community 936`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `ServiceCatalogView.test.tsx`
+- **Thin community `Community 937`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `ServiceIntakeView.test.tsx`
+- **Thin community `Community 938`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 939`** (1 nodes): `ServiceAppointmentsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `index.tsx`
+- **Thin community `Community 940`** (1 nodes): `ServiceCasesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 941`** (1 nodes): `ServiceCatalogView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 942`** (1 nodes): `ServiceIntakeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `button.tsx`
+- **Thin community `Community 943`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 944`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `card.tsx`
+- **Thin community `Community 945`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 946`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 947`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `command.tsx`
+- **Thin community `Community 948`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 949`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 950`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 951`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `form.tsx`
+- **Thin community `Community 952`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `icons.tsx`
+- **Thin community `Community 953`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 954`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `input.tsx`
+- **Thin community `Community 955`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 956`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `popover.tsx`
+- **Thin community `Community 957`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 958`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 959`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 960`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `select.tsx`
+- **Thin community `Community 961`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `separator.tsx`
+- **Thin community `Community 962`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 963`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `switch.tsx`
+- **Thin community `Community 964`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `table.tsx`
+- **Thin community `Community 965`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 966`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 967`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 968`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 969`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 970`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 971`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 972`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `columns.tsx`
+- **Thin community `Community 973`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `constants.ts`
+- **Thin community `Community 974`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 975`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 976`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 977`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `data.ts`
+- **Thin community `Community 978`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 979`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 980`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `columns.tsx`
+- **Thin community `Community 981`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 982`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 983`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 984`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 985`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 986`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 987`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 988`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 989`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 990`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 991`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `index.ts`
+- **Thin community `Community 992`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `config.ts`
+- **Thin community `Community 993`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 994`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 995`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 996`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `aws.ts`
+- **Thin community `Community 997`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `constants.ts`
+- **Thin community `Community 998`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `countries.ts`
+- **Thin community `Community 999`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1000`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1001`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1002`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1003`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1004`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `category.ts`
+- **Thin community `Community 1005`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `product.ts`
+- **Thin community `Community 1006`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `store.ts`
+- **Thin community `Community 1007`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1008`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `user.ts`
+- **Thin community `Community 1009`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1010`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1011`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1012`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1013`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `index.tsx`
+- **Thin community `Community 1014`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `index.tsx`
+- **Thin community `Community 1015`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `index.tsx`
+- **Thin community `Community 1016`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1017`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1018`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1019`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1020`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1021`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `index.tsx`
+- **Thin community `Community 1022`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1023`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1024`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1025`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `home.tsx`
+- **Thin community `Community 1026`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1027`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1028`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1029`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `index.tsx`
+- **Thin community `Community 1030`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `index.tsx`
+- **Thin community `Community 1031`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1032`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1033`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1034`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1035`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1036`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1037`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1038`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1039`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1040`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1041`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1042`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `index.tsx`
+- **Thin community `Community 1043`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1044`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1045`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1046`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1047`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1048`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `index.tsx`
+- **Thin community `Community 1049`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `index.tsx`
+- **Thin community `Community 1050`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `new.tsx`
+- **Thin community `Community 1051`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `index.tsx`
+- **Thin community `Community 1052`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `new.tsx`
+- **Thin community `Community 1053`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1054`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1055`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1056`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1057`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `index.tsx`
+- **Thin community `Community 1058`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1059`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1060`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1061`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1062`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1063`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1064`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `index.tsx`
+- **Thin community `Community 1065`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1066`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1067`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1068`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1069`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `posStore.ts`
+- **Thin community `Community 1070`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1071`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1072`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1073`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1074`** (1 nodes): `posStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1075`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1076`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1077`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1078`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1079`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1080`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1081`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1082`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `setup.ts`
+- **Thin community `Community 1083`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1084`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1085`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `types.ts`
+- **Thin community `Community 1086`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1087`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1088`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1089`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1090`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1091`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1092`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `types.ts`
+- **Thin community `Community 1093`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1094`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `client.tsx`
+- **Thin community `Community 1095`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1096`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1097`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1098`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1099`** (1 nodes): `client.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1100`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1101`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1102`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1103`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `schema.ts`
+- **Thin community `Community 1104`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1105`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1106`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1107`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1108`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1109`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1110`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1111`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1112`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1113`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `types.ts`
+- **Thin community `Community 1114`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1115`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1116`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1117`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1118`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1119`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1120`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1121`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `constants.ts`
+- **Thin community `Community 1122`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1123`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `About.tsx`
+- **Thin community `Community 1124`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1125`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1126`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1127`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1128`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1129`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1130`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1131`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1132`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1133`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `types.ts`
+- **Thin community `Community 1134`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1135`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1136`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1137`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1138`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1139`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1140`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1141`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1142`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1143`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1144`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `button.tsx`
+- **Thin community `Community 1145`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `card.tsx`
+- **Thin community `Community 1146`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1147`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `command.tsx`
+- **Thin community `Community 1148`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1149`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1150`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1151`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `form.tsx`
+- **Thin community `Community 1152`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1153`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1154`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1155`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1156`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `input.tsx`
+- **Thin community `Community 1157`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `label.tsx`
+- **Thin community `Community 1158`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1159`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1160`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1161`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `index.ts`
+- **Thin community `Community 1162`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `types.ts`
+- **Thin community `Community 1163`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1164`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1165`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1166`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1167`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `select.tsx`
+- **Thin community `Community 1168`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1169`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1170`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `table.tsx`
+- **Thin community `Community 1171`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1172`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1173`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1174`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1175`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1176`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `config.ts`
+- **Thin community `Community 1177`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1178`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1179`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1180`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `constants.ts`
+- **Thin community `Community 1181`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `countries.ts`
+- **Thin community `Community 1182`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1183`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1184`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1185`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1186`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `index.ts`
+- **Thin community `Community 1187`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `store.ts`
+- **Thin community `Community 1188`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `bag.ts`
+- **Thin community `Community 1189`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1190`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `category.ts`
+- **Thin community `Community 1191`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `organization.ts`
+- **Thin community `Community 1192`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `product.ts`
+- **Thin community `Community 1193`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `store.ts`
+- **Thin community `Community 1194`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1195`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `user.ts`
+- **Thin community `Community 1196`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `states.ts`
+- **Thin community `Community 1197`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1198`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1199`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1200`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1201`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1202`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1203`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1204`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `index.tsx`
+- **Thin community `Community 1205`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1206`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `index.tsx`
+- **Thin community `Community 1207`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1208`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1209`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1210`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1211`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1212`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `index.tsx`
+- **Thin community `Community 1213`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1214`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `ssr.tsx`
+- **Thin community `Community 1215`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1216`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1217`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1218`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `index.js`
+- **Thin community `Community 1219`** (1 nodes): `ssr.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1220`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1221`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1222`** (1 nodes): `vitest.setup.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1223`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1224`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1225`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1226`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -5387,7 +5387,7 @@
       "relation": "calls",
       "source": "onlineorder_appendtransition",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L110",
+      "source_location": "L118",
       "target": "onlineorder_applyonlineorderupdate",
       "weight": 1
     },
@@ -9424,6 +9424,54 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
+      "_tgt": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L115",
+      "target": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
+      "_tgt": "returnexchangeoperations_getapprovalreason",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L90",
+      "target": "returnexchangeoperations_getapprovalreason",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
+      "_tgt": "returnexchangeoperations_getkind",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L74",
+      "target": "returnexchangeoperations_getkind",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
+      "_tgt": "returnexchangeoperations_getlinerefundamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L70",
+      "target": "returnexchangeoperations_getlinerefundamount",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_convex_storefront_offers_ts",
       "_tgt": "offers_createoffer",
       "confidence": "EXTRACTED",
@@ -9479,7 +9527,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_onlineorder_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L51",
+      "source_location": "L59",
       "target": "onlineorder_appendtransition",
       "weight": 1
     },
@@ -9491,8 +9539,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_onlineorder_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L75",
+      "source_location": "L83",
       "target": "onlineorder_applyonlineorderupdate",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "_tgt": "onlineorder_buildreturnexchangereplacementsourceid",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L202",
+      "target": "onlineorder_buildreturnexchangereplacementsourceid",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "_tgt": "onlineorder_buildreturnexchangereturnsourceid",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L210",
+      "target": "onlineorder_buildreturnexchangereturnsourceid",
       "weight": 1
     },
     {
@@ -9503,7 +9575,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_onlineorder_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L41",
+      "source_location": "L49",
       "target": "onlineorder_listorderitems",
       "weight": 1
     },
@@ -9517,6 +9589,42 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L25",
       "target": "onlineorderitem_updateonlineorderitem",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "_tgt": "returnexchangeoperations_test_createorderitem",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L13",
+      "target": "returnexchangeoperations_test_createorderitem",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "_tgt": "returnexchangeoperations_test_createreplacement",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L31",
+      "target": "returnexchangeoperations_test_createreplacement",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "_tgt": "returnexchangeoperations_test_getsource",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L9",
+      "target": "returnexchangeoperations_test_getsource",
       "weight": 1
     },
     {
@@ -12335,7 +12443,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
-      "source_location": "L67",
+      "source_location": "L68",
       "target": "orderview_handlerefundorder",
       "weight": 1
     },
@@ -12469,6 +12577,42 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L199",
       "target": "refundutils_validaterefund",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
+      "_tgt": "returnexchangeview_handlesubmit",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L374",
+      "target": "returnexchangeview_handlesubmit",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
+      "_tgt": "returnexchangeview_resetreplacementfields",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L95",
+      "target": "returnexchangeview_resetreplacementfields",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
+      "_tgt": "returnexchangeview_toggleitem",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L81",
+      "target": "returnexchangeview_toggleitem",
       "weight": 1
     },
     {
@@ -24592,6 +24736,42 @@
       "weight": 1
     },
     {
+      "_src": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
+      "_tgt": "returnexchangeoperations_getapprovalreason",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "returnexchangeoperations_getapprovalreason",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L157",
+      "target": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
+      "weight": 1
+    },
+    {
+      "_src": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
+      "_tgt": "returnexchangeoperations_getkind",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "returnexchangeoperations_getkind",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L144",
+      "target": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
+      "weight": 1
+    },
+    {
+      "_src": "returnexchangeview_handlesubmit",
+      "_tgt": "returnexchangeview_resetreplacementfields",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "returnexchangeview_resetreplacementfields",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L149",
+      "target": "returnexchangeview_handlesubmit",
+      "weight": 1
+    },
+    {
       "_src": "reviews_createreview",
       "_tgt": "reviews_getbaseurl",
       "confidence": "EXTRACTED",
@@ -32238,50 +32418,86 @@
     {
       "community": 100,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "label": "posSessions.ts",
-      "norm_label": "possessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
+      "label": "validateExpenseItemBelongsToSession()",
+      "norm_label": "validateexpenseitembelongstosession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionactive",
+      "label": "validateExpenseSessionActive()",
+      "norm_label": "validateexpensesessionactive()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionexists",
+      "label": "validateExpenseSessionExists()",
+      "norm_label": "validateexpensesessionexists()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
+      "label": "validateExpenseSessionModifiable()",
+      "norm_label": "validateexpensesessionmodifiable()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
+      "label": "expenseSessionValidation.ts",
+      "norm_label": "expensesessionvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L1"
     },
     {
-      "community": 100,
-      "file_type": "code",
-      "id": "possessions_buildnextsessionnumber",
-      "label": "buildNextSessionNumber()",
-      "norm_label": "buildnextsessionnumber()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "possessions_listpossessionsbystatusbefore",
-      "label": "listPosSessionsByStatusBefore()",
-      "norm_label": "listpossessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "possessions_listpossessionsforstorestatus",
-      "label": "listPosSessionsForStoreStatus()",
-      "norm_label": "listpossessionsforstorestatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "possessions_loadpossessionitems",
-      "label": "loadPosSessionItems()",
-      "norm_label": "loadpossessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L45"
-    },
-    {
       "community": 1000,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_aws_ts",
+      "label": "aws.ts",
+      "norm_label": "aws.ts",
+      "source_file": "packages/athena-webapp/src/lib/aws.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1003,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/src/lib/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -32290,7 +32506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -32299,7 +32515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -32308,7 +32524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -32317,7 +32533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -32326,7 +32542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -32335,7 +32551,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "label": "posSessions.ts",
+      "norm_label": "possessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "possessions_buildnextsessionnumber",
+      "label": "buildNextSessionNumber()",
+      "norm_label": "buildnextsessionnumber()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "possessions_listpossessionsbystatusbefore",
+      "label": "listPosSessionsByStatusBefore()",
+      "norm_label": "listpossessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "possessions_listpossessionsforstorestatus",
+      "label": "listPosSessionsForStoreStatus()",
+      "norm_label": "listpossessionsforstorestatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "possessions_loadpossessionitems",
+      "label": "loadPosSessionItems()",
+      "norm_label": "loadpossessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 1010,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -32344,7 +32605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1011,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -32353,7 +32614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -32362,7 +32623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1009,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -32371,52 +32632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 101,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_products_ts",
-      "label": "products.ts",
-      "norm_label": "products.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "products_calculatetotalavailablecount",
-      "label": "calculateTotalAvailableCount()",
-      "norm_label": "calculatetotalavailablecount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "products_calculatetotalinventorycount",
-      "label": "calculateTotalInventoryCount()",
-      "norm_label": "calculatetotalinventorycount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "products_generatebarcode",
-      "label": "generateBarcode()",
-      "norm_label": "generatebarcode()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "products_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 1010,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -32425,7 +32641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -32434,7 +32650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -32443,7 +32659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -32452,7 +32668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -32461,7 +32677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -32470,7 +32686,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 102,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_products_ts",
+      "label": "products.ts",
+      "norm_label": "products.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "products_calculatetotalavailablecount",
+      "label": "calculateTotalAvailableCount()",
+      "norm_label": "calculatetotalavailablecount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "products_calculatetotalinventorycount",
+      "label": "calculateTotalInventoryCount()",
+      "norm_label": "calculatetotalinventorycount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "products_generatebarcode",
+      "label": "generateBarcode()",
+      "norm_label": "generatebarcode()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "products_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 1020,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -32479,7 +32740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1021,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -32488,7 +32749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -32497,7 +32758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1019,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -32506,52 +32767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 102,
-      "file_type": "code",
-      "id": "customerprofiles_compactrecord",
-      "label": "compactRecord()",
-      "norm_label": "compactrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
-      "label": "ensureCustomerProfileFromSourcesWithCtx()",
-      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "customerprofiles_findexistingprofile",
-      "label": "findExistingProfile()",
-      "norm_label": "findexistingprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "customerprofiles_loadcustomersources",
-      "label": "loadCustomerSources()",
-      "norm_label": "loadcustomersources()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
-      "label": "customerProfiles.ts",
-      "norm_label": "customerprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1020,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -32560,7 +32776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -32569,7 +32785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -32578,7 +32794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -32587,7 +32803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -32596,7 +32812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -32605,7 +32821,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 103,
+      "file_type": "code",
+      "id": "customerprofiles_compactrecord",
+      "label": "compactRecord()",
+      "norm_label": "compactrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
+      "label": "ensureCustomerProfileFromSourcesWithCtx()",
+      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "customerprofiles_findexistingprofile",
+      "label": "findExistingProfile()",
+      "norm_label": "findexistingprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "customerprofiles_loadcustomersources",
+      "label": "loadCustomerSources()",
+      "norm_label": "loadcustomersources()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
+      "label": "customerProfiles.ts",
+      "norm_label": "customerprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1030,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -32614,7 +32875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1031,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -32623,7 +32884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -32632,7 +32893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1029,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -32641,52 +32902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 103,
-      "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1030,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
@@ -32695,7 +32911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -32704,7 +32920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -32713,7 +32929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -32722,7 +32938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -32731,7 +32947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -32740,7 +32956,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 104,
+      "file_type": "code",
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1040,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -32749,7 +33010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1041,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -32758,7 +33019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -32767,7 +33028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1039,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -32776,52 +33037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 104,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 1040,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -32830,7 +33046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -32839,7 +33055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -32848,7 +33064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -32857,7 +33073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -32866,7 +33082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -32875,7 +33091,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 105,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 1050,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -32884,7 +33145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1051,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -32893,7 +33154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -32902,7 +33163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1049,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -32911,52 +33172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 105,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
-      "label": "serviceIntake.ts",
-      "norm_label": "serviceintake.ts",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "serviceintake_resolveserviceintakecustomerprofile",
-      "label": "resolveServiceIntakeCustomerProfile()",
-      "norm_label": "resolveserviceintakecustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "serviceintake_splitfullname",
-      "label": "splitFullName()",
-      "norm_label": "splitfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "serviceintake_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "serviceintake_validateserviceintakeinput",
-      "label": "validateServiceIntakeInput()",
-      "norm_label": "validateserviceintakeinput()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 1050,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -32965,7 +33181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -32974,7 +33190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -32983,7 +33199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -32992,7 +33208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -33001,7 +33217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -33010,7 +33226,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 106,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
+      "label": "serviceIntake.ts",
+      "norm_label": "serviceintake.ts",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "serviceintake_resolveserviceintakecustomerprofile",
+      "label": "resolveServiceIntakeCustomerProfile()",
+      "norm_label": "resolveserviceintakecustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "serviceintake_splitfullname",
+      "label": "splitFullName()",
+      "norm_label": "splitfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "serviceintake_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "serviceintake_validateserviceintakeinput",
+      "label": "validateServiceIntakeInput()",
+      "norm_label": "validateserviceintakeinput()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 1060,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -33019,7 +33280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1061,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -33028,7 +33289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -33037,7 +33298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1059,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -33046,52 +33307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 106,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_paystackservice_ts",
-      "label": "paystackService.ts",
-      "norm_label": "paystackservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paystackservice_getpaystackheaders",
-      "label": "getPaystackHeaders()",
-      "norm_label": "getpaystackheaders()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paystackservice_initializetransaction",
-      "label": "initializeTransaction()",
-      "norm_label": "initializetransaction()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paystackservice_initiaterefund",
-      "label": "initiateRefund()",
-      "norm_label": "initiaterefund()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paystackservice_verifytransaction",
-      "label": "verifyTransaction()",
-      "norm_label": "verifytransaction()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 1060,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -33100,7 +33316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -33109,7 +33325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -33118,7 +33334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -33127,7 +33343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -33136,7 +33352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -33145,7 +33361,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 107,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_paystackservice_ts",
+      "label": "paystackService.ts",
+      "norm_label": "paystackservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paystackservice_getpaystackheaders",
+      "label": "getPaystackHeaders()",
+      "norm_label": "getpaystackheaders()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paystackservice_initializetransaction",
+      "label": "initializeTransaction()",
+      "norm_label": "initializetransaction()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paystackservice_initiaterefund",
+      "label": "initiateRefund()",
+      "norm_label": "initiaterefund()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paystackservice_verifytransaction",
+      "label": "verifyTransaction()",
+      "norm_label": "verifytransaction()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 1070,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -33154,7 +33415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1071,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -33163,7 +33424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -33172,7 +33433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1069,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -33181,52 +33442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 107,
-      "file_type": "code",
-      "id": "offers_createoffer",
-      "label": "createOffer()",
-      "norm_label": "createoffer()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "offers_getupsellproducts",
-      "label": "getUpsellProducts()",
-      "norm_label": "getupsellproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L685"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "offers_isduplicate",
-      "label": "isDuplicate()",
-      "norm_label": "isduplicate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "offers_updatestorefrontactoremail",
-      "label": "updateStoreFrontActorEmail()",
-      "norm_label": "updatestorefrontactoremail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1070,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_posstore_ts",
       "label": "posStore.ts",
@@ -33235,7 +33451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -33244,7 +33460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -33253,7 +33469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -33262,7 +33478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -33271,7 +33487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -33280,7 +33496,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 108,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
+      "label": "returnExchangeOperations.ts",
+      "norm_label": "returnexchangeoperations.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
+      "label": "buildOnlineOrderReturnExchangePlan()",
+      "norm_label": "buildonlineorderreturnexchangeplan()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getapprovalreason",
+      "label": "getApprovalReason()",
+      "norm_label": "getapprovalreason()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getkind",
+      "label": "getKind()",
+      "norm_label": "getkind()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getlinerefundamount",
+      "label": "getLineRefundAmount()",
+      "norm_label": "getlinerefundamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 1080,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -33289,7 +33550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1081,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -33298,7 +33559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -33307,7 +33568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1079,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -33316,52 +33577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 108,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
-      "label": "storefrontObservabilityReport.ts",
-      "norm_label": "storefrontobservabilityreport.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
-      "label": "buildStorefrontObservabilityReport()",
-      "norm_label": "buildstorefrontobservabilityreport()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_getnonemptystring",
-      "label": "getNonEmptyString()",
-      "norm_label": "getnonemptystring()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_gettrafficsource",
-      "label": "getTrafficSource()",
-      "norm_label": "gettrafficsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
-      "label": "normalizeStorefrontObservabilityEvent()",
-      "norm_label": "normalizestorefrontobservabilityevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 1080,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -33370,7 +33586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -33379,7 +33595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -33388,7 +33604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -33397,7 +33613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -33406,7 +33622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -33415,7 +33631,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 109,
+      "file_type": "code",
+      "id": "offers_createoffer",
+      "label": "createOffer()",
+      "norm_label": "createoffer()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "offers_getupsellproducts",
+      "label": "getUpsellProducts()",
+      "norm_label": "getupsellproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L685"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "offers_isduplicate",
+      "label": "isDuplicate()",
+      "norm_label": "isduplicate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "offers_updatestorefrontactoremail",
+      "label": "updateStoreFrontActorEmail()",
+      "norm_label": "updatestorefrontactoremail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1090,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -33424,7 +33685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1091,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -33433,7 +33694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -33442,7 +33703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1089,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -33451,52 +33712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 109,
-      "file_type": "code",
-      "id": "navbar_appheader",
-      "label": "AppHeader()",
-      "norm_label": "appheader()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "navbar_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "navbar_navbar",
-      "label": "Navbar()",
-      "norm_label": "navbar()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "navbar_settingsheader",
-      "label": "SettingsHeader()",
-      "norm_label": "settingsheader()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_navbar_tsx",
-      "label": "Navbar.tsx",
-      "norm_label": "navbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1090,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -33505,7 +33721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -33514,7 +33730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -33523,7 +33739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -33532,7 +33748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -33541,48 +33757,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_client_tsx",
       "label": "client.tsx",
       "norm_label": "client.tsx",
       "source_file": "packages/storefront-webapp/src/client.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1096,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
-      "label": "DefaultCatchBoundary.tsx",
-      "norm_label": "defaultcatchboundary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1097,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
-      "label": "HomePage.test.tsx",
-      "norm_label": "homepage.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1098,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
-      "label": "ProductCard.test.tsx",
-      "norm_label": "productcard.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_tsx",
-      "label": "ProductCard.tsx",
-      "norm_label": "productcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
       "source_location": "L1"
     },
     {
@@ -33768,50 +33948,86 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
-      "label": "ProductCategorization.tsx",
-      "norm_label": "productcategorization.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
+      "label": "storefrontObservabilityReport.ts",
+      "norm_label": "storefrontobservabilityreport.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L1"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "productcategorization_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L286"
+      "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
+      "label": "buildStorefrontObservabilityReport()",
+      "norm_label": "buildstorefrontobservabilityreport()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L124"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "productcategorization_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L203"
+      "id": "storefrontobservabilityreport_getnonemptystring",
+      "label": "getNonEmptyString()",
+      "norm_label": "getnonemptystring()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L67"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "productcategorization_handleproductvisibility",
-      "label": "handleProductVisibility()",
-      "norm_label": "handleproductvisibility()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L243"
+      "id": "storefrontobservabilityreport_gettrafficsource",
+      "label": "getTrafficSource()",
+      "norm_label": "gettrafficsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L106"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "productcategorization_setinitialselectedoption",
-      "label": "setInitialSelectedOption()",
-      "norm_label": "setinitialselectedoption()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L230"
+      "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
+      "label": "normalizeStorefrontObservabilityEvent()",
+      "norm_label": "normalizestorefrontobservabilityevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L73"
     },
     {
       "community": 1100,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
+      "label": "DefaultCatchBoundary.tsx",
+      "norm_label": "defaultcatchboundary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
+      "label": "HomePage.test.tsx",
+      "norm_label": "homepage.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1102,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
+      "label": "ProductCard.test.tsx",
+      "norm_label": "productcard.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1103,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productcard_tsx",
+      "label": "ProductCard.tsx",
+      "norm_label": "productcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1104,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -33820,7 +34036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -33829,7 +34045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -33838,7 +34054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -33847,7 +34063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -33856,7 +34072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -33865,7 +34081,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 111,
+      "file_type": "code",
+      "id": "navbar_appheader",
+      "label": "AppHeader()",
+      "norm_label": "appheader()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "navbar_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "navbar_navbar",
+      "label": "Navbar()",
+      "norm_label": "navbar()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "navbar_settingsheader",
+      "label": "SettingsHeader()",
+      "norm_label": "settingsheader()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_navbar_tsx",
+      "label": "Navbar.tsx",
+      "norm_label": "navbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1110,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -33874,7 +34135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1111,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -33883,7 +34144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -33892,7 +34153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1109,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -33901,52 +34162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 111,
-      "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1110,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -33955,7 +34171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -33964,7 +34180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -33973,7 +34189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -33982,7 +34198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -33991,7 +34207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -34000,7 +34216,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 112,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
+      "label": "ProductCategorization.tsx",
+      "norm_label": "productcategorization.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "productcategorization_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L286"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "productcategorization_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L203"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "productcategorization_handleproductvisibility",
+      "label": "handleProductVisibility()",
+      "norm_label": "handleproductvisibility()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L243"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "productcategorization_setinitialselectedoption",
+      "label": "setInitialSelectedOption()",
+      "norm_label": "setinitialselectedoption()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L230"
+    },
+    {
+      "community": 1120,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -34009,7 +34270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1121,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -34018,7 +34279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -34027,7 +34288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1119,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -34036,52 +34297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 112,
-      "file_type": "code",
-      "id": "dashboard_getperiodrange",
-      "label": "getPeriodRange()",
-      "norm_label": "getperiodrange()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "dashboard_loadingsection",
-      "label": "LoadingSection()",
-      "norm_label": "loadingsection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "dashboard_renderproductssection",
-      "label": "renderProductsSection()",
-      "norm_label": "renderproductssection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "dashboard_rendersalessection",
-      "label": "renderSalesSection()",
-      "norm_label": "rendersalessection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L322"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "label": "Dashboard.tsx",
-      "norm_label": "dashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1120,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -34090,7 +34306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -34099,7 +34315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -34108,7 +34324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -34117,7 +34333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -34126,7 +34342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -34135,7 +34351,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 113,
+      "file_type": "code",
+      "id": "dashboard_getperiodrange",
+      "label": "getPeriodRange()",
+      "norm_label": "getperiodrange()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "dashboard_loadingsection",
+      "label": "LoadingSection()",
+      "norm_label": "loadingsection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "dashboard_renderproductssection",
+      "label": "renderProductsSection()",
+      "norm_label": "renderproductssection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "dashboard_rendersalessection",
+      "label": "renderSalesSection()",
+      "norm_label": "rendersalessection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
+      "label": "Dashboard.tsx",
+      "norm_label": "dashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1130,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -34144,7 +34405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1131,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -34153,7 +34414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -34162,7 +34423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1129,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -34171,52 +34432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 113,
-      "file_type": "code",
-      "id": "herosectiontabs_handledisplaytypechange",
-      "label": "handleDisplayTypeChange()",
-      "norm_label": "handledisplaytypechange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "herosectiontabs_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L57"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "herosectiontabs_handleoverlaytoggle",
-      "label": "handleOverlayToggle()",
-      "norm_label": "handleoverlaytoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "herosectiontabs_handletexttoggle",
-      "label": "handleTextToggle()",
-      "norm_label": "handletexttoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L134"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
-      "label": "HeroSectionTabs.tsx",
-      "norm_label": "herosectiontabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1130,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -34225,7 +34441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -34234,7 +34450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -34243,7 +34459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -34252,7 +34468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -34261,7 +34477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -34270,7 +34486,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 114,
+      "file_type": "code",
+      "id": "herosectiontabs_handledisplaytypechange",
+      "label": "handleDisplayTypeChange()",
+      "norm_label": "handledisplaytypechange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "herosectiontabs_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L57"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "herosectiontabs_handleoverlaytoggle",
+      "label": "handleOverlayToggle()",
+      "norm_label": "handleoverlaytoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "herosectiontabs_handletexttoggle",
+      "label": "handleTextToggle()",
+      "norm_label": "handletexttoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L134"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
+      "label": "HeroSectionTabs.tsx",
+      "norm_label": "herosectiontabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1140,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -34279,7 +34540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1141,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -34288,7 +34549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -34297,7 +34558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1139,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -34306,52 +34567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 114,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
-      "label": "ReelUploader.tsx",
-      "norm_label": "reeluploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "reeluploader_formatfilesize",
-      "label": "formatFileSize()",
-      "norm_label": "formatfilesize()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "reeluploader_handlefileselect",
-      "label": "handleFileSelect()",
-      "norm_label": "handlefileselect()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "reeluploader_handleupload",
-      "label": "handleUpload()",
-      "norm_label": "handleupload()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L135"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "reeluploader_validatefile",
-      "label": "validateFile()",
-      "norm_label": "validatefile()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 1140,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -34360,7 +34576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -34369,7 +34585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -34378,7 +34594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -34387,7 +34603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -34396,7 +34612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -34405,7 +34621,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 115,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
+      "label": "ReelUploader.tsx",
+      "norm_label": "reeluploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "reeluploader_formatfilesize",
+      "label": "formatFileSize()",
+      "norm_label": "formatfilesize()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "reeluploader_handlefileselect",
+      "label": "handleFileSelect()",
+      "norm_label": "handlefileselect()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "reeluploader_handleupload",
+      "label": "handleUpload()",
+      "norm_label": "handleupload()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L135"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "reeluploader_validatefile",
+      "label": "validateFile()",
+      "norm_label": "validatefile()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 1150,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -34414,7 +34675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1151,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -34423,7 +34684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -34432,7 +34693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1149,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -34441,52 +34702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 115,
-      "file_type": "code",
-      "id": "activityview_iscreatedaction",
-      "label": "isCreatedAction()",
-      "norm_label": "iscreatedaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "activityview_isfeedbackrequestaction",
-      "label": "isFeedbackRequestAction()",
-      "norm_label": "isfeedbackrequestaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "activityview_isrefundaction",
-      "label": "isRefundAction()",
-      "norm_label": "isrefundaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "activityview_istransitionaction",
-      "label": "isTransitionAction()",
-      "norm_label": "istransitionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
-      "label": "ActivityView.tsx",
-      "norm_label": "activityview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1150,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -34495,7 +34711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -34504,7 +34720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -34513,7 +34729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -34522,7 +34738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -34531,7 +34747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -34540,7 +34756,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 116,
+      "file_type": "code",
+      "id": "activityview_iscreatedaction",
+      "label": "isCreatedAction()",
+      "norm_label": "iscreatedaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "activityview_isfeedbackrequestaction",
+      "label": "isFeedbackRequestAction()",
+      "norm_label": "isfeedbackrequestaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "activityview_isrefundaction",
+      "label": "isRefundAction()",
+      "norm_label": "isrefundaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "activityview_istransitionaction",
+      "label": "isTransitionAction()",
+      "norm_label": "istransitionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
+      "label": "ActivityView.tsx",
+      "norm_label": "activityview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1160,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -34549,7 +34810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1161,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -34558,7 +34819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -34567,7 +34828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1159,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -34576,52 +34837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 116,
-      "file_type": "code",
-      "id": "orderdetailsview_fetchtransactions",
-      "label": "fetchTransactions()",
-      "norm_label": "fetchtransactions()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L138"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkasverified",
-      "label": "handleMarkAsVerified()",
-      "norm_label": "handlemarkasverified()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L175"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkpaymentcollected",
-      "label": "handleMarkPaymentCollected()",
-      "norm_label": "handlemarkpaymentcollected()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L189"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "orderdetailsview_verifiedbadge",
-      "label": "VerifiedBadge()",
-      "norm_label": "verifiedbadge()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "label": "OrderDetailsView.tsx",
-      "norm_label": "orderdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1160,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -34630,7 +34846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -34639,7 +34855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -34648,7 +34864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -34657,7 +34873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -34666,7 +34882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -34675,7 +34891,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 117,
+      "file_type": "code",
+      "id": "orderdetailsview_fetchtransactions",
+      "label": "fetchTransactions()",
+      "norm_label": "fetchtransactions()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L138"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkasverified",
+      "label": "handleMarkAsVerified()",
+      "norm_label": "handlemarkasverified()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L175"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkpaymentcollected",
+      "label": "handleMarkPaymentCollected()",
+      "norm_label": "handlemarkpaymentcollected()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L189"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "orderdetailsview_verifiedbadge",
+      "label": "VerifiedBadge()",
+      "norm_label": "verifiedbadge()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
+      "label": "OrderDetailsView.tsx",
+      "norm_label": "orderdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1170,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -34684,7 +34945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1171,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -34693,7 +34954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -34702,7 +34963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1169,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -34711,52 +34972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 117,
-      "file_type": "code",
-      "id": "orderitemsview_handlerequestfeedback",
-      "label": "handleRequestFeedback()",
-      "norm_label": "handlerequestfeedback()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "orderitemsview_handlerestockall",
-      "label": "handleRestockAll()",
-      "norm_label": "handlerestockall()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L295"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "orderitemsview_handlereturnitemtostock",
-      "label": "handleReturnItemToStock()",
-      "norm_label": "handlereturnitemtostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "orderitemsview_handleupdateorderitem",
-      "label": "handleUpdateOrderItem()",
-      "norm_label": "handleupdateorderitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
-      "label": "OrderItemsView.tsx",
-      "norm_label": "orderitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1170,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -34765,7 +34981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -34774,7 +34990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -34783,7 +34999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -34792,7 +35008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -34801,7 +35017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -34810,7 +35026,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 118,
+      "file_type": "code",
+      "id": "orderitemsview_handlerequestfeedback",
+      "label": "handleRequestFeedback()",
+      "norm_label": "handlerequestfeedback()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "orderitemsview_handlerestockall",
+      "label": "handleRestockAll()",
+      "norm_label": "handlerestockall()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L295"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "orderitemsview_handlereturnitemtostock",
+      "label": "handleReturnItemToStock()",
+      "norm_label": "handlereturnitemtostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "orderitemsview_handleupdateorderitem",
+      "label": "handleUpdateOrderItem()",
+      "norm_label": "handleupdateorderitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
+      "label": "OrderItemsView.tsx",
+      "norm_label": "orderitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1180,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -34819,7 +35080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1181,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -34828,7 +35089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -34837,7 +35098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1179,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -34846,52 +35107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 118,
-      "file_type": "code",
-      "id": "ordersummary_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L320"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "ordersummary_handlecompletetransaction",
-      "label": "handleCompleteTransaction()",
-      "norm_label": "handlecompletetransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L130"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "ordersummary_handlenewtransaction",
-      "label": "handleNewTransaction()",
-      "norm_label": "handlenewtransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L164"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "ordersummary_handleselectedpaymentmethod",
-      "label": "handleSelectedPaymentMethod()",
-      "norm_label": "handleselectedpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L152"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1180,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -34900,7 +35116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -34909,7 +35125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -34918,7 +35134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -34927,7 +35143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -34936,7 +35152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -34945,7 +35161,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 119,
+      "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1190,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -34954,7 +35215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1191,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -34963,7 +35224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -34972,7 +35233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1189,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -34981,52 +35242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
-      "label": "PaymentView.tsx",
-      "norm_label": "paymentview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "paymentview_handleaddpayment",
-      "label": "handleAddPayment()",
-      "norm_label": "handleaddpayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L182"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "paymentview_handleamountblur",
-      "label": "handleAmountBlur()",
-      "norm_label": "handleamountblur()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L246"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "paymentview_handleamountchange",
-      "label": "handleAmountChange()",
-      "norm_label": "handleamountchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "paymentview_handleclearall",
-      "label": "handleClearAll()",
-      "norm_label": "handleclearall()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L223"
-    },
-    {
-      "community": 1190,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -35035,7 +35251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -35044,7 +35260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -35053,7 +35269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -35062,7 +35278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -35071,48 +35287,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1196,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1197,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_states_ts",
-      "label": "states.ts",
-      "norm_label": "states.ts",
-      "source_file": "packages/storefront-webapp/src/lib/states.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1198,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
-      "label": "storefrontFailureObservability.test.ts",
-      "norm_label": "storefrontfailureobservability.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
-      "label": "storefrontJourneyEvents.test.ts",
-      "norm_label": "storefrontjourneyevents.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
       "source_location": "L1"
     },
     {
@@ -35280,50 +35460,86 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
-      "label": "SessionManager.tsx",
-      "norm_label": "sessionmanager.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
+      "id": "ordersummary_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L320"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "ordersummary_handlecompletetransaction",
+      "label": "handleCompleteTransaction()",
+      "norm_label": "handlecompletetransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L130"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "ordersummary_handlenewtransaction",
+      "label": "handleNewTransaction()",
+      "norm_label": "handlenewtransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L164"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "ordersummary_handleselectedpaymentmethod",
+      "label": "handleSelectedPaymentMethod()",
+      "norm_label": "handleselectedpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L152"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L1"
     },
     {
-      "community": 120,
-      "file_type": "code",
-      "id": "sessionmanager_onholdconfirm",
-      "label": "onHoldConfirm()",
-      "norm_label": "onholdconfirm()",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "sessionmanager_onnewsessionclick",
-      "label": "onNewSessionClick()",
-      "norm_label": "onnewsessionclick()",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
-      "source_location": "L96"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "sessionmanager_onresumesession",
-      "label": "onResumeSession()",
-      "norm_label": "onresumesession()",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "sessionmanager_onvoidconfirm",
-      "label": "onVoidConfirm()",
-      "norm_label": "onvoidconfirm()",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
-      "source_location": "L90"
-    },
-    {
       "community": 1200,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_states_ts",
+      "label": "states.ts",
+      "norm_label": "states.ts",
+      "source_file": "packages/storefront-webapp/src/lib/states.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1202,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
+      "label": "storefrontFailureObservability.test.ts",
+      "norm_label": "storefrontfailureobservability.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1203,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
+      "label": "storefrontJourneyEvents.test.ts",
+      "norm_label": "storefrontjourneyevents.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1204,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -35332,7 +35548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -35341,7 +35557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -35350,7 +35566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -35359,7 +35575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -35368,7 +35584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -35377,7 +35593,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
+      "label": "PaymentView.tsx",
+      "norm_label": "paymentview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "paymentview_handleaddpayment",
+      "label": "handleAddPayment()",
+      "norm_label": "handleaddpayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L182"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "paymentview_handleamountblur",
+      "label": "handleAmountBlur()",
+      "norm_label": "handleamountblur()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L246"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "paymentview_handleamountchange",
+      "label": "handleAmountChange()",
+      "norm_label": "handleamountchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "paymentview_handleclearall",
+      "label": "handleClearAll()",
+      "norm_label": "handleclearall()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L223"
+    },
+    {
+      "community": 1210,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -35386,7 +35647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1211,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -35395,7 +35656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -35404,7 +35665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1209,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -35413,52 +35674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 121,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
-      "label": "PromoCodeView.tsx",
-      "norm_label": "promocodeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "promocodeview_handleaddpromocode",
-      "label": "handleAddPromoCode()",
-      "norm_label": "handleaddpromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L146"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "promocodeview_handleupdatepromocode",
-      "label": "handleUpdatePromoCode()",
-      "norm_label": "handleupdatepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "promocodeview_updatehomepagediscountcode",
-      "label": "updateHomepageDiscountCode()",
-      "norm_label": "updatehomepagediscountcode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L299"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "promocodeview_updateleaveareviewdiscountcode",
-      "label": "updateLeaveAReviewDiscountCode()",
-      "norm_label": "updateleaveareviewdiscountcode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L351"
-    },
-    {
-      "community": 1210,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -35467,7 +35683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -35476,7 +35692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -35485,7 +35701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -35494,7 +35710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -35503,7 +35719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_ssr_tsx",
       "label": "ssr.tsx",
@@ -35512,7 +35728,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
+      "label": "SessionManager.tsx",
+      "norm_label": "sessionmanager.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "sessionmanager_onholdconfirm",
+      "label": "onHoldConfirm()",
+      "norm_label": "onholdconfirm()",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "sessionmanager_onnewsessionclick",
+      "label": "onNewSessionClick()",
+      "norm_label": "onnewsessionclick()",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
+      "source_location": "L96"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "sessionmanager_onresumesession",
+      "label": "onResumeSession()",
+      "norm_label": "onresumesession()",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "sessionmanager_onvoidconfirm",
+      "label": "onVoidConfirm()",
+      "norm_label": "onvoidconfirm()",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 1220,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -35521,7 +35782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1221,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -35530,7 +35791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -35539,7 +35800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1219,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -35548,52 +35809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 122,
-      "file_type": "code",
-      "id": "custom_modal_example_basicmodalexample",
-      "label": "BasicModalExample()",
-      "norm_label": "basicmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "custom_modal_example_customclosebuttonexample",
-      "label": "CustomCloseButtonExample()",
-      "norm_label": "customclosebuttonexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L69"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "custom_modal_example_custompositionmodalexample",
-      "label": "CustomPositionModalExample()",
-      "norm_label": "custompositionmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "custom_modal_example_fullscreenmodalexample",
-      "label": "FullScreenModalExample()",
-      "norm_label": "fullscreenmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L103"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
-      "label": "custom-modal-example.tsx",
-      "norm_label": "custom-modal-example.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1220,
+      "community": 1224,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -35602,7 +35818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1225,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -35611,7 +35827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1226,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -35622,6 +35838,96 @@
     {
       "community": 123,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
+      "label": "PromoCodeView.tsx",
+      "norm_label": "promocodeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "promocodeview_handleaddpromocode",
+      "label": "handleAddPromoCode()",
+      "norm_label": "handleaddpromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L146"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "promocodeview_handleupdatepromocode",
+      "label": "handleUpdatePromoCode()",
+      "norm_label": "handleupdatepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L213"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "promocodeview_updatehomepagediscountcode",
+      "label": "updateHomepageDiscountCode()",
+      "norm_label": "updatehomepagediscountcode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L299"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "promocodeview_updateleaveareviewdiscountcode",
+      "label": "updateLeaveAReviewDiscountCode()",
+      "norm_label": "updateleaveareviewdiscountcode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L351"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "custom_modal_example_basicmodalexample",
+      "label": "BasicModalExample()",
+      "norm_label": "basicmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "custom_modal_example_customclosebuttonexample",
+      "label": "CustomCloseButtonExample()",
+      "norm_label": "customclosebuttonexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L69"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "custom_modal_example_custompositionmodalexample",
+      "label": "CustomPositionModalExample()",
+      "norm_label": "custompositionmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "custom_modal_example_fullscreenmodalexample",
+      "label": "FullScreenModalExample()",
+      "norm_label": "fullscreenmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L103"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
+      "label": "custom-modal-example.tsx",
+      "norm_label": "custom-modal-example.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
       "norm_label": "useposproducts.ts",
@@ -35629,7 +35935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 123,
+      "community": 125,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -35638,7 +35944,7 @@
       "source_location": "L30"
     },
     {
-      "community": 123,
+      "community": 125,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -35647,7 +35953,7 @@
       "source_location": "L41"
     },
     {
-      "community": 123,
+      "community": 125,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -35656,7 +35962,7 @@
       "source_location": "L10"
     },
     {
-      "community": 123,
+      "community": 125,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -35665,7 +35971,7 @@
       "source_location": "L100"
     },
     {
-      "community": 124,
+      "community": 126,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -35674,7 +35980,7 @@
       "source_location": "L18"
     },
     {
-      "community": 124,
+      "community": 126,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -35683,7 +35989,7 @@
       "source_location": "L23"
     },
     {
-      "community": 124,
+      "community": 126,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -35692,7 +35998,7 @@
       "source_location": "L65"
     },
     {
-      "community": 124,
+      "community": 126,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -35701,7 +36007,7 @@
       "source_location": "L45"
     },
     {
-      "community": 124,
+      "community": 126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -35710,7 +36016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 125,
+      "community": 127,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -35719,7 +36025,7 @@
       "source_location": "L78"
     },
     {
-      "community": 125,
+      "community": 127,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -35728,7 +36034,7 @@
       "source_location": "L74"
     },
     {
-      "community": 125,
+      "community": 127,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -35737,7 +36043,7 @@
       "source_location": "L103"
     },
     {
-      "community": 125,
+      "community": 127,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -35746,7 +36052,7 @@
       "source_location": "L109"
     },
     {
-      "community": 125,
+      "community": 127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -35755,7 +36061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 126,
+      "community": 128,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -35764,7 +36070,7 @@
       "source_location": "L75"
     },
     {
-      "community": 126,
+      "community": 128,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -35773,7 +36079,7 @@
       "source_location": "L26"
     },
     {
-      "community": 126,
+      "community": 128,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -35782,7 +36088,7 @@
       "source_location": "L38"
     },
     {
-      "community": 126,
+      "community": 128,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -35791,7 +36097,7 @@
       "source_location": "L4"
     },
     {
-      "community": 126,
+      "community": 128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -35800,7 +36106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 127,
+      "community": 129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -35809,7 +36115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 127,
+      "community": 129,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -35818,7 +36124,7 @@
       "source_location": "L42"
     },
     {
-      "community": 127,
+      "community": 129,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -35827,7 +36133,7 @@
       "source_location": "L29"
     },
     {
-      "community": 127,
+      "community": 129,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -35836,103 +36142,13 @@
       "source_location": "L49"
     },
     {
-      "community": 127,
+      "community": 129,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
       "norm_label": "generatetransactionnumber()",
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L14"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_timelineutils_ts",
-      "label": "timelineUtils.ts",
-      "norm_label": "timelineutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "timelineutils_enrichtimelineevent",
-      "label": "enrichTimelineEvent()",
-      "norm_label": "enrichtimelineevent()",
-      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
-      "source_location": "L184"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "timelineutils_enrichtimelineevents",
-      "label": "enrichTimelineEvents()",
-      "norm_label": "enrichtimelineevents()",
-      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
-      "source_location": "L200"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "timelineutils_gettimerangelabel",
-      "label": "getTimeRangeLabel()",
-      "norm_label": "gettimerangelabel()",
-      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
-      "source_location": "L244"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "timelineutils_groupeventsbytimeframe",
-      "label": "groupEventsByTimeframe()",
-      "norm_label": "groupeventsbytimeframe()",
-      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "analytics_getproductviewcount",
-      "label": "getProductViewCount()",
-      "norm_label": "getproductviewcount()",
-      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "analytics_logout",
-      "label": "logout()",
-      "norm_label": "logout()",
-      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "analytics_postanalytics",
-      "label": "postAnalytics()",
-      "norm_label": "postanalytics()",
-      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "analytics_updateanalyticsowner",
-      "label": "updateAnalyticsOwner()",
-      "norm_label": "updateanalyticsowner()",
-      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
-      "source_location": "L1"
     },
     {
       "community": 13,
@@ -36099,6 +36315,96 @@
     {
       "community": 130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_timelineutils_ts",
+      "label": "timelineUtils.ts",
+      "norm_label": "timelineutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "timelineutils_enrichtimelineevent",
+      "label": "enrichTimelineEvent()",
+      "norm_label": "enrichtimelineevent()",
+      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
+      "source_location": "L184"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "timelineutils_enrichtimelineevents",
+      "label": "enrichTimelineEvents()",
+      "norm_label": "enrichtimelineevents()",
+      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
+      "source_location": "L200"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "timelineutils_gettimerangelabel",
+      "label": "getTimeRangeLabel()",
+      "norm_label": "gettimerangelabel()",
+      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
+      "source_location": "L244"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "timelineutils_groupeventsbytimeframe",
+      "label": "groupEventsByTimeframe()",
+      "norm_label": "groupeventsbytimeframe()",
+      "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
+      "source_location": "L206"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "analytics_getproductviewcount",
+      "label": "getProductViewCount()",
+      "norm_label": "getproductviewcount()",
+      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "analytics_logout",
+      "label": "logout()",
+      "norm_label": "logout()",
+      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "analytics_postanalytics",
+      "label": "postAnalytics()",
+      "norm_label": "postanalytics()",
+      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "analytics_updateanalyticsowner",
+      "label": "updateAnalyticsOwner()",
+      "norm_label": "updateanalyticsowner()",
+      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/storefront-webapp/src/api/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
       "norm_label": "getallcategories()",
@@ -36106,7 +36412,7 @@
       "source_location": "L11"
     },
     {
-      "community": 130,
+      "community": 132,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -36115,7 +36421,7 @@
       "source_location": "L25"
     },
     {
-      "community": 130,
+      "community": 132,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -36124,7 +36430,7 @@
       "source_location": "L9"
     },
     {
-      "community": 130,
+      "community": 132,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -36133,7 +36439,7 @@
       "source_location": "L39"
     },
     {
-      "community": 130,
+      "community": 132,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -36142,7 +36448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -36151,7 +36457,7 @@
       "source_location": "L4"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -36160,7 +36466,7 @@
       "source_location": "L24"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -36169,7 +36475,7 @@
       "source_location": "L6"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -36178,7 +36484,7 @@
       "source_location": "L42"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -36187,7 +36493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -36196,7 +36502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -36205,7 +36511,7 @@
       "source_location": "L28"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -36214,7 +36520,7 @@
       "source_location": "L5"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -36223,7 +36529,7 @@
       "source_location": "L7"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -36232,7 +36538,7 @@
       "source_location": "L46"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -36241,7 +36547,7 @@
       "source_location": "L147"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -36250,7 +36556,7 @@
       "source_location": "L185"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -36259,7 +36565,7 @@
       "source_location": "L115"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -36268,7 +36574,7 @@
       "source_location": "L31"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -36277,7 +36583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -36286,7 +36592,7 @@
       "source_location": "L14"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -36295,7 +36601,7 @@
       "source_location": "L22"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -36304,7 +36610,7 @@
       "source_location": "L30"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -36313,7 +36619,7 @@
       "source_location": "L3"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -36322,7 +36628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -36331,7 +36637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -36340,7 +36646,7 @@
       "source_location": "L136"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -36349,7 +36655,7 @@
       "source_location": "L154"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -36358,7 +36664,7 @@
       "source_location": "L25"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -36367,7 +36673,7 @@
       "source_location": "L47"
     },
     {
-      "community": 136,
+      "community": 138,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -36376,7 +36682,7 @@
       "source_location": "L109"
     },
     {
-      "community": 136,
+      "community": 138,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -36385,7 +36691,7 @@
       "source_location": "L84"
     },
     {
-      "community": 136,
+      "community": 138,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -36394,7 +36700,7 @@
       "source_location": "L95"
     },
     {
-      "community": 136,
+      "community": 138,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
       "label": "checkout.ts",
@@ -36403,7 +36709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 137,
+      "community": 139,
       "file_type": "code",
       "id": "expensesessions_buildnextexpensesessionnumber",
       "label": "buildNextExpenseSessionNumber()",
@@ -36412,7 +36718,7 @@
       "source_location": "L33"
     },
     {
-      "community": 137,
+      "community": 139,
       "file_type": "code",
       "id": "expensesessions_listexpensesessionsbystatusbefore",
       "label": "listExpenseSessionsByStatusBefore()",
@@ -36421,7 +36727,7 @@
       "source_location": "L66"
     },
     {
-      "community": 137,
+      "community": 139,
       "file_type": "code",
       "id": "expensesessions_loadexpensesessionitems",
       "label": "loadExpenseSessionItems()",
@@ -36430,85 +36736,13 @@
       "source_location": "L41"
     },
     {
-      "community": 137,
+      "community": 139,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
       "label": "expenseSessions.ts",
       "norm_label": "expensesessions.ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "expensesessionexpiration_calculateexpensesessionexpiration",
-      "label": "calculateExpenseSessionExpiration()",
-      "norm_label": "calculateexpensesessionexpiration()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "expensesessionexpiration_getexpensesessionexpiryduration",
-      "label": "getExpenseSessionExpiryDuration()",
-      "norm_label": "getexpensesessionexpiryduration()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
-      "label": "getExpenseSessionExpiryDurationMinutes()",
-      "norm_label": "getexpensesessionexpirydurationminutes()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
-      "label": "expenseSessionExpiration.ts",
-      "norm_label": "expensesessionexpiration.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
-      "label": "sessionExpiration.ts",
-      "norm_label": "sessionexpiration.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "sessionexpiration_calculatesessionexpiration",
-      "label": "calculateSessionExpiration()",
-      "norm_label": "calculatesessionexpiration()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "sessionexpiration_getsessionexpiryduration",
-      "label": "getSessionExpiryDuration()",
-      "norm_label": "getsessionexpiryduration()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "sessionexpiration_getsessionexpirydurationminutes",
-      "label": "getSessionExpiryDurationMinutes()",
-      "norm_label": "getsessionexpirydurationminutes()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
-      "source_location": "L45"
     },
     {
       "community": 14,
@@ -36666,6 +36900,78 @@
     {
       "community": 140,
       "file_type": "code",
+      "id": "expensesessionexpiration_calculateexpensesessionexpiration",
+      "label": "calculateExpenseSessionExpiration()",
+      "norm_label": "calculateexpensesessionexpiration()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "expensesessionexpiration_getexpensesessionexpiryduration",
+      "label": "getExpenseSessionExpiryDuration()",
+      "norm_label": "getexpensesessionexpiryduration()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
+      "label": "getExpenseSessionExpiryDurationMinutes()",
+      "norm_label": "getexpensesessionexpirydurationminutes()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
+      "label": "expenseSessionExpiration.ts",
+      "norm_label": "expensesessionexpiration.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
+      "label": "sessionExpiration.ts",
+      "norm_label": "sessionexpiration.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "sessionexpiration_calculatesessionexpiration",
+      "label": "calculateSessionExpiration()",
+      "norm_label": "calculatesessionexpiration()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "sessionexpiration_getsessionexpiryduration",
+      "label": "getSessionExpiryDuration()",
+      "norm_label": "getsessionexpiryduration()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "sessionexpiration_getsessionexpirydurationminutes",
+      "label": "getSessionExpiryDurationMinutes()",
+      "norm_label": "getsessionexpirydurationminutes()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
       "norm_label": "todisplayamount()",
@@ -36673,7 +36979,7 @@
       "source_location": "L5"
     },
     {
-      "community": 140,
+      "community": 142,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -36682,7 +36988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 140,
+      "community": 142,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -36691,7 +36997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 140,
+      "community": 142,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
@@ -36700,7 +37006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 141,
+      "community": 143,
       "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
@@ -36709,7 +37015,7 @@
       "source_location": "L26"
     },
     {
-      "community": 141,
+      "community": 143,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -36718,7 +37024,7 @@
       "source_location": "L79"
     },
     {
-      "community": 141,
+      "community": 143,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -36727,7 +37033,7 @@
       "source_location": "L33"
     },
     {
-      "community": 141,
+      "community": 143,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -36736,7 +37042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 142,
+      "community": 144,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -36745,7 +37051,7 @@
       "source_location": "L10"
     },
     {
-      "community": 142,
+      "community": 144,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -36754,7 +37060,7 @@
       "source_location": "L18"
     },
     {
-      "community": 142,
+      "community": 144,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -36763,7 +37069,7 @@
       "source_location": "L52"
     },
     {
-      "community": 142,
+      "community": 144,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -36772,7 +37078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 143,
+      "community": 145,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -36781,7 +37087,7 @@
       "source_location": "L28"
     },
     {
-      "community": 143,
+      "community": 145,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -36790,7 +37096,7 @@
       "source_location": "L42"
     },
     {
-      "community": 143,
+      "community": 145,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -36799,7 +37105,7 @@
       "source_location": "L73"
     },
     {
-      "community": 143,
+      "community": 145,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -36808,7 +37114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 144,
+      "community": 146,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -36817,7 +37123,7 @@
       "source_location": "L8"
     },
     {
-      "community": 144,
+      "community": 146,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -36826,7 +37132,7 @@
       "source_location": "L32"
     },
     {
-      "community": 144,
+      "community": 146,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -36835,7 +37141,7 @@
       "source_location": "L64"
     },
     {
-      "community": 144,
+      "community": 146,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -36844,7 +37150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 145,
+      "community": 147,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -36853,7 +37159,7 @@
       "source_location": "L18"
     },
     {
-      "community": 145,
+      "community": 147,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -36862,7 +37168,7 @@
       "source_location": "L25"
     },
     {
-      "community": 145,
+      "community": 147,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -36871,7 +37177,7 @@
       "source_location": "L11"
     },
     {
-      "community": 145,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -36880,7 +37186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 148,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -36889,7 +37195,7 @@
       "source_location": "L19"
     },
     {
-      "community": 146,
+      "community": 148,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -36898,7 +37204,7 @@
       "source_location": "L26"
     },
     {
-      "community": 146,
+      "community": 148,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -36907,7 +37213,7 @@
       "source_location": "L12"
     },
     {
-      "community": 146,
+      "community": 148,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -36916,112 +37222,40 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 149,
       "file_type": "code",
-      "id": "onlineorder_appendtransition",
-      "label": "appendTransition()",
-      "norm_label": "appendtransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "onlineorder_applyonlineorderupdate",
-      "label": "applyOnlineOrderUpdate()",
-      "norm_label": "applyonlineorderupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "onlineorder_listorderitems",
-      "label": "listOrderItems()",
-      "norm_label": "listorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "attributesmanager_attributesmanager",
-      "label": "AttributesManager()",
-      "norm_label": "attributesmanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "attributesmanager_colormanager",
-      "label": "ColorManager()",
-      "norm_label": "colormanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "attributesmanager_sidebar",
-      "label": "Sidebar()",
-      "norm_label": "sidebar()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L26"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
-      "label": "AttributesManager.tsx",
-      "norm_label": "attributesmanager.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "label": "returnExchangeOperations.test.ts",
+      "norm_label": "returnexchangeoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
       "source_location": "L1"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "attributestable_getproductattribute",
-      "label": "getProductAttribute()",
-      "norm_label": "getproductattribute()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L55"
+      "id": "returnexchangeoperations_test_createorderitem",
+      "label": "createOrderItem()",
+      "norm_label": "createorderitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L13"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "attributestable_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L32"
+      "id": "returnexchangeoperations_test_createreplacement",
+      "label": "createReplacement()",
+      "norm_label": "createreplacement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L31"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "attributestable_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L210"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
-      "label": "AttributesTable.tsx",
-      "norm_label": "attributestable.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L1"
+      "id": "returnexchangeoperations_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L9"
     },
     {
       "community": 15,
@@ -37179,6 +37413,78 @@
     {
       "community": 150,
       "file_type": "code",
+      "id": "attributesmanager_attributesmanager",
+      "label": "AttributesManager()",
+      "norm_label": "attributesmanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "attributesmanager_colormanager",
+      "label": "ColorManager()",
+      "norm_label": "colormanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "attributesmanager_sidebar",
+      "label": "Sidebar()",
+      "norm_label": "sidebar()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
+      "label": "AttributesManager.tsx",
+      "norm_label": "attributesmanager.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "attributestable_getproductattribute",
+      "label": "getProductAttribute()",
+      "norm_label": "getproductattribute()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "attributestable_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L32"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "attributestable_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L210"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
+      "label": "AttributesTable.tsx",
+      "norm_label": "attributestable.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
       "norm_label": "categorymanager()",
@@ -37186,7 +37492,7 @@
       "source_location": "L51"
     },
     {
-      "community": 150,
+      "community": 152,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -37195,7 +37501,7 @@
       "source_location": "L26"
     },
     {
-      "community": 150,
+      "community": 152,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -37204,7 +37510,7 @@
       "source_location": "L290"
     },
     {
-      "community": 150,
+      "community": 152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -37213,7 +37519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 153,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -37222,7 +37528,7 @@
       "source_location": "L48"
     },
     {
-      "community": 151,
+      "community": 153,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -37231,7 +37537,7 @@
       "source_location": "L88"
     },
     {
-      "community": 151,
+      "community": 153,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -37240,7 +37546,7 @@
       "source_location": "L14"
     },
     {
-      "community": 151,
+      "community": 153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -37249,7 +37555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 152,
+      "community": 154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -37258,7 +37564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 152,
+      "community": 154,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -37267,7 +37573,7 @@
       "source_location": "L15"
     },
     {
-      "community": 152,
+      "community": 154,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -37276,7 +37582,7 @@
       "source_location": "L28"
     },
     {
-      "community": 152,
+      "community": 154,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -37285,7 +37591,7 @@
       "source_location": "L19"
     },
     {
-      "community": 153,
+      "community": 155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -37294,7 +37600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 155,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -37303,7 +37609,7 @@
       "source_location": "L52"
     },
     {
-      "community": 153,
+      "community": 155,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -37312,7 +37618,7 @@
       "source_location": "L3"
     },
     {
-      "community": 153,
+      "community": 155,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -37321,7 +37627,7 @@
       "source_location": "L90"
     },
     {
-      "community": 154,
+      "community": 156,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -37330,7 +37636,7 @@
       "source_location": "L86"
     },
     {
-      "community": 154,
+      "community": 156,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -37339,7 +37645,7 @@
       "source_location": "L76"
     },
     {
-      "community": 154,
+      "community": 156,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -37348,7 +37654,7 @@
       "source_location": "L52"
     },
     {
-      "community": 154,
+      "community": 156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -37357,7 +37663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -37366,7 +37672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 157,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -37375,7 +37681,7 @@
       "source_location": "L67"
     },
     {
-      "community": 155,
+      "community": 157,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -37384,7 +37690,7 @@
       "source_location": "L90"
     },
     {
-      "community": 155,
+      "community": 157,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -37393,7 +37699,43 @@
       "source_location": "L73"
     },
     {
-      "community": 156,
+      "community": 158,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
+      "label": "ReturnExchangeView.tsx",
+      "norm_label": "returnexchangeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "returnexchangeview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L103"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "returnexchangeview_resetreplacementfields",
+      "label": "resetReplacementFields()",
+      "norm_label": "resetreplacementfields()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "returnexchangeview_toggleitem",
+      "label": "toggleItem()",
+      "norm_label": "toggleitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L81"
+    },
+    {
+      "community": 159,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -37402,7 +37744,7 @@
       "source_location": "L91"
     },
     {
-      "community": 156,
+      "community": 159,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -37411,7 +37753,7 @@
       "source_location": "L68"
     },
     {
-      "community": 156,
+      "community": 159,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -37420,120 +37762,12 @@
       "source_location": "L22"
     },
     {
-      "community": 156,
+      "community": 159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
       "norm_label": "newtransactionview.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
-      "label": "POSSettingsView.tsx",
-      "norm_label": "possettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "possettingsview_handleregisterterminal",
-      "label": "handleRegisterTerminal()",
-      "norm_label": "handleregisterterminal()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L247"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "possettingsview_handleupdateexistingterminal",
-      "label": "handleUpdateExistingTerminal()",
-      "norm_label": "handleupdateexistingterminal()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L284"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "possettingsview_loadfingerprint",
-      "label": "loadFingerprint()",
-      "norm_label": "loadfingerprint()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L166"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productstock_tsx",
-      "label": "ProductStock.tsx",
-      "norm_label": "productstock.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "productstock_lowstockstatus",
-      "label": "LowStockStatus()",
-      "norm_label": "lowstockstatus()",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "productstock_outofstockstatus",
-      "label": "OutOfStockStatus()",
-      "norm_label": "outofstockstatus()",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "productstock_productstockstatus",
-      "label": "ProductStockStatus()",
-      "norm_label": "productstockstatus()",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "complimentaryproductsview_body",
-      "label": "Body()",
-      "norm_label": "body()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "complimentaryproductsview_complimentaryproductsview",
-      "label": "ComplimentaryProductsView()",
-      "norm_label": "complimentaryproductsview()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "complimentaryproductsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
-      "label": "ComplimentaryProductsView.tsx",
-      "norm_label": "complimentaryproductsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L1"
     },
     {
@@ -37692,6 +37926,114 @@
     {
       "community": 160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
+      "label": "POSSettingsView.tsx",
+      "norm_label": "possettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "possettingsview_handleregisterterminal",
+      "label": "handleRegisterTerminal()",
+      "norm_label": "handleregisterterminal()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L247"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "possettingsview_handleupdateexistingterminal",
+      "label": "handleUpdateExistingTerminal()",
+      "norm_label": "handleupdateexistingterminal()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L284"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "possettingsview_loadfingerprint",
+      "label": "loadFingerprint()",
+      "norm_label": "loadfingerprint()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L166"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productstock_tsx",
+      "label": "ProductStock.tsx",
+      "norm_label": "productstock.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "productstock_lowstockstatus",
+      "label": "LowStockStatus()",
+      "norm_label": "lowstockstatus()",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "productstock_outofstockstatus",
+      "label": "OutOfStockStatus()",
+      "norm_label": "outofstockstatus()",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "productstock_productstockstatus",
+      "label": "ProductStockStatus()",
+      "norm_label": "productstockstatus()",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "complimentaryproductsview_body",
+      "label": "Body()",
+      "norm_label": "body()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "complimentaryproductsview_complimentaryproductsview",
+      "label": "ComplimentaryProductsView()",
+      "norm_label": "complimentaryproductsview()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "complimentaryproductsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
+      "label": "ComplimentaryProductsView.tsx",
+      "norm_label": "complimentaryproductsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "label": "ServiceAppointmentsView.tsx",
       "norm_label": "serviceappointmentsview.tsx",
@@ -37699,7 +38041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 160,
+      "community": 163,
       "file_type": "code",
       "id": "serviceappointmentsview_handlesubmit",
       "label": "handleSubmit()",
@@ -37708,7 +38050,7 @@
       "source_location": "L115"
     },
     {
-      "community": 160,
+      "community": 163,
       "file_type": "code",
       "id": "serviceappointmentsview_parsedatetimelocal",
       "label": "parseDateTimeLocal()",
@@ -37717,7 +38059,7 @@
       "source_location": "L77"
     },
     {
-      "community": 160,
+      "community": 163,
       "file_type": "code",
       "id": "serviceappointmentsview_withsavestate",
       "label": "withSaveState()",
@@ -37726,7 +38068,7 @@
       "source_location": "L441"
     },
     {
-      "community": 161,
+      "community": 164,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -37735,7 +38077,7 @@
       "source_location": "L75"
     },
     {
-      "community": 161,
+      "community": 164,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -37744,7 +38086,7 @@
       "source_location": "L82"
     },
     {
-      "community": 161,
+      "community": 164,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -37753,7 +38095,7 @@
       "source_location": "L93"
     },
     {
-      "community": 161,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -37762,7 +38104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -37771,7 +38113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 165,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -37780,7 +38122,7 @@
       "source_location": "L15"
     },
     {
-      "community": 162,
+      "community": 165,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -37789,7 +38131,7 @@
       "source_location": "L28"
     },
     {
-      "community": 162,
+      "community": 165,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -37798,7 +38140,7 @@
       "source_location": "L54"
     },
     {
-      "community": 163,
+      "community": 166,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -37807,7 +38149,7 @@
       "source_location": "L66"
     },
     {
-      "community": 163,
+      "community": 166,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -37816,7 +38158,7 @@
       "source_location": "L121"
     },
     {
-      "community": 163,
+      "community": 166,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -37825,7 +38167,7 @@
       "source_location": "L74"
     },
     {
-      "community": 163,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -37834,7 +38176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 167,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -37843,7 +38185,7 @@
       "source_location": "L51"
     },
     {
-      "community": 164,
+      "community": 167,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -37852,7 +38194,7 @@
       "source_location": "L92"
     },
     {
-      "community": 164,
+      "community": 167,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -37861,7 +38203,7 @@
       "source_location": "L16"
     },
     {
-      "community": 164,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -37870,7 +38212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 168,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -37879,7 +38221,7 @@
       "source_location": "L13"
     },
     {
-      "community": 165,
+      "community": 168,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -37888,7 +38230,7 @@
       "source_location": "L46"
     },
     {
-      "community": 165,
+      "community": 168,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -37897,7 +38239,7 @@
       "source_location": "L21"
     },
     {
-      "community": 165,
+      "community": 168,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -37906,7 +38248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 169,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -37915,7 +38257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 169,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -37924,7 +38266,7 @@
       "source_location": "L8"
     },
     {
-      "community": 166,
+      "community": 169,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -37933,121 +38275,13 @@
       "source_location": "L5"
     },
     {
-      "community": 166,
+      "community": 169,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L20"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "subcategory_getallsubcategories",
-      "label": "getAllSubcategories()",
-      "norm_label": "getallsubcategories()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "subcategory_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "subcategory_getsubategory",
-      "label": "getSubategory()",
-      "norm_label": "getsubategory()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
-      "label": "ProductActionBar.tsx",
-      "norm_label": "productactionbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "productactionbar_checkscroll",
-      "label": "checkScroll()",
-      "norm_label": "checkscroll()",
-      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "productactionbar_handleaction",
-      "label": "handleAction()",
-      "norm_label": "handleaction()",
-      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "productactionbar_handledismiss",
-      "label": "handleDismiss()",
-      "norm_label": "handledismiss()",
-      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
-      "label": "ProductReminderBar.tsx",
-      "norm_label": "productreminderbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "productreminderbar_checkscroll",
-      "label": "checkScroll()",
-      "norm_label": "checkscroll()",
-      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "productreminderbar_handleaddtobag",
-      "label": "handleAddToBag()",
-      "norm_label": "handleaddtobag()",
-      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
-      "source_location": "L109"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "productreminderbar_handledismiss",
-      "label": "handleDismiss()",
-      "norm_label": "handledismiss()",
-      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
-      "source_location": "L177"
     },
     {
       "community": 17,
@@ -38196,6 +38430,114 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "subcategory_getallsubcategories",
+      "label": "getAllSubcategories()",
+      "norm_label": "getallsubcategories()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "subcategory_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "subcategory_getsubategory",
+      "label": "getSubategory()",
+      "norm_label": "getsubategory()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
+      "label": "ProductActionBar.tsx",
+      "norm_label": "productactionbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "productactionbar_checkscroll",
+      "label": "checkScroll()",
+      "norm_label": "checkscroll()",
+      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "productactionbar_handleaction",
+      "label": "handleAction()",
+      "norm_label": "handleaction()",
+      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "productactionbar_handledismiss",
+      "label": "handleDismiss()",
+      "norm_label": "handledismiss()",
+      "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
+      "label": "ProductReminderBar.tsx",
+      "norm_label": "productreminderbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "productreminderbar_checkscroll",
+      "label": "checkScroll()",
+      "norm_label": "checkscroll()",
+      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "productreminderbar_handleaddtobag",
+      "label": "handleAddToBag()",
+      "norm_label": "handleaddtobag()",
+      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
+      "source_location": "L109"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "productreminderbar_handledismiss",
+      "label": "handleDismiss()",
+      "norm_label": "handledismiss()",
+      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
+      "source_location": "L177"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
       "norm_label": "clearform()",
@@ -38203,7 +38545,7 @@
       "source_location": "L18"
     },
     {
-      "community": 170,
+      "community": 173,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -38212,7 +38554,7 @@
       "source_location": "L52"
     },
     {
-      "community": 170,
+      "community": 173,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -38221,7 +38563,7 @@
       "source_location": "L68"
     },
     {
-      "community": 170,
+      "community": 173,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -38230,7 +38572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 174,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -38239,7 +38581,7 @@
       "source_location": "L68"
     },
     {
-      "community": 171,
+      "community": 174,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -38248,7 +38590,7 @@
       "source_location": "L26"
     },
     {
-      "community": 171,
+      "community": 174,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -38257,7 +38599,7 @@
       "source_location": "L7"
     },
     {
-      "community": 171,
+      "community": 174,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -38266,7 +38608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 175,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -38275,7 +38617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 175,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -38284,7 +38626,7 @@
       "source_location": "L43"
     },
     {
-      "community": 172,
+      "community": 175,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -38293,7 +38635,7 @@
       "source_location": "L13"
     },
     {
-      "community": 172,
+      "community": 175,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -38302,7 +38644,7 @@
       "source_location": "L88"
     },
     {
-      "community": 173,
+      "community": 176,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -38311,7 +38653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 176,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -38320,7 +38662,7 @@
       "source_location": "L111"
     },
     {
-      "community": 173,
+      "community": 176,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -38329,7 +38671,7 @@
       "source_location": "L66"
     },
     {
-      "community": 173,
+      "community": 176,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -38338,7 +38680,7 @@
       "source_location": "L127"
     },
     {
-      "community": 174,
+      "community": 177,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -38347,7 +38689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 177,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -38356,7 +38698,7 @@
       "source_location": "L115"
     },
     {
-      "community": 174,
+      "community": 177,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -38365,7 +38707,7 @@
       "source_location": "L105"
     },
     {
-      "community": 174,
+      "community": 177,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -38374,7 +38716,7 @@
       "source_location": "L110"
     },
     {
-      "community": 175,
+      "community": 178,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -38383,7 +38725,7 @@
       "source_location": "L121"
     },
     {
-      "community": 175,
+      "community": 178,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -38392,7 +38734,7 @@
       "source_location": "L26"
     },
     {
-      "community": 175,
+      "community": 178,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -38401,7 +38743,7 @@
       "source_location": "L71"
     },
     {
-      "community": 175,
+      "community": 178,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -38410,7 +38752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 179,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -38419,7 +38761,7 @@
       "source_location": "L46"
     },
     {
-      "community": 176,
+      "community": 179,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -38428,7 +38770,7 @@
       "source_location": "L24"
     },
     {
-      "community": 176,
+      "community": 179,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -38437,120 +38779,12 @@
       "source_location": "L20"
     },
     {
-      "community": 176,
+      "community": 179,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
       "norm_label": "bootstrap.ts",
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "app_test_createinmemoryredis",
-      "label": "createInMemoryRedis()",
-      "norm_label": "createinmemoryredis()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L33"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "app_test_createresponserecorder",
-      "label": "createResponseRecorder()",
-      "norm_label": "createresponserecorder()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L6"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "app_test_createsilentlogger",
-      "label": "createSilentLogger()",
-      "norm_label": "createsilentlogger()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L25"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_app_test_js",
-      "label": "app.test.js",
-      "norm_label": "app.test.js",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "graphify_check_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "graphify_check_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "graphify_check_test_writegraphifywikiartifacts",
-      "label": "writeGraphifyWikiArtifacts()",
-      "norm_label": "writegraphifywikiartifacts()",
-      "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "scripts_graphify_check_test_ts",
-      "label": "graphify-check.test.ts",
-      "norm_label": "graphify-check.test.ts",
-      "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "scripts_graphify_rebuild_test_ts",
-      "label": "graphify-rebuild.test.ts",
-      "norm_label": "graphify-rebuild.test.ts",
-      "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L1"
     },
     {
@@ -38700,6 +38934,114 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "app_test_createinmemoryredis",
+      "label": "createInMemoryRedis()",
+      "norm_label": "createinmemoryredis()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L33"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "app_test_createresponserecorder",
+      "label": "createResponseRecorder()",
+      "norm_label": "createresponserecorder()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L6"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "app_test_createsilentlogger",
+      "label": "createSilentLogger()",
+      "norm_label": "createsilentlogger()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L25"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "packages_valkey_proxy_server_app_test_js",
+      "label": "app.test.js",
+      "norm_label": "app.test.js",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "graphify_check_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "graphify_check_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "graphify_check_test_writegraphifywikiartifacts",
+      "label": "writeGraphifyWikiArtifacts()",
+      "norm_label": "writegraphifywikiartifacts()",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "scripts_graphify_check_test_ts",
+      "label": "graphify-check.test.ts",
+      "norm_label": "graphify-check.test.ts",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "scripts_graphify_rebuild_test_ts",
+      "label": "graphify-rebuild.test.ts",
+      "norm_label": "graphify-rebuild.test.ts",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
       "norm_label": "buildharnessdocpaths()",
@@ -38707,7 +39049,7 @@
       "source_location": "L126"
     },
     {
-      "community": 180,
+      "community": 183,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -38716,7 +39058,7 @@
       "source_location": "L130"
     },
     {
-      "community": 180,
+      "community": 183,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -38725,7 +39067,7 @@
       "source_location": "L543"
     },
     {
-      "community": 180,
+      "community": 183,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -38734,7 +39076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 184,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -38743,7 +39085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 184,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -38752,7 +39094,7 @@
       "source_location": "L8"
     },
     {
-      "community": 181,
+      "community": 184,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -38761,7 +39103,7 @@
       "source_location": "L79"
     },
     {
-      "community": 181,
+      "community": 184,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -38770,7 +39112,7 @@
       "source_location": "L61"
     },
     {
-      "community": 182,
+      "community": 185,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -38779,7 +39121,7 @@
       "source_location": "L49"
     },
     {
-      "community": 182,
+      "community": 185,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -38788,7 +39130,7 @@
       "source_location": "L17"
     },
     {
-      "community": 182,
+      "community": 185,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -38797,7 +39139,7 @@
       "source_location": "L11"
     },
     {
-      "community": 182,
+      "community": 185,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -38806,7 +39148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 186,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -38815,7 +39157,7 @@
       "source_location": "L26"
     },
     {
-      "community": 183,
+      "community": 186,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -38824,7 +39166,7 @@
       "source_location": "L72"
     },
     {
-      "community": 183,
+      "community": 186,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -38833,7 +39175,7 @@
       "source_location": "L36"
     },
     {
-      "community": 183,
+      "community": 186,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -38842,7 +39184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 187,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -38851,7 +39193,7 @@
       "source_location": "L90"
     },
     {
-      "community": 184,
+      "community": 187,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -38860,7 +39202,7 @@
       "source_location": "L88"
     },
     {
-      "community": 184,
+      "community": 187,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -38869,7 +39211,7 @@
       "source_location": "L89"
     },
     {
-      "community": 184,
+      "community": 187,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -38878,7 +39220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 188,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -38887,7 +39229,7 @@
       "source_location": "L98"
     },
     {
-      "community": 185,
+      "community": 188,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -38896,7 +39238,7 @@
       "source_location": "L33"
     },
     {
-      "community": 185,
+      "community": 188,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -38905,7 +39247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 189,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -38914,7 +39256,7 @@
       "source_location": "L85"
     },
     {
-      "community": 186,
+      "community": 189,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -38923,94 +39265,13 @@
       "source_location": "L31"
     },
     {
-      "community": 186,
+      "community": 189,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
       "norm_label": "discountreminder.tsx",
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "utils_getstoredatafromrequest",
-      "label": "getStoreDataFromRequest()",
-      "norm_label": "getstoredatafromrequest()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "utils_getstorefrontuserfromrequest",
-      "label": "getStorefrontUserFromRequest()",
-      "norm_label": "getstorefrontuserfromrequest()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "analyticsutils_calculateactivitytrend",
-      "label": "calculateActivityTrend()",
-      "norm_label": "calculateactivitytrend()",
-      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "analyticsutils_calculatedevicedistribution",
-      "label": "calculateDeviceDistribution()",
-      "norm_label": "calculatedevicedistribution()",
-      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
-      "label": "analyticsUtils.ts",
-      "norm_label": "analyticsutils.ts",
-      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
-      "label": "staffProfiles.ts",
-      "norm_label": "staffprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "staffprofiles_buildfullname",
-      "label": "buildFullName()",
-      "norm_label": "buildfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "staffprofiles_buildroleassignmentdrafts",
-      "label": "buildRoleAssignmentDrafts()",
-      "norm_label": "buildroleassignmentdrafts()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L17"
     },
     {
       "community": 19,
@@ -39150,6 +39411,87 @@
     {
       "community": 190,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "utils_getstoredatafromrequest",
+      "label": "getStoreDataFromRequest()",
+      "norm_label": "getstoredatafromrequest()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "utils_getstorefrontuserfromrequest",
+      "label": "getStorefrontUserFromRequest()",
+      "norm_label": "getstorefrontuserfromrequest()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "analyticsutils_calculateactivitytrend",
+      "label": "calculateActivityTrend()",
+      "norm_label": "calculateactivitytrend()",
+      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "analyticsutils_calculatedevicedistribution",
+      "label": "calculateDeviceDistribution()",
+      "norm_label": "calculatedevicedistribution()",
+      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
+      "label": "analyticsUtils.ts",
+      "norm_label": "analyticsutils.ts",
+      "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
+      "label": "staffProfiles.ts",
+      "norm_label": "staffprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "staffprofiles_buildfullname",
+      "label": "buildFullName()",
+      "norm_label": "buildfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "staffprofiles_buildroleassignmentdrafts",
+      "label": "buildRoleAssignmentDrafts()",
+      "norm_label": "buildroleassignmentdrafts()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
       "norm_label": "listtransactions()",
@@ -39157,7 +39499,7 @@
       "source_location": "L7"
     },
     {
-      "community": 190,
+      "community": 193,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -39166,7 +39508,7 @@
       "source_location": "L109"
     },
     {
-      "community": 190,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -39175,7 +39517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 194,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -39184,7 +39526,7 @@
       "source_location": "L16"
     },
     {
-      "community": 191,
+      "community": 194,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -39193,7 +39535,7 @@
       "source_location": "L42"
     },
     {
-      "community": 191,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -39202,7 +39544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -39211,7 +39553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 195,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -39220,7 +39562,7 @@
       "source_location": "L23"
     },
     {
-      "community": 192,
+      "community": 195,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -39229,7 +39571,7 @@
       "source_location": "L16"
     },
     {
-      "community": 193,
+      "community": 196,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -39238,7 +39580,7 @@
       "source_location": "L7"
     },
     {
-      "community": 193,
+      "community": 196,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -39247,7 +39589,7 @@
       "source_location": "L14"
     },
     {
-      "community": 193,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -39256,7 +39598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -39265,7 +39607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 197,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -39274,7 +39616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 197,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -39283,7 +39625,7 @@
       "source_location": "L4"
     },
     {
-      "community": 195,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -39292,7 +39634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 198,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -39301,7 +39643,7 @@
       "source_location": "L18"
     },
     {
-      "community": 195,
+      "community": 198,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -39310,7 +39652,7 @@
       "source_location": "L5"
     },
     {
-      "community": 196,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -39319,7 +39661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 199,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -39328,94 +39670,13 @@
       "source_location": "L19"
     },
     {
-      "community": 196,
+      "community": 199,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
       "norm_label": "usesheet()",
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
-      "label": "WigType.tsx",
-      "norm_label": "wigtype.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "wigtype_wigtype",
-      "label": "WigType()",
-      "norm_label": "wigtype()",
-      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "wigtype_wigtypeview",
-      "label": "WigTypeView()",
-      "norm_label": "wigtypeview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "copyimagesprovider_copyimagesprovider",
-      "label": "CopyImagesProvider()",
-      "norm_label": "copyimagesprovider()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "copyimagesprovider_usecopyimages",
-      "label": "useCopyImages()",
-      "norm_label": "usecopyimages()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
-      "label": "CopyImagesProvider.tsx",
-      "norm_label": "copyimagesprovider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "analyticscombinedusers_analyticscombinedusers",
-      "label": "AnalyticsCombinedUsers()",
-      "norm_label": "analyticscombinedusers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "analyticscombinedusers_processanalyticstousers",
-      "label": "processAnalyticsToUsers()",
-      "norm_label": "processanalyticstousers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
-      "label": "AnalyticsCombinedUsers.tsx",
-      "norm_label": "analyticscombinedusers.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
-      "source_location": "L1"
     },
     {
       "community": 2,
@@ -39852,6 +40113,87 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
+      "label": "WigType.tsx",
+      "norm_label": "wigtype.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "wigtype_wigtype",
+      "label": "WigType()",
+      "norm_label": "wigtype()",
+      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "wigtype_wigtypeview",
+      "label": "WigTypeView()",
+      "norm_label": "wigtypeview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "copyimagesprovider_copyimagesprovider",
+      "label": "CopyImagesProvider()",
+      "norm_label": "copyimagesprovider()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "copyimagesprovider_usecopyimages",
+      "label": "useCopyImages()",
+      "norm_label": "usecopyimages()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
+      "label": "CopyImagesProvider.tsx",
+      "norm_label": "copyimagesprovider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "analyticscombinedusers_analyticscombinedusers",
+      "label": "AnalyticsCombinedUsers()",
+      "norm_label": "analyticscombinedusers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "analyticscombinedusers_processanalyticstousers",
+      "label": "processAnalyticsToUsers()",
+      "norm_label": "processanalyticstousers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
+      "label": "AnalyticsCombinedUsers.tsx",
+      "norm_label": "analyticscombinedusers.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
       "norm_label": "analyticstopusers()",
@@ -39859,7 +40201,7 @@
       "source_location": "L100"
     },
     {
-      "community": 200,
+      "community": 203,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -39868,7 +40210,7 @@
       "source_location": "L10"
     },
     {
-      "community": 200,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -39877,7 +40219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 204,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -39886,7 +40228,7 @@
       "source_location": "L15"
     },
     {
-      "community": 201,
+      "community": 204,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -39895,7 +40237,7 @@
       "source_location": "L39"
     },
     {
-      "community": 201,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -39904,7 +40246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 205,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -39913,7 +40255,7 @@
       "source_location": "L48"
     },
     {
-      "community": 202,
+      "community": 205,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -39922,7 +40264,7 @@
       "source_location": "L56"
     },
     {
-      "community": 202,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -39931,7 +40273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 206,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -39940,7 +40282,7 @@
       "source_location": "L3"
     },
     {
-      "community": 203,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -39949,7 +40291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 206,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -39958,7 +40300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 207,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -39967,7 +40309,7 @@
       "source_location": "L53"
     },
     {
-      "community": 204,
+      "community": 207,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -39976,7 +40318,7 @@
       "source_location": "L65"
     },
     {
-      "community": 204,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -39985,7 +40327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 208,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -39994,7 +40336,7 @@
       "source_location": "L47"
     },
     {
-      "community": 205,
+      "community": 208,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -40003,7 +40345,7 @@
       "source_location": "L53"
     },
     {
-      "community": 205,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -40012,7 +40354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -40021,7 +40363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 209,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -40030,94 +40372,13 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 209,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
       "norm_label": "videoplayer()",
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 207,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
-      "label": "PickupDetailsView.tsx",
-      "norm_label": "pickupdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 207,
-      "file_type": "code",
-      "id": "pickupdetailsview_deliverydetails",
-      "label": "DeliveryDetails()",
-      "norm_label": "deliverydetails()",
-      "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 207,
-      "file_type": "code",
-      "id": "pickupdetailsview_pickupdetailsview",
-      "label": "PickupDetailsView()",
-      "norm_label": "pickupdetailsview()",
-      "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "organization_switcher_handlesignout",
-      "label": "handleSignOut()",
-      "norm_label": "handlesignout()",
-      "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
-      "source_location": "L99"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "organization_switcher_onorganizationselect",
-      "label": "onOrganizationSelect()",
-      "norm_label": "onorganizationselect()",
-      "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
-      "source_location": "L94"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
-      "label": "organization-switcher.tsx",
-      "norm_label": "organization-switcher.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "heldsessionslist_getsessioncartitemscount",
-      "label": "getSessionCartItemsCount()",
-      "norm_label": "getsessioncartitemscount()",
-      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
-      "source_location": "L59"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "heldsessionslist_hasexpired",
-      "label": "hasExpired()",
-      "norm_label": "hasexpired()",
-      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
-      "label": "HeldSessionsList.tsx",
-      "norm_label": "heldsessionslist.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
-      "source_location": "L1"
     },
     {
       "community": 21,
@@ -40248,6 +40509,87 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
+      "label": "PickupDetailsView.tsx",
+      "norm_label": "pickupdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "pickupdetailsview_deliverydetails",
+      "label": "DeliveryDetails()",
+      "norm_label": "deliverydetails()",
+      "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "pickupdetailsview_pickupdetailsview",
+      "label": "PickupDetailsView()",
+      "norm_label": "pickupdetailsview()",
+      "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "organization_switcher_handlesignout",
+      "label": "handleSignOut()",
+      "norm_label": "handlesignout()",
+      "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
+      "source_location": "L99"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "organization_switcher_onorganizationselect",
+      "label": "onOrganizationSelect()",
+      "norm_label": "onorganizationselect()",
+      "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
+      "source_location": "L94"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
+      "label": "organization-switcher.tsx",
+      "norm_label": "organization-switcher.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 212,
+      "file_type": "code",
+      "id": "heldsessionslist_getsessioncartitemscount",
+      "label": "getSessionCartItemsCount()",
+      "norm_label": "getsessioncartitemscount()",
+      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 212,
+      "file_type": "code",
+      "id": "heldsessionslist_hasexpired",
+      "label": "hasExpired()",
+      "norm_label": "hasexpired()",
+      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 212,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
+      "label": "HeldSessionsList.tsx",
+      "norm_label": "heldsessionslist.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 213,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
       "norm_label": "transactionsview.tsx",
@@ -40255,7 +40597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 210,
+      "community": 213,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -40264,7 +40606,7 @@
       "source_location": "L20"
     },
     {
-      "community": 210,
+      "community": 213,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -40273,7 +40615,7 @@
       "source_location": "L26"
     },
     {
-      "community": 211,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -40282,7 +40624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 214,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -40291,7 +40633,7 @@
       "source_location": "L65"
     },
     {
-      "community": 211,
+      "community": 214,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -40300,7 +40642,7 @@
       "source_location": "L20"
     },
     {
-      "community": 212,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -40309,7 +40651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 215,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -40318,7 +40660,7 @@
       "source_location": "L16"
     },
     {
-      "community": 212,
+      "community": 215,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -40327,7 +40669,7 @@
       "source_location": "L60"
     },
     {
-      "community": 213,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -40336,7 +40678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 216,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -40345,7 +40687,7 @@
       "source_location": "L45"
     },
     {
-      "community": 213,
+      "community": 216,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -40354,7 +40696,7 @@
       "source_location": "L19"
     },
     {
-      "community": 214,
+      "community": 217,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -40363,7 +40705,7 @@
       "source_location": "L128"
     },
     {
-      "community": 214,
+      "community": 217,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -40372,7 +40714,7 @@
       "source_location": "L40"
     },
     {
-      "community": 214,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -40381,7 +40723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 218,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -40390,7 +40732,7 @@
       "source_location": "L24"
     },
     {
-      "community": 215,
+      "community": 218,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -40399,7 +40741,7 @@
       "source_location": "L20"
     },
     {
-      "community": 215,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -40408,7 +40750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 219,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -40417,7 +40759,7 @@
       "source_location": "L25"
     },
     {
-      "community": 216,
+      "community": 219,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -40426,93 +40768,12 @@
       "source_location": "L17"
     },
     {
-      "community": 216,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
       "norm_label": "currency-provider.tsx",
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
-      "label": "ServiceIntakeView.tsx",
-      "norm_label": "serviceintakeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "serviceintakeview_handlecreateintake",
-      "label": "handleCreateIntake()",
-      "norm_label": "handlecreateintake()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
-      "source_location": "L238"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "serviceintakeview_serviceintakeviewcontent",
-      "label": "ServiceIntakeViewContent()",
-      "norm_label": "serviceintakeviewcontent()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
-      "source_location": "L69"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
-      "label": "SingleLineError.tsx",
-      "norm_label": "singlelineerror.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/error/SingleLineError.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
-      "label": "SingleLineError.tsx",
-      "norm_label": "singlelineerror.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "singlelineerror_singlelineerror",
-      "label": "SingleLineError()",
-      "norm_label": "singlelineerror()",
-      "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "index_errorpage",
-      "label": "ErrorPage()",
-      "norm_label": "errorpage()",
-      "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_error_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/error/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
       "source_location": "L1"
     },
     {
@@ -40635,6 +40896,87 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
+      "label": "ServiceIntakeView.tsx",
+      "norm_label": "serviceintakeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "serviceintakeview_handlecreateintake",
+      "label": "handleCreateIntake()",
+      "norm_label": "handlecreateintake()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
+      "source_location": "L238"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "serviceintakeview_serviceintakeviewcontent",
+      "label": "ServiceIntakeViewContent()",
+      "norm_label": "serviceintakeviewcontent()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
+      "source_location": "L69"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
+      "label": "SingleLineError.tsx",
+      "norm_label": "singlelineerror.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/error/SingleLineError.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
+      "label": "SingleLineError.tsx",
+      "norm_label": "singlelineerror.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "singlelineerror_singlelineerror",
+      "label": "SingleLineError()",
+      "norm_label": "singlelineerror()",
+      "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "index_errorpage",
+      "label": "ErrorPage()",
+      "norm_label": "errorpage()",
+      "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_error_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/error/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
       "norm_label": "appskeleton()",
@@ -40642,7 +40984,7 @@
       "source_location": "L3"
     },
     {
-      "community": 220,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -40651,7 +40993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 220,
+      "community": 223,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -40660,7 +41002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 224,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -40669,7 +41011,7 @@
       "source_location": "L3"
     },
     {
-      "community": 221,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -40678,7 +41020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 224,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -40687,7 +41029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -40696,7 +41038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 225,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -40705,7 +41047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 225,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -40714,7 +41056,7 @@
       "source_location": "L3"
     },
     {
-      "community": 223,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -40723,7 +41065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 226,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -40732,7 +41074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 226,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -40741,7 +41083,7 @@
       "source_location": "L3"
     },
     {
-      "community": 224,
+      "community": 227,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -40750,7 +41092,7 @@
       "source_location": "L4"
     },
     {
-      "community": 224,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -40759,7 +41101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 227,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -40768,7 +41110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 228,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -40777,7 +41119,7 @@
       "source_location": "L104"
     },
     {
-      "community": 225,
+      "community": 228,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -40786,7 +41128,7 @@
       "source_location": "L36"
     },
     {
-      "community": 225,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -40795,7 +41137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 229,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -40804,7 +41146,7 @@
       "source_location": "L20"
     },
     {
-      "community": 226,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -40813,93 +41155,12 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 229,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
       "norm_label": "app-context-menu.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "badge_badge",
-      "label": "Badge()",
-      "norm_label": "badge()",
-      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_badge_tsx",
-      "label": "badge.tsx",
-      "norm_label": "badge.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/badge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
-      "label": "badge.tsx",
-      "norm_label": "badge.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "loading_button_loadingbutton",
-      "label": "LoadingButton()",
-      "norm_label": "loadingbutton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
-      "label": "loading-button.tsx",
-      "norm_label": "loading-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/loading-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
-      "label": "loading-button.tsx",
-      "norm_label": "loading-button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "modal_onchange",
-      "label": "onChange()",
-      "norm_label": "onchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modal_tsx",
-      "label": "modal.tsx",
-      "norm_label": "modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
-      "label": "modal.tsx",
-      "norm_label": "modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L1"
     },
     {
@@ -41022,6 +41283,87 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "badge_badge",
+      "label": "Badge()",
+      "norm_label": "badge()",
+      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_badge_tsx",
+      "label": "badge.tsx",
+      "norm_label": "badge.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/badge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
+      "label": "badge.tsx",
+      "norm_label": "badge.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "loading_button_loadingbutton",
+      "label": "LoadingButton()",
+      "norm_label": "loadingbutton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
+      "label": "loading-button.tsx",
+      "norm_label": "loading-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/loading-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
+      "label": "loading-button.tsx",
+      "norm_label": "loading-button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "modal_onchange",
+      "label": "onChange()",
+      "norm_label": "onchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modal_tsx",
+      "label": "modal.tsx",
+      "norm_label": "modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
+      "label": "modal.tsx",
+      "norm_label": "modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
       "norm_label": "alertmodal()",
@@ -41029,7 +41371,7 @@
       "source_location": "L20"
     },
     {
-      "community": 230,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -41038,7 +41380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 230,
+      "community": 233,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -41047,7 +41389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 234,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -41056,7 +41398,7 @@
       "source_location": "L12"
     },
     {
-      "community": 231,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -41065,7 +41407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 234,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -41074,7 +41416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -41083,7 +41425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 235,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -41092,7 +41434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 235,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -41101,7 +41443,7 @@
       "source_location": "L3"
     },
     {
-      "community": 233,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -41110,7 +41452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 236,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -41119,7 +41461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 236,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -41128,7 +41470,7 @@
       "source_location": "L6"
     },
     {
-      "community": 234,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -41137,7 +41479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 237,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -41146,7 +41488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 237,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -41155,7 +41497,7 @@
       "source_location": "L3"
     },
     {
-      "community": 235,
+      "community": 238,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -41164,7 +41506,7 @@
       "source_location": "L44"
     },
     {
-      "community": 235,
+      "community": 238,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -41173,7 +41515,7 @@
       "source_location": "L19"
     },
     {
-      "community": 235,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -41182,7 +41524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -41191,7 +41533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 239,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -41200,94 +41542,13 @@
       "source_location": "L159"
     },
     {
-      "community": 236,
+      "community": 239,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
       "norm_label": "loadmore()",
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L195"
-    },
-    {
-      "community": 237,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
-      "label": "UserActivity.tsx",
-      "norm_label": "useractivity.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 237,
-      "file_type": "code",
-      "id": "useractivity_activityheader",
-      "label": "ActivityHeader()",
-      "norm_label": "activityheader()",
-      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 237,
-      "file_type": "code",
-      "id": "useractivity_useractivity",
-      "label": "UserActivity()",
-      "norm_label": "useractivity()",
-      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "onlineordercontext_onlineorderprovider",
-      "label": "OnlineOrderProvider()",
-      "norm_label": "onlineorderprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "onlineordercontext_useonlineorder",
-      "label": "useOnlineOrder()",
-      "norm_label": "useonlineorder()",
-      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
-      "label": "OnlineOrderContext.tsx",
-      "norm_label": "onlineordercontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
-      "label": "PermissionsContext.tsx",
-      "norm_label": "permissionscontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "permissionscontext_permissionsprovider",
-      "label": "PermissionsProvider()",
-      "norm_label": "permissionsprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "permissionscontext_usepermissionscontext",
-      "label": "usePermissionsContext()",
-      "norm_label": "usepermissionscontext()",
-      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
-      "source_location": "L51"
     },
     {
       "community": 24,
@@ -41409,6 +41670,87 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
+      "label": "UserActivity.tsx",
+      "norm_label": "useractivity.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "useractivity_activityheader",
+      "label": "ActivityHeader()",
+      "norm_label": "activityheader()",
+      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "useractivity_useractivity",
+      "label": "UserActivity()",
+      "norm_label": "useractivity()",
+      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "onlineordercontext_onlineorderprovider",
+      "label": "OnlineOrderProvider()",
+      "norm_label": "onlineorderprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "onlineordercontext_useonlineorder",
+      "label": "useOnlineOrder()",
+      "norm_label": "useonlineorder()",
+      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
+      "label": "OnlineOrderContext.tsx",
+      "norm_label": "onlineordercontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
+      "label": "PermissionsContext.tsx",
+      "norm_label": "permissionscontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "permissionscontext_permissionsprovider",
+      "label": "PermissionsProvider()",
+      "norm_label": "permissionsprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "permissionscontext_usepermissionscontext",
+      "label": "usePermissionsContext()",
+      "norm_label": "usepermissionscontext()",
+      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
       "norm_label": "productcontext.tsx",
@@ -41416,7 +41758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 240,
+      "community": 243,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -41425,7 +41767,7 @@
       "source_location": "L54"
     },
     {
-      "community": 240,
+      "community": 243,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -41434,7 +41776,7 @@
       "source_location": "L282"
     },
     {
-      "community": 241,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -41443,7 +41785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 244,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -41452,7 +41794,7 @@
       "source_location": "L12"
     },
     {
-      "community": 241,
+      "community": 244,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -41461,7 +41803,7 @@
       "source_location": "L37"
     },
     {
-      "community": 242,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -41470,7 +41812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 245,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -41479,7 +41821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 245,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -41488,7 +41830,7 @@
       "source_location": "L4"
     },
     {
-      "community": 243,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -41497,7 +41839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 246,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -41506,7 +41848,7 @@
       "source_location": "L9"
     },
     {
-      "community": 243,
+      "community": 246,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -41515,7 +41857,7 @@
       "source_location": "L50"
     },
     {
-      "community": 244,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -41524,7 +41866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 247,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -41533,7 +41875,7 @@
       "source_location": "L6"
     },
     {
-      "community": 244,
+      "community": 247,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -41542,7 +41884,7 @@
       "source_location": "L31"
     },
     {
-      "community": 245,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -41551,7 +41893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 248,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -41560,7 +41902,7 @@
       "source_location": "L5"
     },
     {
-      "community": 245,
+      "community": 248,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -41569,7 +41911,7 @@
       "source_location": "L31"
     },
     {
-      "community": 246,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposoperations_ts",
       "label": "usePOSOperations.ts",
@@ -41578,7 +41920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 249,
       "file_type": "code",
       "id": "useposoperations_useposoperations",
       "label": "usePOSOperations()",
@@ -41587,94 +41929,13 @@
       "source_location": "L30"
     },
     {
-      "community": 246,
+      "community": 249,
       "file_type": "code",
       "id": "useposoperations_useposstate",
       "label": "usePOSState()",
       "norm_label": "useposstate()",
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L580"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "maintenanceutils_isinmaintenancemode",
-      "label": "isInMaintenanceMode()",
-      "norm_label": "isinmaintenancemode()",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
-      "label": "maintenanceUtils.ts",
-      "norm_label": "maintenanceutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
-      "label": "maintenanceUtils.ts",
-      "norm_label": "maintenanceutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "displayamounts_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "displayamounts_parsedisplayamountinput",
-      "label": "parseDisplayAmountInput()",
-      "norm_label": "parsedisplayamountinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
-      "label": "displayAmounts.ts",
-      "norm_label": "displayamounts.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "main_app",
-      "label": "App()",
-      "norm_label": "app()",
-      "source_file": "packages/storefront-webapp/src/main.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_main_tsx",
-      "label": "main.tsx",
-      "norm_label": "main.tsx",
-      "source_file": "packages/athena-webapp/src/main.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_main_tsx",
-      "label": "main.tsx",
-      "norm_label": "main.tsx",
-      "source_file": "packages/storefront-webapp/src/main.tsx",
-      "source_location": "L1"
     },
     {
       "community": 25,
@@ -41787,6 +42048,87 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "maintenanceutils_isinmaintenancemode",
+      "label": "isInMaintenanceMode()",
+      "norm_label": "isinmaintenancemode()",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
+      "label": "maintenanceUtils.ts",
+      "norm_label": "maintenanceutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/maintenanceUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
+      "label": "maintenanceUtils.ts",
+      "norm_label": "maintenanceutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "displayamounts_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "displayamounts_parsedisplayamountinput",
+      "label": "parseDisplayAmountInput()",
+      "norm_label": "parsedisplayamountinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
+      "label": "displayAmounts.ts",
+      "norm_label": "displayamounts.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "main_app",
+      "label": "App()",
+      "norm_label": "app()",
+      "source_file": "packages/storefront-webapp/src/main.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_main_tsx",
+      "label": "main.tsx",
+      "norm_label": "main.tsx",
+      "source_file": "packages/athena-webapp/src/main.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_main_tsx",
+      "label": "main.tsx",
+      "norm_label": "main.tsx",
+      "source_file": "packages/storefront-webapp/src/main.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
       "norm_label": "authedcomponent()",
@@ -41794,7 +42136,7 @@
       "source_location": "L18"
     },
     {
-      "community": 250,
+      "community": 253,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -41803,7 +42145,7 @@
       "source_location": "L38"
     },
     {
-      "community": 250,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -41812,7 +42154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 254,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -41821,7 +42163,7 @@
       "source_location": "L127"
     },
     {
-      "community": 251,
+      "community": 254,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -41830,7 +42172,7 @@
       "source_location": "L106"
     },
     {
-      "community": 251,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -41839,7 +42181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 255,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -41848,7 +42190,7 @@
       "source_location": "L66"
     },
     {
-      "community": 252,
+      "community": 255,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -41857,7 +42199,7 @@
       "source_location": "L20"
     },
     {
-      "community": 252,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -41866,7 +42208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 256,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -41875,7 +42217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -41884,7 +42226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 256,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -41893,7 +42235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_session_ts",
       "label": "session.ts",
@@ -41902,7 +42244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 257,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_session_ts",
       "label": "session.ts",
@@ -41911,7 +42253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 257,
       "file_type": "code",
       "id": "session_useappsession",
       "label": "useAppSession()",
@@ -41920,7 +42262,7 @@
       "source_location": "L8"
     },
     {
-      "community": 255,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -41929,7 +42271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 258,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -41938,7 +42280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 258,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -41947,7 +42289,7 @@
       "source_location": "L16"
     },
     {
-      "community": 256,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -41956,7 +42298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 259,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -41965,7 +42307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 259,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -41974,457 +42316,7 @@
       "source_location": "L19"
     },
     {
-      "community": 257,
-      "file_type": "code",
-      "id": "auth_logout",
-      "label": "logout()",
-      "norm_label": "logout()",
-      "source_file": "packages/storefront-webapp/src/api/auth.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "auth_verifyuseraccount",
-      "label": "verifyUserAccount()",
-      "norm_label": "verifyuseraccount()",
-      "source_file": "packages/storefront-webapp/src/api/auth.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/storefront-webapp/src/api/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "color_getallcolors",
-      "label": "getAllColors()",
-      "norm_label": "getallcolors()",
-      "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "color_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_color_ts",
-      "label": "color.ts",
-      "norm_label": "color.ts",
-      "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "organization_getallorganizations",
-      "label": "getAllOrganizations()",
-      "norm_label": "getallorganizations()",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "organization_getorganization",
-      "label": "getOrganization()",
-      "norm_label": "getorganization()",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L1"
-    },
-    {
       "community": 26,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "upsells_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "upsells_getlastviewedproduct",
-      "label": "getLastViewedProduct()",
-      "norm_label": "getlastviewedproduct()",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "useroffers_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "useroffers_getuserofferseligibility",
-      "label": "getUserOffersEligibility()",
-      "norm_label": "getuserofferseligibility()",
-      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "customerdetails_enteredcustomerdetails",
-      "label": "EnteredCustomerDetails()",
-      "norm_label": "enteredcustomerdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "customerdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
-      "label": "CustomerDetails.tsx",
-      "norm_label": "customerdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "deliveryoptionsselector_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "deliveryoptionsselector_storeselector",
-      "label": "StoreSelector()",
-      "norm_label": "storeselector()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
-      "label": "DeliveryOptionsSelector.tsx",
-      "norm_label": "deliveryoptionsselector.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "deliverysection_deliverydetails",
-      "label": "DeliveryDetails()",
-      "norm_label": "deliverydetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "deliverysection_deliveryoptions",
-      "label": "DeliveryOptions()",
-      "norm_label": "deliveryoptions()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
-      "label": "DeliverySection.tsx",
-      "norm_label": "deliverysection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 265,
-      "file_type": "code",
-      "id": "mobilebagsummary_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 265,
-      "file_type": "code",
-      "id": "mobilebagsummary_handleredeempromocode",
-      "label": "handleRedeemPromoCode()",
-      "norm_label": "handleredeempromocode()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 265,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
-      "label": "MobileBagSummary.tsx",
-      "norm_label": "mobilebagsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "checkoutstorage_loadcheckoutstate",
-      "label": "loadCheckoutState()",
-      "norm_label": "loadcheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "checkoutstorage_savecheckoutstate",
-      "label": "saveCheckoutState()",
-      "norm_label": "savecheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
-      "label": "checkoutStorage.ts",
-      "norm_label": "checkoutstorage.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 267,
-      "file_type": "code",
-      "id": "footer_enablecategories",
-      "label": "enableCategories()",
-      "norm_label": "enablecategories()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 267,
-      "file_type": "code",
-      "id": "footer_linkgroup",
-      "label": "LinkGroup()",
-      "norm_label": "linkgroup()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 267,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
-      "label": "Footer.tsx",
-      "norm_label": "footer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "featuredproductssection_featuredproductssection",
-      "label": "FeaturedProductsSection()",
-      "norm_label": "featuredproductssection()",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "featuredproductssection_featuredsection",
-      "label": "FeaturedSection()",
-      "norm_label": "featuredsection()",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
-      "label": "FeaturedProductsSection.tsx",
-      "norm_label": "featuredproductssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
-      "label": "PromoAlert.tsx",
-      "norm_label": "promoalert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "promoalert_getpromoalertcopy",
-      "label": "getPromoAlertCopy()",
-      "norm_label": "getpromoalertcopy()",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "promoalert_promoalert",
-      "label": "PromoAlert()",
-      "norm_label": "promoalert()",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L59"
-    },
-    {
-      "community": 27,
       "file_type": "code",
       "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
       "label": "OrdersTableToolbarProvider()",
@@ -42433,7 +42325,7 @@
       "source_location": "L16"
     },
     {
-      "community": 27,
+      "community": 26,
       "file_type": "code",
       "id": "data_table_toolbar_provider_useorderstabletoolbar",
       "label": "useOrdersTableToolbar()",
@@ -42442,7 +42334,7 @@
       "source_location": "L46"
     },
     {
-      "community": 27,
+      "community": 26,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -42451,7 +42343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 27,
+      "community": 26,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -42460,7 +42352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 27,
+      "community": 26,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -42469,7 +42361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 27,
+      "community": 26,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -42478,7 +42370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 27,
+      "community": 26,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -42487,7 +42379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 27,
+      "community": 26,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -42496,7 +42388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 27,
+      "community": 26,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -42505,7 +42397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 27,
+      "community": 26,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -42514,7 +42406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 27,
+      "community": 26,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -42523,277 +42415,277 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 260,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
-      "label": "RewardsAlert.tsx",
-      "norm_label": "rewardsalert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "id": "auth_logout",
+      "label": "logout()",
+      "norm_label": "logout()",
+      "source_file": "packages/storefront-webapp/src/api/auth.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "auth_verifyuseraccount",
+      "label": "verifyUserAccount()",
+      "norm_label": "verifyuseraccount()",
+      "source_file": "packages/storefront-webapp/src/api/auth.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 261,
       "file_type": "code",
-      "id": "rewardsalert_handleshopnow",
-      "label": "handleShopNow()",
-      "norm_label": "handleshopnow()",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L25"
+      "id": "color_getallcolors",
+      "label": "getAllColors()",
+      "norm_label": "getallcolors()",
+      "source_file": "packages/storefront-webapp/src/api/color.ts",
+      "source_location": "L7"
     },
     {
-      "community": 270,
+      "community": 261,
       "file_type": "code",
-      "id": "rewardsalert_onrewardsalertclose",
-      "label": "onRewardsAlertClose()",
-      "norm_label": "onrewardsalertclose()",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L20"
+      "id": "color_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/color.ts",
+      "source_location": "L5"
     },
     {
-      "community": 271,
+      "community": 261,
       "file_type": "code",
-      "id": "navigationbar_navigationbar",
-      "label": "NavigationBar()",
-      "norm_label": "navigationbar()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 271,
-      "file_type": "code",
-      "id": "navigationbar_storecategoriessubmenu",
-      "label": "StoreCategoriesSubmenu()",
-      "norm_label": "storecategoriessubmenu()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 271,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
-      "label": "NavigationBar.tsx",
-      "norm_label": "navigationbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "id": "packages_storefront_webapp_src_api_color_ts",
+      "label": "color.ts",
+      "norm_label": "color.ts",
+      "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 262,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
-      "label": "ProductAttribute.tsx",
-      "norm_label": "productattribute.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "id": "organization_getallorganizations",
+      "label": "getAllOrganizations()",
+      "norm_label": "getallorganizations()",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "organization_getorganization",
+      "label": "getOrganization()",
+      "norm_label": "getorganization()",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 263,
       "file_type": "code",
-      "id": "productattribute_findsize",
-      "label": "findSize()",
-      "norm_label": "findsize()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 272,
-      "file_type": "code",
-      "id": "productattribute_handleclick",
-      "label": "handleClick()",
-      "norm_label": "handleclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 273,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
-      "label": "ReviewEditor.tsx",
-      "norm_label": "revieweditor.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "id": "packages_storefront_webapp_src_api_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 263,
       "file_type": "code",
-      "id": "revieweditor_handleformdatachange",
-      "label": "handleFormDataChange()",
-      "norm_label": "handleformdatachange()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L150"
+      "id": "upsells_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L3"
     },
     {
-      "community": 273,
+      "community": 263,
       "file_type": "code",
-      "id": "revieweditor_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L157"
+      "id": "upsells_getlastviewedproduct",
+      "label": "getLastViewedProduct()",
+      "norm_label": "getlastviewedproduct()",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L5"
     },
     {
-      "community": 274,
+      "community": 264,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
-      "label": "UpsellModalForm.tsx",
-      "norm_label": "upsellmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "id": "packages_storefront_webapp_src_api_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 264,
       "file_type": "code",
-      "id": "upsellmodalform_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
-      "source_location": "L63"
+      "id": "useroffers_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
+      "source_location": "L18"
     },
     {
-      "community": 274,
+      "community": 264,
       "file_type": "code",
-      "id": "upsellmodalform_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
-      "source_location": "L48"
+      "id": "useroffers_getuserofferseligibility",
+      "label": "getUserOffersEligibility()",
+      "norm_label": "getuserofferseligibility()",
+      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
+      "source_location": "L23"
     },
     {
-      "community": 275,
+      "community": 265,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
-      "label": "WelcomeBackModal.tsx",
-      "norm_label": "welcomebackmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L1"
+      "id": "customerdetails_enteredcustomerdetails",
+      "label": "EnteredCustomerDetails()",
+      "norm_label": "enteredcustomerdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
+      "source_location": "L22"
     },
     {
-      "community": 275,
+      "community": 265,
       "file_type": "code",
-      "id": "welcomebackmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 275,
-      "file_type": "code",
-      "id": "welcomebackmodal_handlesuccess",
-      "label": "handleSuccess()",
-      "norm_label": "handlesuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
-      "label": "WelcomeBackModalForm.tsx",
-      "norm_label": "welcomebackmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "welcomebackmodalform_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L51"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "welcomebackmodalform_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L36"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "navigationbarprovider_navigationbarprovider",
-      "label": "NavigationBarProvider()",
-      "norm_label": "navigationbarprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "navigationbarprovider_usenavigationbarcontext",
-      "label": "useNavigationBarContext()",
-      "norm_label": "usenavigationbarcontext()",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L39"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
-      "label": "NavigationBarProvider.tsx",
-      "norm_label": "navigationbarprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
-      "label": "StoreContext.tsx",
-      "norm_label": "storecontext.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "storecontext_storeprovider",
-      "label": "StoreProvider()",
-      "norm_label": "storeprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "storecontext_usestorecontext",
-      "label": "useStoreContext()",
-      "norm_label": "usestorecontext()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
-      "label": "StorefrontObservabilityProvider.tsx",
-      "norm_label": "storefrontobservabilityprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "label": "StorefrontObservabilityProvider()",
-      "norm_label": "storefrontobservabilityprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "label": "useStorefrontObservability()",
-      "norm_label": "usestorefrontobservability()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "id": "customerdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L55"
     },
     {
-      "community": 28,
+      "community": 265,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
+      "label": "CustomerDetails.tsx",
+      "norm_label": "customerdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "deliveryoptionsselector_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "deliveryoptionsselector_storeselector",
+      "label": "StoreSelector()",
+      "norm_label": "storeselector()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
+      "label": "DeliveryOptionsSelector.tsx",
+      "norm_label": "deliveryoptionsselector.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 267,
+      "file_type": "code",
+      "id": "deliverysection_deliverydetails",
+      "label": "DeliveryDetails()",
+      "norm_label": "deliverydetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 267,
+      "file_type": "code",
+      "id": "deliverysection_deliveryoptions",
+      "label": "DeliveryOptions()",
+      "norm_label": "deliveryoptions()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 267,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
+      "label": "DeliverySection.tsx",
+      "norm_label": "deliverysection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "mobilebagsummary_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "mobilebagsummary_handleredeempromocode",
+      "label": "handleRedeemPromoCode()",
+      "norm_label": "handleredeempromocode()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
+      "label": "MobileBagSummary.tsx",
+      "norm_label": "mobilebagsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "checkoutstorage_loadcheckoutstate",
+      "label": "loadCheckoutState()",
+      "norm_label": "loadcheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "checkoutstorage_savecheckoutstate",
+      "label": "saveCheckoutState()",
+      "norm_label": "savecheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
+      "label": "checkoutStorage.ts",
+      "norm_label": "checkoutstorage.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 27,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepossessions_ts",
       "label": "usePOSSessions.ts",
@@ -42802,7 +42694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 28,
+      "community": 27,
       "file_type": "code",
       "id": "usepossessions_useposactivesession",
       "label": "usePOSActiveSession()",
@@ -42811,7 +42703,7 @@
       "source_location": "L32"
     },
     {
-      "community": 28,
+      "community": 27,
       "file_type": "code",
       "id": "usepossessions_usepossession",
       "label": "usePOSSession()",
@@ -42820,7 +42712,7 @@
       "source_location": "L24"
     },
     {
-      "community": 28,
+      "community": 27,
       "file_type": "code",
       "id": "usepossessions_usepossessioncomplete",
       "label": "usePOSSessionComplete()",
@@ -42829,7 +42721,7 @@
       "source_location": "L157"
     },
     {
-      "community": 28,
+      "community": 27,
       "file_type": "code",
       "id": "usepossessions_usepossessioncreate",
       "label": "usePOSSessionCreate()",
@@ -42838,7 +42730,7 @@
       "source_location": "L47"
     },
     {
-      "community": 28,
+      "community": 27,
       "file_type": "code",
       "id": "usepossessions_usepossessionhold",
       "label": "usePOSSessionHold()",
@@ -42847,7 +42739,7 @@
       "source_location": "L117"
     },
     {
-      "community": 28,
+      "community": 27,
       "file_type": "code",
       "id": "usepossessions_usepossessionmanager",
       "label": "usePOSSessionManager()",
@@ -42856,7 +42748,7 @@
       "source_location": "L207"
     },
     {
-      "community": 28,
+      "community": 27,
       "file_type": "code",
       "id": "usepossessions_usepossessionresume",
       "label": "usePOSSessionResume()",
@@ -42865,7 +42757,7 @@
       "source_location": "L137"
     },
     {
-      "community": 28,
+      "community": 27,
       "file_type": "code",
       "id": "usepossessions_usepossessionupdate",
       "label": "usePOSSessionUpdate()",
@@ -42874,7 +42766,7 @@
       "source_location": "L82"
     },
     {
-      "community": 28,
+      "community": 27,
       "file_type": "code",
       "id": "usepossessions_usepossessionvoid",
       "label": "usePOSSessionVoid()",
@@ -42883,7 +42775,7 @@
       "source_location": "L191"
     },
     {
-      "community": 28,
+      "community": 27,
       "file_type": "code",
       "id": "usepossessions_useposstoresessions",
       "label": "usePOSStoreSessions()",
@@ -42892,277 +42784,277 @@
       "source_location": "L8"
     },
     {
-      "community": 280,
+      "community": 270,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
-      "label": "useProductDiscount.ts",
-      "norm_label": "useproductdiscount.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "id": "footer_enablecategories",
+      "label": "enableCategories()",
+      "norm_label": "enablecategories()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "footer_linkgroup",
+      "label": "LinkGroup()",
+      "norm_label": "linkgroup()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
+      "label": "Footer.tsx",
+      "norm_label": "footer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 271,
       "file_type": "code",
-      "id": "useproductdiscount_useproductdiscount",
-      "label": "useProductDiscount()",
-      "norm_label": "useproductdiscount()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L107"
+      "id": "featuredproductssection_featuredproductssection",
+      "label": "FeaturedProductsSection()",
+      "norm_label": "featuredproductssection()",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L20"
     },
     {
-      "community": 280,
+      "community": 271,
       "file_type": "code",
-      "id": "useproductdiscount_useproductdiscounts",
-      "label": "useProductDiscounts()",
-      "norm_label": "useproductdiscounts()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 281,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
-      "label": "useShoppingBag.ts",
-      "norm_label": "useshoppingbag.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 281,
-      "file_type": "code",
-      "id": "useshoppingbag_isunavailableproductlist",
-      "label": "isUnavailableProductList()",
-      "norm_label": "isunavailableproductlist()",
-      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
-      "source_location": "L556"
-    },
-    {
-      "community": 281,
-      "file_type": "code",
-      "id": "useshoppingbag_useshoppingbag",
-      "label": "useShoppingBag()",
-      "norm_label": "useshoppingbag()",
-      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 282,
-      "file_type": "code",
-      "id": "index_getordermessage",
-      "label": "getOrderMessage()",
-      "norm_label": "getordermessage()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L429"
-    },
-    {
-      "community": 282,
-      "file_type": "code",
-      "id": "index_getpaymenttext",
-      "label": "getPaymentText()",
-      "norm_label": "getpaymenttext()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 282,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 283,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
-      "label": "review.tsx",
-      "norm_label": "review.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 283,
-      "file_type": "code",
-      "id": "review_getordermessage",
-      "label": "getOrderMessage()",
-      "norm_label": "getordermessage()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L250"
-    },
-    {
-      "community": 283,
-      "file_type": "code",
-      "id": "review_ordernavigation",
-      "label": "OrderNavigation()",
-      "norm_label": "ordernavigation()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "id": "featuredproductssection_featuredsection",
+      "label": "FeaturedSection()",
+      "norm_label": "featuredsection()",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L46"
     },
     {
-      "community": 284,
+      "community": 271,
       "file_type": "code",
-      "id": "account_accountbeforeload",
-      "label": "accountBeforeLoad()",
-      "norm_label": "accountbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L17"
+      "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
+      "label": "FeaturedProductsSection.tsx",
+      "norm_label": "featuredproductssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 272,
       "file_type": "code",
-      "id": "account_handleonsubmitform",
-      "label": "handleOnSubmitForm()",
-      "norm_label": "handleonsubmitform()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
+      "label": "PromoAlert.tsx",
+      "norm_label": "promoalert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 272,
+      "file_type": "code",
+      "id": "promoalert_getpromoalertcopy",
+      "label": "getPromoAlertCopy()",
+      "norm_label": "getpromoalertcopy()",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 272,
+      "file_type": "code",
+      "id": "promoalert_promoalert",
+      "label": "PromoAlert()",
+      "norm_label": "promoalert()",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
+      "label": "RewardsAlert.tsx",
+      "norm_label": "rewardsalert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "rewardsalert_handleshopnow",
+      "label": "handleShopNow()",
+      "norm_label": "handleshopnow()",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "rewardsalert_onrewardsalertclose",
+      "label": "onRewardsAlertClose()",
+      "norm_label": "onrewardsalertclose()",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "navigationbar_navigationbar",
+      "label": "NavigationBar()",
+      "norm_label": "navigationbar()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "navigationbar_storecategoriessubmenu",
+      "label": "StoreCategoriesSubmenu()",
+      "norm_label": "storecategoriessubmenu()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
+      "label": "NavigationBar.tsx",
+      "norm_label": "navigationbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 275,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
+      "label": "ProductAttribute.tsx",
+      "norm_label": "productattribute.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 275,
+      "file_type": "code",
+      "id": "productattribute_findsize",
+      "label": "findSize()",
+      "norm_label": "findsize()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 275,
+      "file_type": "code",
+      "id": "productattribute_handleclick",
+      "label": "handleClick()",
+      "norm_label": "handleclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 276,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
+      "label": "ReviewEditor.tsx",
+      "norm_label": "revieweditor.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 276,
+      "file_type": "code",
+      "id": "revieweditor_handleformdatachange",
+      "label": "handleFormDataChange()",
+      "norm_label": "handleformdatachange()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 276,
+      "file_type": "code",
+      "id": "revieweditor_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L157"
+    },
+    {
+      "community": 277,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
+      "label": "UpsellModalForm.tsx",
+      "norm_label": "upsellmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 277,
+      "file_type": "code",
+      "id": "upsellmodalform_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L63"
     },
     {
-      "community": 284,
+      "community": 277,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
-      "label": "account.tsx",
-      "norm_label": "account.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "id": "upsellmodalform_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 278,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
+      "label": "WelcomeBackModal.tsx",
+      "norm_label": "welcomebackmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 278,
       "file_type": "code",
-      "id": "login_loginbeforeload",
-      "label": "loginBeforeLoad()",
-      "norm_label": "loginbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L47"
+      "id": "welcomebackmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L63"
     },
     {
-      "community": 285,
+      "community": 278,
       "file_type": "code",
-      "id": "login_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L141"
+      "id": "welcomebackmodal_handlesuccess",
+      "label": "handleSuccess()",
+      "norm_label": "handlesuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L76"
     },
     {
-      "community": 285,
+      "community": 279,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "label": "login.tsx",
-      "norm_label": "login.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
+      "label": "WelcomeBackModalForm.tsx",
+      "norm_label": "welcomebackmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 279,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
-      "label": "verify.index.tsx",
-      "norm_label": "verify.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L1"
+      "id": "welcomebackmodalform_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L51"
     },
     {
-      "community": 286,
+      "community": 279,
       "file_type": "code",
-      "id": "verify_index_verify",
-      "label": "Verify()",
-      "norm_label": "verify()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L21"
+      "id": "welcomebackmodalform_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L36"
     },
     {
-      "community": 286,
-      "file_type": "code",
-      "id": "verify_index_verifycheckoutsessionpayment",
-      "label": "VerifyCheckoutSessionPayment()",
-      "norm_label": "verifycheckoutsessionpayment()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L107"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_signup_tsx",
-      "label": "signup.tsx",
-      "norm_label": "signup.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "signup_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "signup_signupbeforeload",
-      "label": "signupBeforeLoad()",
-      "norm_label": "signupbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "env_optionalnumberenv",
-      "label": "optionalNumberEnv()",
-      "norm_label": "optionalnumberenv()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "env_requireenv",
-      "label": "requireEnv()",
-      "norm_label": "requireenv()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
-      "label": "env.ts",
-      "norm_label": "env.ts",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "graphify_wiki_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "graphify_wiki_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "scripts_graphify_wiki_test_ts",
-      "label": "graphify-wiki.test.ts",
-      "norm_label": "graphify-wiki.test.ts",
-      "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 29,
+      "community": 28,
       "file_type": "code",
       "id": "backend_test_completesession",
       "label": "completeSession()",
@@ -43171,7 +43063,7 @@
       "source_location": "L629"
     },
     {
-      "community": 29,
+      "community": 28,
       "file_type": "code",
       "id": "backend_test_createtransaction",
       "label": "createTransaction()",
@@ -43180,7 +43072,7 @@
       "source_location": "L391"
     },
     {
-      "community": 29,
+      "community": 28,
       "file_type": "code",
       "id": "backend_test_createtransactionitems",
       "label": "createTransactionItems()",
@@ -43189,7 +43081,7 @@
       "source_location": "L467"
     },
     {
-      "community": 29,
+      "community": 28,
       "file_type": "code",
       "id": "backend_test_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -43198,7 +43090,7 @@
       "source_location": "L374"
     },
     {
-      "community": 29,
+      "community": 28,
       "file_type": "code",
       "id": "backend_test_handledatabaseerror",
       "label": "handleDatabaseError()",
@@ -43207,7 +43099,7 @@
       "source_location": "L671"
     },
     {
-      "community": 29,
+      "community": 28,
       "file_type": "code",
       "id": "backend_test_rollbackinventory",
       "label": "rollbackInventory()",
@@ -43216,7 +43108,7 @@
       "source_location": "L692"
     },
     {
-      "community": 29,
+      "community": 28,
       "file_type": "code",
       "id": "backend_test_updateinventory",
       "label": "updateInventory()",
@@ -43225,7 +43117,7 @@
       "source_location": "L422"
     },
     {
-      "community": 29,
+      "community": 28,
       "file_type": "code",
       "id": "backend_test_validateinventory",
       "label": "validateInventory()",
@@ -43234,7 +43126,7 @@
       "source_location": "L58"
     },
     {
-      "community": 29,
+      "community": 28,
       "file_type": "code",
       "id": "backend_test_validatesession",
       "label": "validateSession()",
@@ -43243,7 +43135,7 @@
       "source_location": "L553"
     },
     {
-      "community": 29,
+      "community": 28,
       "file_type": "code",
       "id": "backend_test_validatesessioninventory",
       "label": "validateSessionInventory()",
@@ -43252,7 +43144,7 @@
       "source_location": "L593"
     },
     {
-      "community": 29,
+      "community": 28,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
       "label": "backend.test.ts",
@@ -43261,7 +43153,457 @@
       "source_location": "L1"
     },
     {
+      "community": 280,
+      "file_type": "code",
+      "id": "navigationbarprovider_navigationbarprovider",
+      "label": "NavigationBarProvider()",
+      "norm_label": "navigationbarprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "navigationbarprovider_usenavigationbarcontext",
+      "label": "useNavigationBarContext()",
+      "norm_label": "usenavigationbarcontext()",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
+      "label": "NavigationBarProvider.tsx",
+      "norm_label": "navigationbarprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
+      "label": "StoreContext.tsx",
+      "norm_label": "storecontext.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "storecontext_storeprovider",
+      "label": "StoreProvider()",
+      "norm_label": "storeprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "storecontext_usestorecontext",
+      "label": "useStoreContext()",
+      "norm_label": "usestorecontext()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
+      "label": "StorefrontObservabilityProvider.tsx",
+      "norm_label": "storefrontobservabilityprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
+      "label": "StorefrontObservabilityProvider()",
+      "norm_label": "storefrontobservabilityprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_usestorefrontobservability",
+      "label": "useStorefrontObservability()",
+      "norm_label": "usestorefrontobservability()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 283,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
+      "label": "useProductDiscount.ts",
+      "norm_label": "useproductdiscount.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 283,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscount",
+      "label": "useProductDiscount()",
+      "norm_label": "useproductdiscount()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 283,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscounts",
+      "label": "useProductDiscounts()",
+      "norm_label": "useproductdiscounts()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 284,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
+      "label": "useShoppingBag.ts",
+      "norm_label": "useshoppingbag.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 284,
+      "file_type": "code",
+      "id": "useshoppingbag_isunavailableproductlist",
+      "label": "isUnavailableProductList()",
+      "norm_label": "isunavailableproductlist()",
+      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
+      "source_location": "L556"
+    },
+    {
+      "community": 284,
+      "file_type": "code",
+      "id": "useshoppingbag_useshoppingbag",
+      "label": "useShoppingBag()",
+      "norm_label": "useshoppingbag()",
+      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "index_getordermessage",
+      "label": "getOrderMessage()",
+      "norm_label": "getordermessage()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L429"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "index_getpaymenttext",
+      "label": "getPaymentText()",
+      "norm_label": "getpaymenttext()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
+      "label": "review.tsx",
+      "norm_label": "review.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "review_getordermessage",
+      "label": "getOrderMessage()",
+      "norm_label": "getordermessage()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L250"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "review_ordernavigation",
+      "label": "OrderNavigation()",
+      "norm_label": "ordernavigation()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "account_accountbeforeload",
+      "label": "accountBeforeLoad()",
+      "norm_label": "accountbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "account_handleonsubmitform",
+      "label": "handleOnSubmitForm()",
+      "norm_label": "handleonsubmitform()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
+      "label": "account.tsx",
+      "norm_label": "account.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 288,
+      "file_type": "code",
+      "id": "login_loginbeforeload",
+      "label": "loginBeforeLoad()",
+      "norm_label": "loginbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 288,
+      "file_type": "code",
+      "id": "login_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 288,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_login_tsx",
+      "label": "login.tsx",
+      "norm_label": "login.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
+      "label": "verify.index.tsx",
+      "norm_label": "verify.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "verify_index_verify",
+      "label": "Verify()",
+      "norm_label": "verify()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "verify_index_verifycheckoutsessionpayment",
+      "label": "VerifyCheckoutSessionPayment()",
+      "norm_label": "verifycheckoutsessionpayment()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L107"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
+    },
+    {
       "community": 290,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_signup_tsx",
+      "label": "signup.tsx",
+      "norm_label": "signup.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "signup_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "signup_signupbeforeload",
+      "label": "signupBeforeLoad()",
+      "norm_label": "signupbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "env_optionalnumberenv",
+      "label": "optionalNumberEnv()",
+      "norm_label": "optionalnumberenv()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "env_requireenv",
+      "label": "requireEnv()",
+      "norm_label": "requireenv()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
+      "label": "env.ts",
+      "norm_label": "env.ts",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 292,
+      "file_type": "code",
+      "id": "graphify_wiki_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 292,
+      "file_type": "code",
+      "id": "graphify_wiki_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 292,
+      "file_type": "code",
+      "id": "scripts_graphify_wiki_test_ts",
+      "label": "graphify-wiki.test.ts",
+      "norm_label": "graphify-wiki.test.ts",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 293,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -43270,7 +43612,7 @@
       "source_location": "L17"
     },
     {
-      "community": 290,
+      "community": 293,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -43279,7 +43621,7 @@
       "source_location": "L11"
     },
     {
-      "community": 290,
+      "community": 293,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -43288,7 +43630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 294,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -43297,7 +43639,7 @@
       "source_location": "L21"
     },
     {
-      "community": 291,
+      "community": 294,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -43306,7 +43648,7 @@
       "source_location": "L15"
     },
     {
-      "community": 291,
+      "community": 294,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -43315,7 +43657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 295,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -43324,7 +43666,7 @@
       "source_location": "L48"
     },
     {
-      "community": 292,
+      "community": 295,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -43333,7 +43675,7 @@
       "source_location": "L42"
     },
     {
-      "community": 292,
+      "community": 295,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -43342,7 +43684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 296,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -43351,7 +43693,7 @@
       "source_location": "L16"
     },
     {
-      "community": 293,
+      "community": 296,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -43360,7 +43702,7 @@
       "source_location": "L10"
     },
     {
-      "community": 293,
+      "community": 296,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -43369,7 +43711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 297,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -43378,7 +43720,7 @@
       "source_location": "L19"
     },
     {
-      "community": 294,
+      "community": 297,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -43387,7 +43729,7 @@
       "source_location": "L13"
     },
     {
-      "community": 294,
+      "community": 297,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -43396,7 +43738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 298,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -43405,7 +43747,7 @@
       "source_location": "L16"
     },
     {
-      "community": 295,
+      "community": 298,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -43414,7 +43756,7 @@
       "source_location": "L10"
     },
     {
-      "community": 295,
+      "community": 298,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -43423,7 +43765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 299,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -43432,7 +43774,7 @@
       "source_location": "L20"
     },
     {
-      "community": 296,
+      "community": 299,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -43441,85 +43783,13 @@
       "source_location": "L14"
     },
     {
-      "community": 296,
+      "community": 299,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
       "norm_label": "harness-test.test.ts",
       "source_file": "scripts/harness-test.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 297,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 297,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 297,
-      "file_type": "code",
-      "id": "scripts_pre_commit_generated_artifacts_test_ts",
-      "label": "pre-commit-generated-artifacts.test.ts",
-      "norm_label": "pre-commit-generated-artifacts.test.ts",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
-      "label": "runPreCommitGeneratedArtifacts()",
-      "norm_label": "runprecommitgeneratedartifacts()",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
-      "label": "stageTrackedGraphifyArtifacts()",
-      "norm_label": "stagetrackedgraphifyartifacts()",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "scripts_pre_commit_generated_artifacts_ts",
-      "label": "pre-commit-generated-artifacts.ts",
-      "norm_label": "pre-commit-generated-artifacts.ts",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
-      "label": "stream.ts",
-      "norm_label": "stream.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "stream_getcloudflareconfig",
-      "label": "getCloudflareConfig()",
-      "norm_label": "getcloudflareconfig()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
-      "source_location": "L8"
     },
     {
       "community": 3,
@@ -43902,6 +44172,78 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_test_ts",
+      "label": "pre-commit-generated-artifacts.test.ts",
+      "norm_label": "pre-commit-generated-artifacts.test.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
+      "label": "runPreCommitGeneratedArtifacts()",
+      "norm_label": "runprecommitgeneratedartifacts()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
+      "label": "stageTrackedGraphifyArtifacts()",
+      "norm_label": "stagetrackedgraphifyartifacts()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_ts",
+      "label": "pre-commit-generated-artifacts.ts",
+      "norm_label": "pre-commit-generated-artifacts.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
+      "label": "stream.ts",
+      "norm_label": "stream.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
+      "id": "stream_getcloudflareconfig",
+      "label": "getCloudflareConfig()",
+      "norm_label": "getcloudflareconfig()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 303,
+      "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
       "norm_label": "createcommandshimbin()",
@@ -43909,7 +44251,7 @@
       "source_location": "L10"
     },
     {
-      "community": 300,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -43918,7 +44260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -43927,7 +44269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 304,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -43936,7 +44278,7 @@
       "source_location": "L18"
     },
     {
-      "community": 302,
+      "community": 305,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -43945,7 +44287,7 @@
       "source_location": "L10"
     },
     {
-      "community": 302,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -43954,7 +44296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -43963,7 +44305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 306,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -43972,7 +44314,7 @@
       "source_location": "L6"
     },
     {
-      "community": 304,
+      "community": 307,
       "file_type": "code",
       "id": "cashier_authenticatehandler",
       "label": "authenticateHandler()",
@@ -43981,7 +44323,7 @@
       "source_location": "L239"
     },
     {
-      "community": 304,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -43990,7 +44332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -43999,7 +44341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 308,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -44008,7 +44350,7 @@
       "source_location": "L8"
     },
     {
-      "community": 306,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -44017,67 +44359,13 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 309,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
       "norm_label": "readprojectfile()",
       "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 307,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 307,
-      "file_type": "code",
-      "id": "stores_tov2onlyconfig",
-      "label": "toV2OnlyConfig()",
-      "norm_label": "tov2onlyconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "callllmprovider_callllmprovider",
-      "label": "callLlmProvider()",
-      "norm_label": "callllmprovider()",
-      "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
-      "label": "callLlmProvider.ts",
-      "norm_label": "callllmprovider.ts",
-      "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "anthropic_callanthropic",
-      "label": "callAnthropic()",
-      "norm_label": "callanthropic()",
-      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
-      "label": "anthropic.ts",
-      "norm_label": "anthropic.ts",
-      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
-      "source_location": "L1"
     },
     {
       "community": 31,
@@ -44181,6 +44469,60 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "stores_tov2onlyconfig",
+      "label": "toV2OnlyConfig()",
+      "norm_label": "tov2onlyconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "callllmprovider_callllmprovider",
+      "label": "callLlmProvider()",
+      "norm_label": "callllmprovider()",
+      "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
+      "label": "callLlmProvider.ts",
+      "norm_label": "callllmprovider.ts",
+      "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "anthropic_callanthropic",
+      "label": "callAnthropic()",
+      "norm_label": "callanthropic()",
+      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
+      "label": "anthropic.ts",
+      "norm_label": "anthropic.ts",
+      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 313,
+      "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
       "norm_label": "callopenai()",
@@ -44188,7 +44530,7 @@
       "source_location": "L3"
     },
     {
-      "community": 310,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -44197,7 +44539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 314,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -44206,7 +44548,7 @@
       "source_location": "L6"
     },
     {
-      "community": 311,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -44215,7 +44557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 315,
       "file_type": "code",
       "id": "approvalrequests_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -44224,7 +44566,7 @@
       "source_location": "L5"
     },
     {
-      "community": 312,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "label": "approvalRequests.ts",
@@ -44233,7 +44575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 316,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -44242,7 +44584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -44251,7 +44593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_ts",
       "label": "registerSessions.ts",
@@ -44260,7 +44602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 317,
       "file_type": "code",
       "id": "registersessions_buildregistersession",
       "label": "buildRegisterSession()",
@@ -44269,7 +44611,7 @@
       "source_location": "L5"
     },
     {
-      "community": 315,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
@@ -44278,7 +44620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 318,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -44287,7 +44629,7 @@
       "source_location": "L7"
     },
     {
-      "community": 316,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_verificationcodeemail_tsx",
       "label": "VerificationCodeEmail.tsx",
@@ -44296,67 +44638,13 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 319,
       "file_type": "code",
       "id": "verificationcodeemail_verificationcodeemail",
       "label": "VerificationCodeEmail()",
       "norm_label": "verificationcodeemail()",
       "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "catalog_buildservicecatalogitem",
-      "label": "buildServiceCatalogItem()",
-      "norm_label": "buildservicecatalogitem()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
-      "label": "catalog.ts",
-      "norm_label": "catalog.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "modulewiring_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
-      "label": "moduleWiring.test.ts",
-      "norm_label": "modulewiring.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "auth_getstorefrontactorbyid",
-      "label": "getStoreFrontActorById()",
-      "norm_label": "getstorefrontactorbyid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
-      "source_location": "L1"
     },
     {
       "community": 32,
@@ -44451,6 +44739,60 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "catalog_buildservicecatalogitem",
+      "label": "buildServiceCatalogItem()",
+      "norm_label": "buildservicecatalogitem()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
+      "label": "catalog.ts",
+      "norm_label": "catalog.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "modulewiring_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
+      "label": "moduleWiring.test.ts",
+      "norm_label": "modulewiring.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "auth_getstorefrontactorbyid",
+      "label": "getStoreFrontActorById()",
+      "norm_label": "getstorefrontactorbyid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
       "norm_label": "createqueryctx()",
@@ -44458,7 +44800,7 @@
       "source_location": "L5"
     },
     {
-      "community": 320,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -44467,7 +44809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 324,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -44476,7 +44818,7 @@
       "source_location": "L17"
     },
     {
-      "community": 321,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -44485,7 +44827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 325,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -44494,7 +44836,7 @@
       "source_location": "L6"
     },
     {
-      "community": 322,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -44503,7 +44845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 326,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -44512,7 +44854,7 @@
       "source_location": "L25"
     },
     {
-      "community": 323,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -44521,7 +44863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -44530,7 +44872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 327,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -44539,7 +44881,7 @@
       "source_location": "L17"
     },
     {
-      "community": 325,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -44548,7 +44890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 328,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -44557,7 +44899,7 @@
       "source_location": "L14"
     },
     {
-      "community": 326,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -44566,67 +44908,13 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 329,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
       "norm_label": "createanalyticsevent()",
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L8"
-    },
-    {
-      "community": 327,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
-      "label": "syntheticMonitor.ts",
-      "norm_label": "syntheticmonitor.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 327,
-      "file_type": "code",
-      "id": "syntheticmonitor_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
-      "label": "timeQueryRefactors.test.ts",
-      "norm_label": "timequeryrefactors.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "timequeryrefactors_test_readsource",
-      "label": "readSource()",
-      "norm_label": "readsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "user_getstorefrontactorbyid",
-      "label": "getStoreFrontActorById()",
-      "norm_label": "getstorefrontactorbyid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
-      "source_location": "L16"
     },
     {
       "community": 33,
@@ -44721,6 +45009,60 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
+      "label": "syntheticMonitor.ts",
+      "norm_label": "syntheticmonitor.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "syntheticmonitor_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
+      "label": "timeQueryRefactors.test.ts",
+      "norm_label": "timequeryrefactors.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "timequeryrefactors_test_readsource",
+      "label": "readSource()",
+      "norm_label": "readsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "user_getstorefrontactorbyid",
+      "label": "getStoreFrontActorById()",
+      "norm_label": "getstorefrontactorbyid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 333,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
       "norm_label": "useroffers.ts",
@@ -44728,7 +45070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 333,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -44737,7 +45079,7 @@
       "source_location": "L30"
     },
     {
-      "community": 331,
+      "community": 334,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -44746,7 +45088,7 @@
       "source_location": "L7"
     },
     {
-      "community": 331,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -44755,7 +45097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 335,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -44764,7 +45106,7 @@
       "source_location": "L12"
     },
     {
-      "community": 332,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -44773,7 +45115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -44782,7 +45124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 336,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -44791,7 +45133,7 @@
       "source_location": "L11"
     },
     {
-      "community": 334,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -44800,7 +45142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 337,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -44809,7 +45151,7 @@
       "source_location": "L11"
     },
     {
-      "community": 335,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -44818,7 +45160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 338,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -44827,7 +45169,7 @@
       "source_location": "L3"
     },
     {
-      "community": 336,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -44836,67 +45178,13 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 339,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
       "norm_label": "storeactions()",
       "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
       "source_location": "L12"
-    },
-    {
-      "community": 337,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storedropdown_tsx",
-      "label": "StoreDropdown.tsx",
-      "norm_label": "storedropdown.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 337,
-      "file_type": "code",
-      "id": "storedropdown_storedropdown",
-      "label": "StoreDropdown()",
-      "norm_label": "storedropdown()",
-      "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeview_tsx",
-      "label": "StoreView.tsx",
-      "norm_label": "storeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "storeview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
-      "label": "StoresDropdown.tsx",
-      "norm_label": "storesdropdown.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "storesdropdown_storesdropdown",
-      "label": "StoresDropdown()",
-      "norm_label": "storesdropdown()",
-      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
-      "source_location": "L42"
     },
     {
       "community": 34,
@@ -44991,6 +45279,60 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storedropdown_tsx",
+      "label": "StoreDropdown.tsx",
+      "norm_label": "storedropdown.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "storedropdown_storedropdown",
+      "label": "StoreDropdown()",
+      "norm_label": "storedropdown()",
+      "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeview_tsx",
+      "label": "StoreView.tsx",
+      "norm_label": "storeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "storeview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
+      "label": "StoresDropdown.tsx",
+      "norm_label": "storesdropdown.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
+      "id": "storesdropdown_storesdropdown",
+      "label": "StoresDropdown()",
+      "norm_label": "storesdropdown()",
+      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 343,
+      "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
       "norm_label": "handleprint()",
@@ -44998,7 +45340,7 @@
       "source_location": "L31"
     },
     {
-      "community": 340,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -45007,7 +45349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -45016,7 +45358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 344,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -45025,7 +45367,7 @@
       "source_location": "L10"
     },
     {
-      "community": 342,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -45034,7 +45376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 345,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -45043,7 +45385,7 @@
       "source_location": "L14"
     },
     {
-      "community": 343,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -45052,7 +45394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 346,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -45061,7 +45403,7 @@
       "source_location": "L5"
     },
     {
-      "community": 344,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -45070,7 +45412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 347,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -45079,7 +45421,7 @@
       "source_location": "L10"
     },
     {
-      "community": 345,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -45088,7 +45430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 348,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -45097,7 +45439,7 @@
       "source_location": "L15"
     },
     {
-      "community": 346,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -45106,67 +45448,13 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 349,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
       "norm_label": "productpage()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 347,
-      "file_type": "code",
-      "id": "copyimagesview_setisupdatingsku",
-      "label": "setIsUpdatingSku()",
-      "norm_label": "setisupdatingsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 347,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
-      "label": "CopyImagesView.tsx",
-      "norm_label": "copyimagesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
-      "label": "product-variant-columns.tsx",
-      "norm_label": "product-variant-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "product_variant_columns_setsourcevariant",
-      "label": "setSourceVariant()",
-      "norm_label": "setsourcevariant()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "activitytimeline_capitalizefirstletter",
-      "label": "capitalizeFirstLetter()",
-      "norm_label": "capitalizefirstletter()",
-      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
-      "source_location": "L151"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
-      "label": "ActivityTimeline.tsx",
-      "norm_label": "activitytimeline.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
-      "source_location": "L1"
     },
     {
       "community": 35,
@@ -45261,6 +45549,60 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "copyimagesview_setisupdatingsku",
+      "label": "setIsUpdatingSku()",
+      "norm_label": "setisupdatingsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
+      "label": "CopyImagesView.tsx",
+      "norm_label": "copyimagesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
+      "label": "product-variant-columns.tsx",
+      "norm_label": "product-variant-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "product_variant_columns_setsourcevariant",
+      "label": "setSourceVariant()",
+      "norm_label": "setsourcevariant()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
+      "id": "activitytimeline_capitalizefirstletter",
+      "label": "capitalizeFirstLetter()",
+      "norm_label": "capitalizefirstletter()",
+      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
+      "source_location": "L151"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
+      "label": "ActivityTimeline.tsx",
+      "norm_label": "activitytimeline.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 353,
+      "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
       "norm_label": "analyticsitems()",
@@ -45268,7 +45610,7 @@
       "source_location": "L6"
     },
     {
-      "community": 350,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -45277,7 +45619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 354,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -45286,7 +45628,7 @@
       "source_location": "L19"
     },
     {
-      "community": 351,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -45295,7 +45637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 355,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -45304,7 +45646,7 @@
       "source_location": "L7"
     },
     {
-      "community": 352,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -45313,7 +45655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 356,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -45322,7 +45664,7 @@
       "source_location": "L42"
     },
     {
-      "community": 353,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -45331,7 +45673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -45340,7 +45682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 357,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -45349,7 +45691,7 @@
       "source_location": "L66"
     },
     {
-      "community": 355,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -45358,7 +45700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 358,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -45367,7 +45709,7 @@
       "source_location": "L18"
     },
     {
-      "community": 356,
+      "community": 359,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -45376,67 +45718,13 @@
       "source_location": "L6"
     },
     {
-      "community": 356,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
       "norm_label": "logitems.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 357,
-      "file_type": "code",
-      "id": "logview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 357,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
-      "label": "LogView.tsx",
-      "norm_label": "logview.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "logsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
-      "label": "LogsView.tsx",
-      "norm_label": "logsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
-      "label": "useLoadLogItems.ts",
-      "norm_label": "useloadlogitems.ts",
-      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "useloadlogitems_useloadlogitems",
-      "label": "useLoadLogItems()",
-      "norm_label": "useloadlogitems()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
-      "source_location": "L12"
     },
     {
       "community": 36,
@@ -45531,6 +45819,60 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "logview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
+      "label": "LogView.tsx",
+      "norm_label": "logview.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "logsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
+      "label": "LogsView.tsx",
+      "norm_label": "logsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
+      "label": "useLoadLogItems.ts",
+      "norm_label": "useloadlogitems.ts",
+      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
+      "id": "useloadlogitems_useloadlogitems",
+      "label": "useLoadLogItems()",
+      "norm_label": "useloadlogitems()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 363,
+      "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
       "norm_label": "auth()",
@@ -45538,7 +45880,7 @@
       "source_location": "L3"
     },
     {
-      "community": 360,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -45547,7 +45889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 364,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -45556,7 +45898,7 @@
       "source_location": "L5"
     },
     {
-      "community": 361,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -45565,7 +45907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 365,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -45574,7 +45916,7 @@
       "source_location": "L49"
     },
     {
-      "community": 362,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -45583,7 +45925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 366,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -45592,7 +45934,7 @@
       "source_location": "L23"
     },
     {
-      "community": 363,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -45601,7 +45943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 367,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -45610,7 +45952,7 @@
       "source_location": "L50"
     },
     {
-      "community": 364,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -45619,7 +45961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 368,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -45628,7 +45970,7 @@
       "source_location": "L13"
     },
     {
-      "community": 365,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -45637,7 +45979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 369,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -45646,66 +45988,12 @@
       "source_location": "L11"
     },
     {
-      "community": 366,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
       "norm_label": "checkoutsesssionsview.tsx",
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 367,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
-      "label": "PageHeader.tsx",
-      "norm_label": "pageheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 367,
-      "file_type": "code",
-      "id": "pageheader_pageheader",
-      "label": "PageHeader()",
-      "norm_label": "pageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "bestsellersdialog_handleaddbestseller",
-      "label": "handleAddBestSeller()",
-      "norm_label": "handleaddbestseller()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
-      "label": "BestSellersDialog.tsx",
-      "norm_label": "bestsellersdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "featuredsectiondialog_handleaddfeatureditem",
-      "label": "handleAddFeaturedItem()",
-      "norm_label": "handleaddfeatureditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
-      "label": "FeaturedSectionDialog.tsx",
-      "norm_label": "featuredsectiondialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
       "source_location": "L1"
     },
     {
@@ -45801,6 +46089,60 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
+      "label": "PageHeader.tsx",
+      "norm_label": "pageheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "pageheader_pageheader",
+      "label": "PageHeader()",
+      "norm_label": "pageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "bestsellersdialog_handleaddbestseller",
+      "label": "handleAddBestSeller()",
+      "norm_label": "handleaddbestseller()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
+      "label": "BestSellersDialog.tsx",
+      "norm_label": "bestsellersdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
+      "id": "featuredsectiondialog_handleaddfeatureditem",
+      "label": "handleAddFeaturedItem()",
+      "norm_label": "handleaddfeatureditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
+      "label": "FeaturedSectionDialog.tsx",
+      "norm_label": "featuredsectiondialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 373,
+      "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
@@ -45808,7 +46150,7 @@
       "source_location": "L25"
     },
     {
-      "community": 370,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -45817,7 +46159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 374,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -45826,7 +46168,7 @@
       "source_location": "L83"
     },
     {
-      "community": 371,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -45835,7 +46177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -45844,7 +46186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 375,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -45853,7 +46195,7 @@
       "source_location": "L35"
     },
     {
-      "community": 373,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -45862,7 +46204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 376,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -45871,7 +46213,7 @@
       "source_location": "L28"
     },
     {
-      "community": 374,
+      "community": 377,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -45880,7 +46222,7 @@
       "source_location": "L11"
     },
     {
-      "community": 374,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -45889,7 +46231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 378,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -45898,7 +46240,7 @@
       "source_location": "L13"
     },
     {
-      "community": 375,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -45907,7 +46249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 379,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -45916,66 +46258,12 @@
       "source_location": "L41"
     },
     {
-      "community": 376,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
       "norm_label": "emailstatusview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 377,
-      "file_type": "code",
-      "id": "ordermetricspanel_handletimerangechange",
-      "label": "handleTimeRangeChange()",
-      "norm_label": "handletimerangechange()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 377,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
-      "label": "OrderMetricsPanel.tsx",
-      "norm_label": "ordermetricspanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "orderview_handlerefundorder",
-      "label": "handleRefundOrder()",
-      "norm_label": "handlerefundorder()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
-      "label": "OrderView.tsx",
-      "norm_label": "orderview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "ordersview_gettimefilter",
-      "label": "getTimeFilter()",
-      "norm_label": "gettimefilter()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
-      "label": "OrdersView.tsx",
-      "norm_label": "ordersview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1"
     },
     {
@@ -46062,6 +46350,60 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "ordermetricspanel_handletimerangechange",
+      "label": "handleTimeRangeChange()",
+      "norm_label": "handletimerangechange()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
+      "label": "OrderMetricsPanel.tsx",
+      "norm_label": "ordermetricspanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "orderview_handlerefundorder",
+      "label": "handleRefundOrder()",
+      "norm_label": "handlerefundorder()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
+      "source_location": "L68"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
+      "label": "OrderView.tsx",
+      "norm_label": "orderview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
+      "id": "ordersview_gettimefilter",
+      "label": "getTimeFilter()",
+      "norm_label": "gettimefilter()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
+      "label": "OrdersView.tsx",
+      "norm_label": "ordersview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 383,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
       "norm_label": "refundsview.tsx",
@@ -46069,7 +46411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 383,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -46078,7 +46420,7 @@
       "source_location": "L79"
     },
     {
-      "community": 381,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -46087,7 +46429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 384,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -46096,7 +46438,7 @@
       "source_location": "L6"
     },
     {
-      "community": 382,
+      "community": 385,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -46105,7 +46447,7 @@
       "source_location": "L34"
     },
     {
-      "community": 382,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -46114,7 +46456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 386,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -46123,7 +46465,7 @@
       "source_location": "L89"
     },
     {
-      "community": 383,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -46132,7 +46474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 387,
       "file_type": "code",
       "id": "cashierview_handlesignout",
       "label": "handleSignOut()",
@@ -46141,7 +46483,7 @@
       "source_location": "L63"
     },
     {
-      "community": 384,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -46150,7 +46492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 388,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -46159,7 +46501,7 @@
       "source_location": "L5"
     },
     {
-      "community": 385,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -46168,7 +46510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 389,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -46177,67 +46519,13 @@
       "source_location": "L7"
     },
     {
-      "community": 386,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
       "norm_label": "noresultsmessage.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 387,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
-      "label": "PinInput.tsx",
-      "norm_label": "pininput.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 387,
-      "file_type": "code",
-      "id": "pininput_pininput",
-      "label": "PinInput()",
-      "norm_label": "pininput()",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
-      "label": "PointOfSaleView.tsx",
-      "norm_label": "pointofsaleview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "pointofsaleview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
-      "label": "PrintInstructions.tsx",
-      "norm_label": "printinstructions.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "printinstructions_printinstructions",
-      "label": "PrintInstructions()",
-      "norm_label": "printinstructions()",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L3"
     },
     {
       "community": 39,
@@ -46323,6 +46611,60 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
+      "label": "PinInput.tsx",
+      "norm_label": "pininput.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "pininput_pininput",
+      "label": "PinInput()",
+      "norm_label": "pininput()",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
+      "label": "PointOfSaleView.tsx",
+      "norm_label": "pointofsaleview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "pointofsaleview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 392,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
+      "label": "PrintInstructions.tsx",
+      "norm_label": "printinstructions.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 392,
+      "file_type": "code",
+      "id": "printinstructions_printinstructions",
+      "label": "PrintInstructions()",
+      "norm_label": "printinstructions()",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 393,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
       "norm_label": "productcard.tsx",
@@ -46330,7 +46672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 393,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -46339,7 +46681,7 @@
       "source_location": "L14"
     },
     {
-      "community": 391,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -46348,7 +46690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 394,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -46357,7 +46699,7 @@
       "source_location": "L86"
     },
     {
-      "community": 392,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_quickactionsbar_tsx",
       "label": "QuickActionsBar.tsx",
@@ -46366,7 +46708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 395,
       "file_type": "code",
       "id": "quickactionsbar_quickactionsbar",
       "label": "QuickActionsBar()",
@@ -46375,7 +46717,7 @@
       "source_location": "L11"
     },
     {
-      "community": 393,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -46384,7 +46726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 396,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -46393,7 +46735,7 @@
       "source_location": "L15"
     },
     {
-      "community": 394,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -46402,7 +46744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 397,
       "file_type": "code",
       "id": "totalsdisplay_totalsdisplay",
       "label": "TotalsDisplay()",
@@ -46411,7 +46753,7 @@
       "source_location": "L14"
     },
     {
-      "community": 395,
+      "community": 398,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -46420,7 +46762,7 @@
       "source_location": "L18"
     },
     {
-      "community": 395,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -46429,7 +46771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 399,
       "file_type": "code",
       "id": "hooks_useposcashier",
       "label": "usePOSCashier()",
@@ -46438,67 +46780,13 @@
       "source_location": "L5"
     },
     {
-      "community": 396,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_hooks_ts",
       "label": "hooks.ts",
       "norm_label": "hooks.ts",
       "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 397,
-      "file_type": "code",
-      "id": "holdsessiondialog_holdsessiondialog",
-      "label": "HoldSessionDialog()",
-      "norm_label": "holdsessiondialog()",
-      "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 397,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_session_holdsessiondialog_tsx",
-      "label": "HoldSessionDialog.tsx",
-      "norm_label": "holdsessiondialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_session_voidsessiondialog_tsx",
-      "label": "VoidSessionDialog.tsx",
-      "norm_label": "voidsessiondialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "voidsessiondialog_voidsessiondialog",
-      "label": "VoidSessionDialog()",
-      "norm_label": "voidsessiondialog()",
-      "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
-      "label": "transactionColumns.tsx",
-      "norm_label": "transactioncolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "transactioncolumns_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L22"
     },
     {
       "community": 4,
@@ -46836,6 +47124,60 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "holdsessiondialog_holdsessiondialog",
+      "label": "HoldSessionDialog()",
+      "norm_label": "holdsessiondialog()",
+      "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_session_holdsessiondialog_tsx",
+      "label": "HoldSessionDialog.tsx",
+      "norm_label": "holdsessiondialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_session_voidsessiondialog_tsx",
+      "label": "VoidSessionDialog.tsx",
+      "norm_label": "voidsessiondialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "voidsessiondialog_voidsessiondialog",
+      "label": "VoidSessionDialog()",
+      "norm_label": "voidsessiondialog()",
+      "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
+      "label": "transactionColumns.tsx",
+      "norm_label": "transactioncolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "transactioncolumns_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
       "norm_label": "barcodeview()",
@@ -46843,7 +47185,7 @@
       "source_location": "L14"
     },
     {
-      "community": 400,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -46852,7 +47194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 404,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -46861,7 +47203,7 @@
       "source_location": "L6"
     },
     {
-      "community": 401,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -46870,7 +47212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 405,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -46879,7 +47221,7 @@
       "source_location": "L38"
     },
     {
-      "community": 402,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -46888,7 +47230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -46897,7 +47239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 406,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -46906,7 +47248,7 @@
       "source_location": "L10"
     },
     {
-      "community": 404,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -46915,7 +47257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 407,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -46924,7 +47266,7 @@
       "source_location": "L6"
     },
     {
-      "community": 405,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -46933,7 +47275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 408,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -46942,7 +47284,7 @@
       "source_location": "L5"
     },
     {
-      "community": 406,
+      "community": 409,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -46951,67 +47293,13 @@
       "source_location": "L17"
     },
     {
-      "community": 406,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
       "norm_label": "add-product-command.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 407,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 407,
-      "file_type": "code",
-      "id": "products_products",
-      "label": "Products()",
-      "norm_label": "products()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
-      "label": "PromoCodeForm.tsx",
-      "norm_label": "promocodeform.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "promocodeform_togglediscounttype",
-      "label": "toggleDiscountType()",
-      "norm_label": "togglediscounttype()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
-      "source_location": "L84"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
-      "label": "PromoCodeHeader.tsx",
-      "norm_label": "promocodeheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "promocodeheader_handledeletepromocode",
-      "label": "handleDeletePromoCode()",
-      "norm_label": "handledeletepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L22"
     },
     {
       "community": 41,
@@ -47097,6 +47385,60 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "products_products",
+      "label": "Products()",
+      "norm_label": "products()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
+      "label": "PromoCodeForm.tsx",
+      "norm_label": "promocodeform.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "promocodeform_togglediscounttype",
+      "label": "toggleDiscountType()",
+      "norm_label": "togglediscounttype()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
+      "source_location": "L84"
+    },
+    {
+      "community": 412,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
+      "label": "PromoCodeHeader.tsx",
+      "norm_label": "promocodeheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 412,
+      "file_type": "code",
+      "id": "promocodeheader_handledeletepromocode",
+      "label": "handleDeletePromoCode()",
+      "norm_label": "handledeletepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 413,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
       "norm_label": "promocodesview.tsx",
@@ -47104,7 +47446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 413,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -47113,7 +47455,7 @@
       "source_location": "L9"
     },
     {
-      "community": 411,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -47122,7 +47464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 414,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -47131,7 +47473,7 @@
       "source_location": "L23"
     },
     {
-      "community": 412,
+      "community": 415,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -47140,7 +47482,7 @@
       "source_location": "L5"
     },
     {
-      "community": 412,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -47149,7 +47491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -47158,7 +47500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 416,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -47167,7 +47509,7 @@
       "source_location": "L4"
     },
     {
-      "community": 414,
+      "community": 417,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -47176,7 +47518,7 @@
       "source_location": "L13"
     },
     {
-      "community": 414,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -47185,7 +47527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -47194,7 +47536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 418,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -47203,7 +47545,7 @@
       "source_location": "L29"
     },
     {
-      "community": 416,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -47212,67 +47554,13 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 419,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
       "norm_label": "reviewactions()",
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L20"
-    },
-    {
-      "community": 417,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
-      "label": "ServiceCasesView.tsx",
-      "norm_label": "servicecasesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 417,
-      "file_type": "code",
-      "id": "servicecasesview_handlecreatecase",
-      "label": "handleCreateCase()",
-      "norm_label": "handlecreatecase()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L171"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
-      "label": "ServiceIntakeForm.tsx",
-      "norm_label": "serviceintakeform.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "serviceintakeform_serviceintakeform",
-      "label": "ServiceIntakeForm()",
-      "norm_label": "serviceintakeform()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "empty_state_onclick",
-      "label": "onClick()",
-      "norm_label": "onclick()",
-      "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
-      "label": "empty-state.tsx",
-      "norm_label": "empty-state.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
-      "source_location": "L1"
     },
     {
       "community": 42,
@@ -47358,6 +47646,60 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
+      "label": "ServiceCasesView.tsx",
+      "norm_label": "servicecasesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "servicecasesview_handlecreatecase",
+      "label": "handleCreateCase()",
+      "norm_label": "handlecreatecase()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L171"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
+      "label": "ServiceIntakeForm.tsx",
+      "norm_label": "serviceintakeform.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "serviceintakeform_serviceintakeform",
+      "label": "ServiceIntakeForm()",
+      "norm_label": "serviceintakeform()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx",
+      "source_location": "L52"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
+      "id": "empty_state_onclick",
+      "label": "onClick()",
+      "norm_label": "onclick()",
+      "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
+      "label": "empty-state.tsx",
+      "norm_label": "empty-state.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 423,
+      "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
       "norm_label": "nopermission()",
@@ -47365,7 +47707,7 @@
       "source_location": "L3"
     },
     {
-      "community": 420,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -47374,7 +47716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 424,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -47383,7 +47725,7 @@
       "source_location": "L4"
     },
     {
-      "community": 421,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -47392,7 +47734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 425,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -47401,7 +47743,7 @@
       "source_location": "L4"
     },
     {
-      "community": 422,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -47410,7 +47752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 426,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -47419,7 +47761,7 @@
       "source_location": "L9"
     },
     {
-      "community": 423,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -47428,7 +47770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 427,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -47437,7 +47779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -47446,7 +47788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 428,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -47455,7 +47797,7 @@
       "source_location": "L13"
     },
     {
-      "community": 425,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -47464,7 +47806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -47473,67 +47815,13 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 429,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
       "norm_label": "handleupdatetaxsettings()",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
       "source_location": "L25"
-    },
-    {
-      "community": 427,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
-      "label": "useStoreConfigUpdate.ts",
-      "norm_label": "usestoreconfigupdate.ts",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 427,
-      "file_type": "code",
-      "id": "usestoreconfigupdate_usestoreconfigupdate",
-      "label": "useStoreConfigUpdate()",
-      "norm_label": "usestoreconfigupdate()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_switcher_tsx",
-      "label": "store-switcher.tsx",
-      "norm_label": "store-switcher.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "store_switcher_onstoreselect",
-      "label": "onStoreSelect()",
-      "norm_label": "onstoreselect()",
-      "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "calendar_calendar",
-      "label": "Calendar()",
-      "norm_label": "calendar()",
-      "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
-      "label": "calendar.tsx",
-      "norm_label": "calendar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
-      "source_location": "L1"
     },
     {
       "community": 43,
@@ -47619,6 +47907,60 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
+      "label": "useStoreConfigUpdate.ts",
+      "norm_label": "usestoreconfigupdate.ts",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "usestoreconfigupdate_usestoreconfigupdate",
+      "label": "useStoreConfigUpdate()",
+      "norm_label": "usestoreconfigupdate()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_switcher_tsx",
+      "label": "store-switcher.tsx",
+      "norm_label": "store-switcher.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "store_switcher_onstoreselect",
+      "label": "onStoreSelect()",
+      "norm_label": "onstoreselect()",
+      "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
+      "id": "calendar_calendar",
+      "label": "Calendar()",
+      "norm_label": "calendar()",
+      "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
+      "label": "calendar.tsx",
+      "norm_label": "calendar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 433,
+      "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
       "norm_label": "usechart()",
@@ -47626,7 +47968,7 @@
       "source_location": "L25"
     },
     {
-      "community": 430,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -47635,7 +47977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 434,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -47644,7 +47986,7 @@
       "source_location": "L15"
     },
     {
-      "community": 431,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -47653,7 +47995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 435,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -47662,7 +48004,7 @@
       "source_location": "L21"
     },
     {
-      "community": 432,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -47671,7 +48013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 436,
       "file_type": "code",
       "id": "date_time_picker_datetimepicker",
       "label": "DateTimePicker()",
@@ -47680,7 +48022,7 @@
       "source_location": "L21"
     },
     {
-      "community": 433,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -47689,7 +48031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 437,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -47698,7 +48040,7 @@
       "source_location": "L6"
     },
     {
-      "community": 434,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -47707,7 +48049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 438,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -47716,7 +48058,7 @@
       "source_location": "L25"
     },
     {
-      "community": 435,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -47725,7 +48067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 439,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -47734,67 +48076,13 @@
       "source_location": "L49"
     },
     {
-      "community": 436,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
       "norm_label": "organization-modal.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
-      "label": "store-modal.tsx",
-      "norm_label": "store-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "store_modal_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
-      "label": "welcome-back-modal-example.tsx",
-      "norm_label": "welcome-back-modal-example.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "welcome_back_modal_example_welcomebackmodalexample",
-      "label": "WelcomeBackModalExample()",
-      "norm_label": "welcomebackmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
-      "label": "welcome-back-modal.tsx",
-      "norm_label": "welcome-back-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "welcome_back_modal_welcomebackmodal",
-      "label": "WelcomeBackModal()",
-      "norm_label": "welcomebackmodal()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
-      "source_location": "L12"
     },
     {
       "community": 44,
@@ -47880,6 +48168,60 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
+      "label": "store-modal.tsx",
+      "norm_label": "store-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "store_modal_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
+      "label": "welcome-back-modal-example.tsx",
+      "norm_label": "welcome-back-modal-example.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "welcome_back_modal_example_welcomebackmodalexample",
+      "label": "WelcomeBackModalExample()",
+      "norm_label": "welcomebackmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
+      "label": "welcome-back-modal.tsx",
+      "norm_label": "welcome-back-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
+      "id": "welcome_back_modal_welcomebackmodal",
+      "label": "WelcomeBackModal()",
+      "norm_label": "welcomebackmodal()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 443,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
       "norm_label": "select-native.tsx",
@@ -47887,7 +48229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 443,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -47896,7 +48238,7 @@
       "source_location": "L15"
     },
     {
-      "community": 441,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -47905,7 +48247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 444,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -47914,7 +48256,7 @@
       "source_location": "L3"
     },
     {
-      "community": 442,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -47923,7 +48265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 445,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -47932,7 +48274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 446,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -47941,7 +48283,7 @@
       "source_location": "L5"
     },
     {
-      "community": 443,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -47950,7 +48292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 447,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -47959,7 +48301,7 @@
       "source_location": "L11"
     },
     {
-      "community": 444,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -47968,7 +48310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 448,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -47977,7 +48319,7 @@
       "source_location": "L4"
     },
     {
-      "community": 445,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -47986,7 +48328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 449,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -47995,67 +48337,13 @@
       "source_location": "L110"
     },
     {
-      "community": 446,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
       "norm_label": "customerbehaviortimeline.tsx",
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 447,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
-      "label": "UserAnalyticsName.tsx",
-      "norm_label": "useranalyticsname.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 447,
-      "file_type": "code",
-      "id": "useranalyticsname_useranalyticsname",
-      "label": "UserAnalyticsName()",
-      "norm_label": "useranalyticsname()",
-      "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userbag_tsx",
-      "label": "UserBag.tsx",
-      "norm_label": "userbag.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "userbag_userbag",
-      "label": "UserBag()",
-      "norm_label": "userbag()",
-      "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
-      "label": "UserOnlineOrders.tsx",
-      "norm_label": "useronlineorders.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "useronlineorders_useronlineorders",
-      "label": "UserOnlineOrders()",
-      "norm_label": "useronlineorders()",
-      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
-      "source_location": "L11"
     },
     {
       "community": 45,
@@ -48141,6 +48429,60 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
+      "label": "UserAnalyticsName.tsx",
+      "norm_label": "useranalyticsname.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "useranalyticsname_useranalyticsname",
+      "label": "UserAnalyticsName()",
+      "norm_label": "useranalyticsname()",
+      "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userbag_tsx",
+      "label": "UserBag.tsx",
+      "norm_label": "userbag.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "userbag_userbag",
+      "label": "UserBag()",
+      "norm_label": "userbag()",
+      "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
+      "label": "UserOnlineOrders.tsx",
+      "norm_label": "useronlineorders.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
+      "id": "useronlineorders_useronlineorders",
+      "label": "UserOnlineOrders()",
+      "norm_label": "useronlineorders()",
+      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 453,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
       "norm_label": "userstatus.tsx",
@@ -48148,7 +48490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 453,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -48157,7 +48499,7 @@
       "source_location": "L7"
     },
     {
-      "community": 451,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -48166,7 +48508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 454,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -48175,7 +48517,7 @@
       "source_location": "L45"
     },
     {
-      "community": 452,
+      "community": 455,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -48184,7 +48526,7 @@
       "source_location": "L13"
     },
     {
-      "community": 452,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -48193,7 +48535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -48202,7 +48544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 456,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -48211,7 +48553,7 @@
       "source_location": "L7"
     },
     {
-      "community": 454,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -48220,7 +48562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 457,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -48229,7 +48571,7 @@
       "source_location": "L5"
     },
     {
-      "community": 455,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -48238,7 +48580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 458,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -48247,7 +48589,7 @@
       "source_location": "L5"
     },
     {
-      "community": 456,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -48256,67 +48598,13 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 459,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
       "norm_label": "usenavigationkeyboardshortcuts()",
       "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L7"
-    },
-    {
-      "community": 457,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
-      "label": "use-pagination-persistence.ts",
-      "norm_label": "use-pagination-persistence.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 457,
-      "file_type": "code",
-      "id": "use_pagination_persistence_usepaginationpersistence",
-      "label": "usePaginationPersistence()",
-      "norm_label": "usepaginationpersistence()",
-      "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
-      "label": "use-table-keyboard-pagination.ts",
-      "norm_label": "use-table-keyboard-pagination.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
-      "label": "useTableKeyboardPagination()",
-      "norm_label": "usetablekeyboardpagination()",
-      "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
-      "label": "useBulkOperations.test.ts",
-      "norm_label": "usebulkoperations.test.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "usebulkoperations_test_makesku",
-      "label": "makeSku()",
-      "norm_label": "makesku()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
-      "source_location": "L168"
     },
     {
       "community": 46,
@@ -48402,6 +48690,60 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
+      "label": "use-pagination-persistence.ts",
+      "norm_label": "use-pagination-persistence.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "use_pagination_persistence_usepaginationpersistence",
+      "label": "usePaginationPersistence()",
+      "norm_label": "usepaginationpersistence()",
+      "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
+      "label": "use-table-keyboard-pagination.ts",
+      "norm_label": "use-table-keyboard-pagination.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
+      "label": "useTableKeyboardPagination()",
+      "norm_label": "usetablekeyboardpagination()",
+      "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
+      "label": "useBulkOperations.test.ts",
+      "norm_label": "usebulkoperations.test.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
+      "id": "usebulkoperations_test_makesku",
+      "label": "makeSku()",
+      "norm_label": "makesku()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 463,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecartoperations_ts",
       "label": "useCartOperations.ts",
       "norm_label": "usecartoperations.ts",
@@ -48409,7 +48751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 463,
       "file_type": "code",
       "id": "usecartoperations_usecartoperations",
       "label": "useCartOperations()",
@@ -48418,7 +48760,7 @@
       "source_location": "L23"
     },
     {
-      "community": 461,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -48427,7 +48769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 464,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -48436,7 +48778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -48445,7 +48787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 465,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -48454,7 +48796,7 @@
       "source_location": "L6"
     },
     {
-      "community": 463,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecustomeroperations_ts",
       "label": "useCustomerOperations.ts",
@@ -48463,7 +48805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 466,
       "file_type": "code",
       "id": "usecustomeroperations_usecustomeroperations",
       "label": "useCustomerOperations()",
@@ -48472,7 +48814,7 @@
       "source_location": "L21"
     },
     {
-      "community": 464,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -48481,7 +48823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 467,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -48490,7 +48832,7 @@
       "source_location": "L12"
     },
     {
-      "community": 465,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -48499,7 +48841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 468,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
@@ -48508,7 +48850,7 @@
       "source_location": "L23"
     },
     {
-      "community": 466,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -48517,67 +48859,13 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 469,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
       "norm_label": "usegetactiveproduct()",
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 467,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
-      "label": "useGetAuthedUser.ts",
-      "norm_label": "usegetautheduser.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 467,
-      "file_type": "code",
-      "id": "usegetautheduser_usegetautheduser",
-      "label": "useGetAuthedUser()",
-      "norm_label": "usegetautheduser()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
-      "label": "useGetCategories.ts",
-      "norm_label": "usegetcategories.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "usegetcategories_usegetcategories",
-      "label": "useGetCategories()",
-      "norm_label": "usegetcategories()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
-      "label": "useGetComplimentaryProducts.ts",
-      "norm_label": "usegetcomplimentaryproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
-      "label": "useGetComplimentaryProducts()",
-      "norm_label": "usegetcomplimentaryproducts()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
-      "source_location": "L5"
     },
     {
       "community": 47,
@@ -48654,6 +48942,60 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
+      "label": "useGetAuthedUser.ts",
+      "norm_label": "usegetautheduser.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "usegetautheduser_usegetautheduser",
+      "label": "useGetAuthedUser()",
+      "norm_label": "usegetautheduser()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
+      "label": "useGetCategories.ts",
+      "norm_label": "usegetcategories.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "usegetcategories_usegetcategories",
+      "label": "useGetCategories()",
+      "norm_label": "usegetcategories()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
+      "label": "useGetComplimentaryProducts.ts",
+      "norm_label": "usegetcomplimentaryproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
+      "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
+      "label": "useGetComplimentaryProducts()",
+      "norm_label": "usegetcomplimentaryproducts()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 473,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
       "norm_label": "usegetcurrencyformatter.ts",
@@ -48661,7 +49003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 473,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -48670,7 +49012,7 @@
       "source_location": "L4"
     },
     {
-      "community": 471,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -48679,7 +49021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 474,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -48688,7 +49030,7 @@
       "source_location": "L5"
     },
     {
-      "community": 472,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -48697,7 +49039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 475,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -48706,7 +49048,7 @@
       "source_location": "L6"
     },
     {
-      "community": 473,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -48715,7 +49057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 476,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -48724,7 +49066,7 @@
       "source_location": "L8"
     },
     {
-      "community": 474,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -48733,7 +49075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 477,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -48742,7 +49084,7 @@
       "source_location": "L13"
     },
     {
-      "community": 475,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -48751,7 +49093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 478,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -48760,7 +49102,7 @@
       "source_location": "L3"
     },
     {
-      "community": 476,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -48769,67 +49111,13 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 479,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
       "norm_label": "useproductsearchresults()",
       "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
       "source_location": "L26"
-    },
-    {
-      "community": 477,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
-      "label": "useProductWithNoImagesNotification.tsx",
-      "norm_label": "useproductwithnoimagesnotification.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 477,
-      "file_type": "code",
-      "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
-      "label": "useProductWithNoImagesNotification()",
-      "norm_label": "useproductwithnoimagesnotification()",
-      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usesessionmanagement_ts",
-      "label": "useSessionManagement.ts",
-      "norm_label": "usesessionmanagement.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "usesessionmanagement_usesessionmanagement",
-      "label": "useSessionManagement()",
-      "norm_label": "usesessionmanagement()",
-      "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
-      "label": "useSessionManagementExpense.ts",
-      "norm_label": "usesessionmanagementexpense.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "usesessionmanagementexpense_usesessionmanagementexpense",
-      "label": "useSessionManagementExpense()",
-      "norm_label": "usesessionmanagementexpense()",
-      "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
-      "source_location": "L17"
     },
     {
       "community": 48,
@@ -48906,6 +49194,60 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
+      "label": "useProductWithNoImagesNotification.tsx",
+      "norm_label": "useproductwithnoimagesnotification.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
+      "label": "useProductWithNoImagesNotification()",
+      "norm_label": "useproductwithnoimagesnotification()",
+      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usesessionmanagement_ts",
+      "label": "useSessionManagement.ts",
+      "norm_label": "usesessionmanagement.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "usesessionmanagement_usesessionmanagement",
+      "label": "useSessionManagement()",
+      "norm_label": "usesessionmanagement()",
+      "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
+      "label": "useSessionManagementExpense.ts",
+      "norm_label": "usesessionmanagementexpense.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
+      "id": "usesessionmanagementexpense_usesessionmanagementexpense",
+      "label": "useSessionManagementExpense()",
+      "norm_label": "usesessionmanagementexpense()",
+      "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 483,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanageroperations_ts",
       "label": "useSessionManagerOperations.ts",
       "norm_label": "usesessionmanageroperations.ts",
@@ -48913,7 +49255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 483,
       "file_type": "code",
       "id": "usesessionmanageroperations_usesessionmanageroperations",
       "label": "useSessionManagerOperations()",
@@ -48922,7 +49264,7 @@
       "source_location": "L16"
     },
     {
-      "community": 481,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -48931,7 +49273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 484,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -48940,7 +49282,7 @@
       "source_location": "L12"
     },
     {
-      "community": 482,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -48949,7 +49291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 485,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -48958,7 +49300,7 @@
       "source_location": "L12"
     },
     {
-      "community": 483,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -48967,7 +49309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 486,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -48976,7 +49318,7 @@
       "source_location": "L5"
     },
     {
-      "community": 484,
+      "community": 487,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -48985,7 +49327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -48994,7 +49336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 488,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -49003,7 +49345,7 @@
       "source_location": "L10"
     },
     {
-      "community": 485,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -49012,7 +49354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -49021,67 +49363,13 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 489,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
       "norm_label": "hashpin()",
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 487,
-      "file_type": "code",
-      "id": "index_storerootredirect",
-      "label": "StoreRootRedirect()",
-      "norm_label": "storerootredirect()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 487,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
-      "label": "published.index.tsx",
-      "norm_label": "published.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "published_index_routecomponent",
-      "label": "RouteComponent()",
-      "norm_label": "routecomponent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "index_index",
-      "label": "Index()",
-      "norm_label": "index()",
-      "source_file": "packages/athena-webapp/src/routes/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 49,
@@ -49158,6 +49446,60 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "index_storerootredirect",
+      "label": "StoreRootRedirect()",
+      "norm_label": "storerootredirect()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
+      "label": "published.index.tsx",
+      "norm_label": "published.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "published_index_routecomponent",
+      "label": "RouteComponent()",
+      "norm_label": "routecomponent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
+      "id": "index_index",
+      "label": "Index()",
+      "norm_label": "index()",
+      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 493,
+      "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
       "norm_label": "athenaloginreadyview()",
@@ -49165,7 +49507,7 @@
       "source_location": "L4"
     },
     {
-      "community": 490,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -49174,7 +49516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 494,
       "file_type": "code",
       "id": "layout_loginlayout",
       "label": "LoginLayout()",
@@ -49183,7 +49525,7 @@
       "source_location": "L36"
     },
     {
-      "community": 491,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -49192,7 +49534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 495,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -49201,7 +49543,7 @@
       "source_location": "L13"
     },
     {
-      "community": 492,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -49210,7 +49552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 496,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -49219,7 +49561,7 @@
       "source_location": "L5"
     },
     {
-      "community": 493,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -49228,7 +49570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 497,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -49237,7 +49579,7 @@
       "source_location": "L17"
     },
     {
-      "community": 494,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -49246,7 +49588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 498,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -49255,7 +49597,7 @@
       "source_location": "L15"
     },
     {
-      "community": 495,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -49264,7 +49606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 499,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -49273,67 +49615,13 @@
       "source_location": "L12"
     },
     {
-      "community": 496,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
       "norm_label": "feedback.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 497,
-      "file_type": "code",
-      "id": "overview_stories_primitivesoverview",
-      "label": "PrimitivesOverview()",
-      "norm_label": "primitivesoverview()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 497,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
-      "label": "Popover.stories.tsx",
-      "norm_label": "popover.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "popover_stories_popovershowcase",
-      "label": "PopoverShowcase()",
-      "norm_label": "popovershowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
-      "label": "Sheet.stories.tsx",
-      "norm_label": "sheet.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "sheet_stories_sheetshowcase",
-      "label": "SheetShowcase()",
-      "norm_label": "sheetshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
-      "source_location": "L14"
     },
     {
       "community": 5,
@@ -49662,6 +49950,60 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "overview_stories_primitivesoverview",
+      "label": "PrimitivesOverview()",
+      "norm_label": "primitivesoverview()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
+      "label": "Popover.stories.tsx",
+      "norm_label": "popover.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "popover_stories_popovershowcase",
+      "label": "PopoverShowcase()",
+      "norm_label": "popovershowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
+      "label": "Sheet.stories.tsx",
+      "norm_label": "sheet.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
+      "id": "sheet_stories_sheetshowcase",
+      "label": "SheetShowcase()",
+      "norm_label": "sheetshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 503,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
       "norm_label": "tooltip.stories.tsx",
@@ -49669,7 +50011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 503,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -49678,7 +50020,7 @@
       "source_location": "L13"
     },
     {
-      "community": 501,
+      "community": 504,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -49687,7 +50029,7 @@
       "source_location": "L5"
     },
     {
-      "community": 501,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -49696,7 +50038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -49705,7 +50047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 505,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -49714,7 +50056,7 @@
       "source_location": "L17"
     },
     {
-      "community": 503,
+      "community": 506,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -49723,7 +50065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -49732,7 +50074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 507,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -49741,7 +50083,7 @@
       "source_location": "L4"
     },
     {
-      "community": 504,
+      "community": 507,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -49750,7 +50092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 508,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -49759,7 +50101,7 @@
       "source_location": "L27"
     },
     {
-      "community": 505,
+      "community": 508,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -49768,7 +50110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 509,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -49777,67 +50119,13 @@
       "source_location": "L4"
     },
     {
-      "community": 506,
+      "community": 509,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
       "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_storefront_ts",
-      "label": "storefront.ts",
-      "norm_label": "storefront.ts",
-      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "storefront_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "entitypage_entitypage",
-      "label": "EntityPage()",
-      "norm_label": "entitypage()",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
-      "label": "EntityPage.tsx",
-      "norm_label": "entitypage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productspage_tsx",
-      "label": "ProductsPage.tsx",
-      "norm_label": "productspage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "productspage_productcardloadingskeleton",
-      "label": "ProductCardLoadingSkeleton()",
-      "norm_label": "productcardloadingskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
-      "source_location": "L10"
     },
     {
       "community": 51,
@@ -49914,6 +50202,60 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_storefront_ts",
+      "label": "storefront.ts",
+      "norm_label": "storefront.ts",
+      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "storefront_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "entitypage_entitypage",
+      "label": "EntityPage()",
+      "norm_label": "entitypage()",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
+      "label": "EntityPage.tsx",
+      "norm_label": "entitypage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productspage_tsx",
+      "label": "ProductsPage.tsx",
+      "norm_label": "productspage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
+      "id": "productspage_productcardloadingskeleton",
+      "label": "ProductCardLoadingSkeleton()",
+      "norm_label": "productcardloadingskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 513,
+      "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
       "norm_label": "authcomponent()",
@@ -49921,7 +50263,7 @@
       "source_location": "L4"
     },
     {
-      "community": 510,
+      "community": 513,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -49930,7 +50272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 514,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -49939,7 +50281,7 @@
       "source_location": "L39"
     },
     {
-      "community": 511,
+      "community": 514,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -49948,7 +50290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 515,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -49957,7 +50299,7 @@
       "source_location": "L18"
     },
     {
-      "community": 512,
+      "community": 515,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -49966,7 +50308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 516,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -49975,7 +50317,7 @@
       "source_location": "L71"
     },
     {
-      "community": 513,
+      "community": 516,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -49984,7 +50326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 517,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -49993,7 +50335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 517,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -50002,7 +50344,7 @@
       "source_location": "L12"
     },
     {
-      "community": 515,
+      "community": 518,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -50011,7 +50353,7 @@
       "source_location": "L6"
     },
     {
-      "community": 515,
+      "community": 518,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -50020,7 +50362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 519,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -50029,67 +50371,13 @@
       "source_location": "L18"
     },
     {
-      "community": 516,
+      "community": 519,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
       "norm_label": "ordersummary.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "index_pickupdetails",
-      "label": "PickupDetails()",
-      "norm_label": "pickupdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
-      "label": "PaymentMethodSection.tsx",
-      "norm_label": "paymentmethodsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "paymentmethodsection_paymentmethodsection",
-      "label": "PaymentMethodSection()",
-      "norm_label": "paymentmethodsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
-      "label": "PaymentSection.tsx",
-      "norm_label": "paymentsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "paymentsection_paymentsection",
-      "label": "PaymentSection()",
-      "norm_label": "paymentsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L27"
     },
     {
       "community": 52,
@@ -50166,6 +50454,60 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "index_pickupdetails",
+      "label": "PickupDetails()",
+      "norm_label": "pickupdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
+      "label": "PaymentMethodSection.tsx",
+      "norm_label": "paymentmethodsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "paymentmethodsection_paymentmethodsection",
+      "label": "PaymentMethodSection()",
+      "norm_label": "paymentmethodsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
+      "label": "PaymentSection.tsx",
+      "norm_label": "paymentsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
+      "id": "paymentsection_paymentsection",
+      "label": "PaymentSection()",
+      "norm_label": "paymentsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 523,
+      "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
       "norm_label": "calculatedeliveryfee()",
@@ -50173,7 +50515,7 @@
       "source_location": "L40"
     },
     {
-      "community": 520,
+      "community": 523,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -50182,7 +50524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 524,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -50191,7 +50533,7 @@
       "source_location": "L3"
     },
     {
-      "community": 521,
+      "community": 524,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -50200,7 +50542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 525,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -50209,7 +50551,7 @@
       "source_location": "L8"
     },
     {
-      "community": 522,
+      "community": 525,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -50218,7 +50560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 526,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -50227,7 +50569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 526,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -50236,7 +50578,7 @@
       "source_location": "L12"
     },
     {
-      "community": 524,
+      "community": 527,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -50245,7 +50587,7 @@
       "source_location": "L77"
     },
     {
-      "community": 524,
+      "community": 527,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -50254,7 +50596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 528,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -50263,7 +50605,7 @@
       "source_location": "L161"
     },
     {
-      "community": 525,
+      "community": 528,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -50272,7 +50614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 529,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -50281,66 +50623,12 @@
       "source_location": "L3"
     },
     {
-      "community": 526,
+      "community": 529,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
       "norm_label": "hooks.ts",
       "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 527,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
-      "label": "TrustSignals.tsx",
-      "norm_label": "trustsignals.tsx",
-      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 527,
-      "file_type": "code",
-      "id": "trustsignals_trustsignals",
-      "label": "TrustSignals()",
-      "norm_label": "trustsignals()",
-      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
-      "label": "ProductFilter.tsx",
-      "norm_label": "productfilter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "productfilter_productfilter",
-      "label": "ProductFilter()",
-      "norm_label": "productfilter()",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "filter_handlecheckboxchange",
-      "label": "handleCheckboxChange()",
-      "norm_label": "handlecheckboxchange()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
-      "label": "Filter.tsx",
-      "norm_label": "filter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L1"
     },
     {
@@ -50418,6 +50706,60 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
+      "label": "TrustSignals.tsx",
+      "norm_label": "trustsignals.tsx",
+      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "trustsignals_trustsignals",
+      "label": "TrustSignals()",
+      "norm_label": "trustsignals()",
+      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
+      "label": "ProductFilter.tsx",
+      "norm_label": "productfilter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "productfilter_productfilter",
+      "label": "ProductFilter()",
+      "norm_label": "productfilter()",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
+      "id": "filter_handlecheckboxchange",
+      "label": "handleCheckboxChange()",
+      "norm_label": "handlecheckboxchange()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
+      "label": "Filter.tsx",
+      "norm_label": "filter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 533,
+      "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
       "norm_label": "bestsellerssection()",
@@ -50425,7 +50767,7 @@
       "source_location": "L17"
     },
     {
-      "community": 530,
+      "community": 533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -50434,7 +50776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 534,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -50443,7 +50785,7 @@
       "source_location": "L13"
     },
     {
-      "community": 531,
+      "community": 534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -50452,7 +50794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 535,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -50461,7 +50803,7 @@
       "source_location": "L47"
     },
     {
-      "community": 532,
+      "community": 535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -50470,7 +50812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 536,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -50479,7 +50821,7 @@
       "source_location": "L7"
     },
     {
-      "community": 533,
+      "community": 536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -50488,7 +50830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -50497,7 +50839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 537,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -50506,7 +50848,7 @@
       "source_location": "L17"
     },
     {
-      "community": 535,
+      "community": 538,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -50515,7 +50857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 538,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -50524,7 +50866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 539,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -50533,66 +50875,12 @@
       "source_location": "L12"
     },
     {
-      "community": 536,
+      "community": 539,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
       "norm_label": "dimensionbar.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "discountbadge_discountbadge",
-      "label": "DiscountBadge()",
-      "norm_label": "discountbadge()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
-      "label": "DiscountBadge.tsx",
-      "norm_label": "discountbadge.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "galleryviewer_handleclickonpreview",
-      "label": "handleClickOnPreview()",
-      "norm_label": "handleclickonpreview()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
-      "label": "GalleryViewer.tsx",
-      "norm_label": "galleryviewer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "onsaleproduct_onsaleproduct",
-      "label": "OnsaleProduct()",
-      "norm_label": "onsaleproduct()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
-      "label": "OnSaleProduct.tsx",
-      "norm_label": "onsaleproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L1"
     },
     {
@@ -50670,6 +50958,60 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "discountbadge_discountbadge",
+      "label": "DiscountBadge()",
+      "norm_label": "discountbadge()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
+      "label": "DiscountBadge.tsx",
+      "norm_label": "discountbadge.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "galleryviewer_handleclickonpreview",
+      "label": "handleClickOnPreview()",
+      "norm_label": "handleclickonpreview()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
+      "label": "GalleryViewer.tsx",
+      "norm_label": "galleryviewer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
+      "id": "onsaleproduct_onsaleproduct",
+      "label": "OnsaleProduct()",
+      "norm_label": "onsaleproduct()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
+      "label": "OnSaleProduct.tsx",
+      "norm_label": "onsaleproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 543,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
       "norm_label": "productactions.tsx",
@@ -50677,7 +51019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 543,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -50686,7 +51028,7 @@
       "source_location": "L17"
     },
     {
-      "community": 541,
+      "community": 544,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -50695,7 +51037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 544,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -50704,7 +51046,7 @@
       "source_location": "L3"
     },
     {
-      "community": 542,
+      "community": 545,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -50713,7 +51055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 545,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -50722,7 +51064,7 @@
       "source_location": "L78"
     },
     {
-      "community": 543,
+      "community": 546,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -50731,7 +51073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 546,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -50740,7 +51082,7 @@
       "source_location": "L87"
     },
     {
-      "community": 544,
+      "community": 547,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -50749,7 +51091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 547,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -50758,7 +51100,7 @@
       "source_location": "L8"
     },
     {
-      "community": 545,
+      "community": 548,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -50767,7 +51109,7 @@
       "source_location": "L12"
     },
     {
-      "community": 545,
+      "community": 548,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -50776,7 +51118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 549,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -50785,67 +51127,13 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 549,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
       "norm_label": "ratingselector()",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L18"
-    },
-    {
-      "community": 547,
-      "file_type": "code",
-      "id": "guestrewardsprompt_guestrewardsprompt",
-      "label": "GuestRewardsPrompt()",
-      "norm_label": "guestrewardsprompt()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 547,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
-      "label": "GuestRewardsPrompt.tsx",
-      "norm_label": "guestrewardsprompt.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "orderpointsdisplay_orderpointsdisplay",
-      "label": "OrderPointsDisplay()",
-      "norm_label": "orderpointsdisplay()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
-      "label": "OrderPointsDisplay.tsx",
-      "norm_label": "orderpointsdisplay.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
-      "label": "PastOrdersRewards.tsx",
-      "norm_label": "pastordersrewards.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "pastordersrewards_handleclaimpoints",
-      "label": "handleClaimPoints()",
-      "norm_label": "handleclaimpoints()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
-      "source_location": "L59"
     },
     {
       "community": 55,
@@ -50922,6 +51210,60 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "guestrewardsprompt_guestrewardsprompt",
+      "label": "GuestRewardsPrompt()",
+      "norm_label": "guestrewardsprompt()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
+      "label": "GuestRewardsPrompt.tsx",
+      "norm_label": "guestrewardsprompt.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "orderpointsdisplay_orderpointsdisplay",
+      "label": "OrderPointsDisplay()",
+      "norm_label": "orderpointsdisplay()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
+      "label": "OrderPointsDisplay.tsx",
+      "norm_label": "orderpointsdisplay.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
+      "label": "PastOrdersRewards.tsx",
+      "norm_label": "pastordersrewards.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
+      "id": "pastordersrewards_handleclaimpoints",
+      "label": "handleClaimPoints()",
+      "norm_label": "handleclaimpoints()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 553,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
       "norm_label": "rewardspanel.tsx",
@@ -50929,7 +51271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 553,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -50938,7 +51280,7 @@
       "source_location": "L33"
     },
     {
-      "community": 551,
+      "community": 554,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -50947,7 +51289,7 @@
       "source_location": "L19"
     },
     {
-      "community": 551,
+      "community": 554,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -50956,7 +51298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 555,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -50965,7 +51307,7 @@
       "source_location": "L4"
     },
     {
-      "community": 552,
+      "community": 555,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -50974,7 +51316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 556,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -50983,7 +51325,7 @@
       "source_location": "L22"
     },
     {
-      "community": 553,
+      "community": 556,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -50992,7 +51334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 557,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -51001,7 +51343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 557,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -51010,7 +51352,7 @@
       "source_location": "L11"
     },
     {
-      "community": 555,
+      "community": 558,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -51019,7 +51361,7 @@
       "source_location": "L3"
     },
     {
-      "community": 555,
+      "community": 558,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -51028,7 +51370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 559,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -51037,67 +51379,13 @@
       "source_location": "L3"
     },
     {
-      "community": 556,
+      "community": 559,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
       "norm_label": "ghana-region-select.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 557,
-      "file_type": "code",
-      "id": "ghost_button_ghostbutton",
-      "label": "GhostButton()",
-      "norm_label": "ghostbutton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 557,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
-      "label": "ghost-button.tsx",
-      "norm_label": "ghost-button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "leaveareviewmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
-      "label": "LeaveAReviewModal.tsx",
-      "norm_label": "leaveareviewmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
-      "label": "UpsellModalSuccess.tsx",
-      "norm_label": "upsellmodalsuccess.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "upsellmodalsuccess_upsellmodalsuccess",
-      "label": "UpsellModalSuccess()",
-      "norm_label": "upsellmodalsuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
-      "source_location": "L19"
     },
     {
       "community": 56,
@@ -51174,6 +51462,60 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "ghost_button_ghostbutton",
+      "label": "GhostButton()",
+      "norm_label": "ghostbutton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
+      "label": "ghost-button.tsx",
+      "norm_label": "ghost-button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "leaveareviewmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
+      "label": "LeaveAReviewModal.tsx",
+      "norm_label": "leaveareviewmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
+      "label": "UpsellModalSuccess.tsx",
+      "norm_label": "upsellmodalsuccess.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
+      "id": "upsellmodalsuccess_upsellmodalsuccess",
+      "label": "UpsellModalSuccess()",
+      "norm_label": "upsellmodalsuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 563,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
       "norm_label": "welcomebackmodalsuccess.tsx",
@@ -51181,7 +51523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 560,
+      "community": 563,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -51190,7 +51532,7 @@
       "source_location": "L13"
     },
     {
-      "community": 561,
+      "community": 564,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -51199,7 +51541,7 @@
       "source_location": "L46"
     },
     {
-      "community": 561,
+      "community": 564,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -51208,7 +51550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 565,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -51217,7 +51559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 565,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -51226,7 +51568,7 @@
       "source_location": "L46"
     },
     {
-      "community": 563,
+      "community": 566,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -51235,7 +51577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 566,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -51244,7 +51586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 567,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -51253,7 +51595,7 @@
       "source_location": "L15"
     },
     {
-      "community": 564,
+      "community": 567,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -51262,7 +51604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 568,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -51271,7 +51613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 568,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -51280,7 +51622,7 @@
       "source_location": "L5"
     },
     {
-      "community": 566,
+      "community": 569,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -51289,67 +51631,13 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 569,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
       "norm_label": "usediscountcodealert()",
       "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
-      "label": "useEnhancedTracking.ts",
-      "norm_label": "useenhancedtracking.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "useenhancedtracking_useenhancedtracking",
-      "label": "useEnhancedTracking()",
-      "norm_label": "useenhancedtracking()",
-      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
-      "label": "useGetActiveCheckoutSession.tsx",
-      "norm_label": "usegetactivecheckoutsession.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
-      "label": "useGetActiveCheckoutSession()",
-      "norm_label": "usegetactivecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
-      "label": "useGetProduct.tsx",
-      "norm_label": "usegetproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "usegetproduct_usegetproductquery",
-      "label": "useGetProductQuery()",
-      "norm_label": "usegetproductquery()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
-      "source_location": "L5"
     },
     {
       "community": 57,
@@ -51417,6 +51705,60 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
+      "label": "useEnhancedTracking.ts",
+      "norm_label": "useenhancedtracking.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "useenhancedtracking_useenhancedtracking",
+      "label": "useEnhancedTracking()",
+      "norm_label": "useenhancedtracking()",
+      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
+      "label": "useGetActiveCheckoutSession.tsx",
+      "norm_label": "usegetactivecheckoutsession.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
+      "label": "useGetActiveCheckoutSession()",
+      "norm_label": "usegetactivecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
+      "label": "useGetProduct.tsx",
+      "norm_label": "usegetproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
+      "id": "usegetproduct_usegetproductquery",
+      "label": "useGetProductQuery()",
+      "norm_label": "usegetproductquery()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 573,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
       "norm_label": "usegetproductfilters.ts",
@@ -51424,7 +51766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 573,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -51433,7 +51775,7 @@
       "source_location": "L3"
     },
     {
-      "community": 571,
+      "community": 574,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -51442,7 +51784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 574,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -51451,7 +51793,7 @@
       "source_location": "L4"
     },
     {
-      "community": 572,
+      "community": 575,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -51460,7 +51802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 575,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -51469,7 +51811,7 @@
       "source_location": "L4"
     },
     {
-      "community": 573,
+      "community": 576,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -51478,7 +51820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 576,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -51487,7 +51829,7 @@
       "source_location": "L9"
     },
     {
-      "community": 574,
+      "community": 577,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -51496,7 +51838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 577,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -51505,7 +51847,7 @@
       "source_location": "L17"
     },
     {
-      "community": 575,
+      "community": 578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -51514,7 +51856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 578,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -51523,7 +51865,7 @@
       "source_location": "L5"
     },
     {
-      "community": 576,
+      "community": 579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -51532,67 +51874,13 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 579,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
       "norm_label": "usemodalstate()",
       "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
       "source_location": "L15"
-    },
-    {
-      "community": 577,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
-      "label": "useProductPageLogic.ts",
-      "norm_label": "useproductpagelogic.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 577,
-      "file_type": "code",
-      "id": "useproductpagelogic_useproductpagelogic",
-      "label": "useProductPageLogic()",
-      "norm_label": "useproductpagelogic()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
-      "label": "useProductReminder.tsx",
-      "norm_label": "useproductreminder.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "useproductreminder_useproductreminder",
-      "label": "useProductReminder()",
-      "norm_label": "useproductreminder()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
-      "label": "usePromoAlert.tsx",
-      "norm_label": "usepromoalert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "usepromoalert_usepromoalert",
-      "label": "usePromoAlert()",
-      "norm_label": "usepromoalert()",
-      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
-      "source_location": "L16"
     },
     {
       "community": 58,
@@ -51660,6 +51948,60 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
+      "label": "useProductPageLogic.ts",
+      "norm_label": "useproductpagelogic.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "useproductpagelogic_useproductpagelogic",
+      "label": "useProductPageLogic()",
+      "norm_label": "useproductpagelogic()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
+      "label": "useProductReminder.tsx",
+      "norm_label": "useproductreminder.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "useproductreminder_useproductreminder",
+      "label": "useProductReminder()",
+      "norm_label": "useproductreminder()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
+      "label": "usePromoAlert.tsx",
+      "norm_label": "usepromoalert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "usepromoalert_usepromoalert",
+      "label": "usePromoAlert()",
+      "norm_label": "usepromoalert()",
+      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 583,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
       "norm_label": "usequeryenabled.ts",
@@ -51667,7 +52009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 583,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -51676,7 +52018,7 @@
       "source_location": "L4"
     },
     {
-      "community": 581,
+      "community": 584,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -51685,7 +52027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 584,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -51694,7 +52036,7 @@
       "source_location": "L11"
     },
     {
-      "community": 582,
+      "community": 585,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -51703,7 +52045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 585,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -51712,7 +52054,7 @@
       "source_location": "L3"
     },
     {
-      "community": 583,
+      "community": 586,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -51721,7 +52063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 586,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -51730,7 +52072,7 @@
       "source_location": "L7"
     },
     {
-      "community": 584,
+      "community": 587,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -51739,7 +52081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 587,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -51748,7 +52090,7 @@
       "source_location": "L4"
     },
     {
-      "community": 585,
+      "community": 588,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -51757,7 +52099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 588,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -51766,7 +52108,7 @@
       "source_location": "L14"
     },
     {
-      "community": 586,
+      "community": 589,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -51775,66 +52117,12 @@
       "source_location": "L4"
     },
     {
-      "community": 586,
+      "community": 589,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
       "norm_label": "analytics.ts",
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "bag_usebagqueries",
-      "label": "useBagQueries()",
-      "norm_label": "usebagqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "bannermessage_usebannermessagequeries",
-      "label": "useBannerMessageQueries()",
-      "norm_label": "usebannermessagequeries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "checkout_usecheckoutsessionqueries",
-      "label": "useCheckoutSessionQueries()",
-      "norm_label": "usecheckoutsessionqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
-      "label": "checkout.ts",
-      "norm_label": "checkout.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
       "source_location": "L1"
     },
     {
@@ -51903,6 +52191,60 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "bag_usebagqueries",
+      "label": "useBagQueries()",
+      "norm_label": "usebagqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "bannermessage_usebannermessagequeries",
+      "label": "useBannerMessageQueries()",
+      "norm_label": "usebannermessagequeries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
+      "id": "checkout_usecheckoutsessionqueries",
+      "label": "useCheckoutSessionQueries()",
+      "norm_label": "usecheckoutsessionqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
+      "label": "checkout.ts",
+      "norm_label": "checkout.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 593,
+      "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
       "norm_label": "useinventoryqueries()",
@@ -51910,7 +52252,7 @@
       "source_location": "L6"
     },
     {
-      "community": 590,
+      "community": 593,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -51919,7 +52261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 594,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -51928,7 +52270,7 @@
       "source_location": "L5"
     },
     {
-      "community": 591,
+      "community": 594,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -51937,7 +52279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 595,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -51946,7 +52288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 595,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -51955,7 +52297,7 @@
       "source_location": "L14"
     },
     {
-      "community": 593,
+      "community": 596,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -51964,7 +52306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 596,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -51973,7 +52315,7 @@
       "source_location": "L9"
     },
     {
-      "community": 594,
+      "community": 597,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -51982,7 +52324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 597,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -51991,7 +52333,7 @@
       "source_location": "L10"
     },
     {
-      "community": 595,
+      "community": 598,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -52000,7 +52342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 598,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -52009,7 +52351,7 @@
       "source_location": "L11"
     },
     {
-      "community": 596,
+      "community": 599,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -52018,67 +52360,13 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 599,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
       "norm_label": "useupsellsqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 597,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 597,
-      "file_type": "code",
-      "id": "user_useuserqueries",
-      "label": "useUserQueries()",
-      "norm_label": "useuserqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "useroffers_useuseroffersqueries",
-      "label": "useUserOffersQueries()",
-      "norm_label": "useuseroffersqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
-      "label": "storeConfig.test.ts",
-      "norm_label": "storeconfig.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "storeconfig_test_buildv2config",
-      "label": "buildV2Config()",
-      "norm_label": "buildv2config()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L10"
     },
     {
       "community": 6,
@@ -52380,6 +52668,60 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "user_useuserqueries",
+      "label": "useUserQueries()",
+      "norm_label": "useuserqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "useroffers_useuseroffersqueries",
+      "label": "useUserOffersQueries()",
+      "norm_label": "useuseroffersqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
+      "label": "storeConfig.test.ts",
+      "norm_label": "storeconfig.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "storeconfig_test_buildv2config",
+      "label": "buildV2Config()",
+      "norm_label": "buildv2config()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 603,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
       "norm_label": "storefrontobservability.test.ts",
@@ -52387,7 +52729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 603,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -52396,7 +52738,7 @@
       "source_location": "L15"
     },
     {
-      "community": 601,
+      "community": 604,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -52405,7 +52747,7 @@
       "source_location": "L14"
     },
     {
-      "community": 601,
+      "community": 604,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -52414,7 +52756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 605,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -52423,7 +52765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 605,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -52432,7 +52774,7 @@
       "source_location": "L5"
     },
     {
-      "community": 603,
+      "community": 606,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -52441,7 +52783,7 @@
       "source_location": "L13"
     },
     {
-      "community": 603,
+      "community": 606,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -52450,7 +52792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 607,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -52459,7 +52801,7 @@
       "source_location": "L8"
     },
     {
-      "community": 604,
+      "community": 607,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -52468,7 +52810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 608,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -52477,7 +52819,7 @@
       "source_location": "L14"
     },
     {
-      "community": 605,
+      "community": 608,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -52486,7 +52828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 609,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -52495,67 +52837,13 @@
       "source_location": "L13"
     },
     {
-      "community": 606,
+      "community": 609,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
       "norm_label": "delivery-returns-exchanges.index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
-      "label": "privacy.index.tsx",
-      "norm_label": "privacy.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "privacy_index_privacypolicy",
-      "label": "PrivacyPolicy()",
-      "norm_label": "privacypolicy()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
-      "label": "tos.index.tsx",
-      "norm_label": "tos.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "tos_index_tossection",
-      "label": "TosSection()",
-      "norm_label": "tossection()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
-      "label": "shop.product.$productSlug.tsx",
-      "norm_label": "shop.product.$productslug.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "shop_product_productslug_component",
-      "label": "Component()",
-      "norm_label": "component()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
-      "source_location": "L16"
     },
     {
       "community": 61,
@@ -52623,6 +52911,60 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
+      "label": "privacy.index.tsx",
+      "norm_label": "privacy.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "privacy_index_privacypolicy",
+      "label": "PrivacyPolicy()",
+      "norm_label": "privacypolicy()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
+      "label": "tos.index.tsx",
+      "norm_label": "tos.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "tos_index_tossection",
+      "label": "TosSection()",
+      "norm_label": "tossection()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
+      "label": "shop.product.$productSlug.tsx",
+      "norm_label": "shop.product.$productslug.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "shop_product_productslug_component",
+      "label": "Component()",
+      "norm_label": "component()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 613,
+      "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
       "norm_label": "layoutcomponent()",
@@ -52630,7 +52972,7 @@
       "source_location": "L6"
     },
     {
-      "community": 610,
+      "community": 613,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -52639,7 +52981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 614,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -52648,7 +52990,7 @@
       "source_location": "L10"
     },
     {
-      "community": 611,
+      "community": 614,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -52657,7 +52999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 615,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -52666,7 +53008,7 @@
       "source_location": "L21"
     },
     {
-      "community": 612,
+      "community": 615,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -52675,7 +53017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 616,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -52684,7 +53026,7 @@
       "source_location": "L33"
     },
     {
-      "community": 613,
+      "community": 616,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -52693,7 +53035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 617,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -52702,7 +53044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 617,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -52711,7 +53053,7 @@
       "source_location": "L193"
     },
     {
-      "community": 615,
+      "community": 618,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -52720,7 +53062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 618,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -52729,7 +53071,7 @@
       "source_location": "L7"
     },
     {
-      "community": 616,
+      "community": 619,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -52738,66 +53080,12 @@
       "source_location": "L10"
     },
     {
-      "community": 616,
+      "community": 619,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
       "norm_label": "architecture-boundaries.test.ts",
       "source_file": "scripts/architecture-boundaries.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 617,
-      "file_type": "code",
-      "id": "architecture_boundary_check_run",
-      "label": "run()",
-      "norm_label": "run()",
-      "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 617,
-      "file_type": "code",
-      "id": "scripts_architecture_boundary_check_ts",
-      "label": "architecture-boundary-check.ts",
-      "norm_label": "architecture-boundary-check.ts",
-      "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "athena_runtime_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
-      "label": "athena-runtime-app.ts",
-      "norm_label": "athena-runtime-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "sample_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_sample_app_ts",
-      "label": "sample-app.ts",
-      "norm_label": "sample-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
       "source_location": "L1"
     },
     {
@@ -52866,6 +53154,60 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "architecture_boundary_check_run",
+      "label": "run()",
+      "norm_label": "run()",
+      "source_file": "scripts/architecture-boundary-check.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "scripts_architecture_boundary_check_ts",
+      "label": "architecture-boundary-check.ts",
+      "norm_label": "architecture-boundary-check.ts",
+      "source_file": "scripts/architecture-boundary-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "athena_runtime_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
+      "label": "athena-runtime-app.ts",
+      "norm_label": "athena-runtime-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
+      "id": "sample_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_sample_app_ts",
+      "label": "sample-app.ts",
+      "norm_label": "sample-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 623,
+      "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
       "norm_label": "buildreportline()",
@@ -52873,7 +53215,7 @@
       "source_location": "L15"
     },
     {
-      "community": 620,
+      "community": 623,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -52882,7 +53224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -52891,7 +53233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -52900,7 +53242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -52909,7 +53251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -52918,7 +53260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -52927,39 +53269,12 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
       "norm_label": "app.ts",
       "source_file": "packages/athena-webapp/convex/app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 627,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_auth_config_js",
-      "label": "auth.config.js",
-      "norm_label": "auth.config.js",
-      "source_file": "packages/athena-webapp/convex/auth.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
       "source_location": "L1"
     },
     {
@@ -53028,6 +53343,33 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_auth_config_js",
+      "label": "auth.config.js",
+      "norm_label": "auth.config.js",
+      "source_file": "packages/athena-webapp/convex/auth.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 633,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
       "norm_label": "email.ts",
@@ -53035,7 +53377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -53044,7 +53386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -53053,7 +53395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -53062,7 +53404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -53071,7 +53413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -53080,39 +53422,12 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
       "norm_label": "orderemail.tsx",
       "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 637,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
-      "label": "PosReceiptEmail.tsx",
-      "norm_label": "posreceiptemail.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_env_ts",
-      "label": "env.ts",
-      "norm_label": "env.ts",
-      "source_file": "packages/athena-webapp/convex/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
       "source_location": "L1"
     },
     {
@@ -53181,6 +53496,33 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
+      "label": "PosReceiptEmail.tsx",
+      "norm_label": "posreceiptemail.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_env_ts",
+      "label": "env.ts",
+      "norm_label": "env.ts",
+      "source_file": "packages/athena-webapp/convex/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 643,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
@@ -53188,7 +53530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -53197,7 +53539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -53206,7 +53548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -53215,7 +53557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -53224,7 +53566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
@@ -53233,7 +53575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
@@ -53242,187 +53584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
-      "label": "subcategories.ts",
-      "norm_label": "subcategories.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
       "community": 65,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 650,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 651,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 652,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 653,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
-      "label": "me.ts",
-      "norm_label": "me.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/me.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 654,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/offers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 656,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
-      "label": "paystack.ts",
-      "norm_label": "paystack.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 66,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
       "label": "reference-fixtures.tsx",
@@ -53431,7 +53593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 66,
+      "community": 65,
       "file_type": "code",
       "id": "reference_fixtures_compacttable",
       "label": "CompactTable()",
@@ -53440,7 +53602,7 @@
       "source_location": "L263"
     },
     {
-      "community": 66,
+      "community": 65,
       "file_type": "code",
       "id": "reference_fixtures_framecard",
       "label": "FrameCard()",
@@ -53449,7 +53611,7 @@
       "source_location": "L163"
     },
     {
-      "community": 66,
+      "community": 65,
       "file_type": "code",
       "id": "reference_fixtures_lanecard",
       "label": "LaneCard()",
@@ -53458,7 +53620,7 @@
       "source_location": "L213"
     },
     {
-      "community": 66,
+      "community": 65,
       "file_type": "code",
       "id": "reference_fixtures_metrictile",
       "label": "MetricTile()",
@@ -53467,7 +53629,7 @@
       "source_location": "L194"
     },
     {
-      "community": 66,
+      "community": 65,
       "file_type": "code",
       "id": "reference_fixtures_minitrendchart",
       "label": "MiniTrendChart()",
@@ -53476,7 +53638,7 @@
       "source_location": "L240"
     },
     {
-      "community": 66,
+      "community": 65,
       "file_type": "code",
       "id": "reference_fixtures_referencepageshell",
       "label": "ReferencePageShell()",
@@ -53485,97 +53647,97 @@
       "source_location": "L145"
     },
     {
-      "community": 660,
+      "community": 650,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
-      "label": "security.test.ts",
-      "norm_label": "security.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 651,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
-      "label": "storefront.ts",
-      "norm_label": "storefront.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/storefront.ts",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
+      "label": "subcategories.ts",
+      "norm_label": "subcategories.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 652,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/upsells.ts",
+      "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/index.ts",
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 653,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/user.ts",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 654,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/userOffers.ts",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/guest.ts",
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 655,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_health_test_ts",
-      "label": "health.test.ts",
-      "norm_label": "health.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/health.test.ts",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts",
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 656,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_ts",
-      "label": "http.ts",
-      "norm_label": "http.ts",
-      "source_file": "packages/athena-webapp/convex/http.ts",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
+      "label": "me.ts",
+      "norm_label": "me.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/me.ts",
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 657,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
-      "label": "athenaUser.ts",
-      "norm_label": "athenauser.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/offers.ts",
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 658,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts",
       "source_location": "L1"
     },
     {
-      "community": 669,
+      "community": 659,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
+      "label": "paystack.ts",
+      "norm_label": "paystack.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
       "source_location": "L1"
     },
     {
-      "community": 67,
+      "community": 66,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
       "label": "savedBag.ts",
@@ -53584,7 +53746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 67,
+      "community": 66,
       "file_type": "code",
       "id": "savedbag_additemtosavedbag",
       "label": "addItemToSavedBag()",
@@ -53593,7 +53755,7 @@
       "source_location": "L25"
     },
     {
-      "community": 67,
+      "community": 66,
       "file_type": "code",
       "id": "savedbag_getactivesavedbag",
       "label": "getActiveSavedBag()",
@@ -53602,7 +53764,7 @@
       "source_location": "L10"
     },
     {
-      "community": 67,
+      "community": 66,
       "file_type": "code",
       "id": "savedbag_getbaseurl",
       "label": "getBaseUrl()",
@@ -53611,7 +53773,7 @@
       "source_location": "L8"
     },
     {
-      "community": 67,
+      "community": 66,
       "file_type": "code",
       "id": "savedbag_removeitemfromsavedbag",
       "label": "removeItemFromSavedBag()",
@@ -53620,7 +53782,7 @@
       "source_location": "L91"
     },
     {
-      "community": 67,
+      "community": 66,
       "file_type": "code",
       "id": "savedbag_updatesavedbagitem",
       "label": "updateSavedBagItem()",
@@ -53629,7 +53791,7 @@
       "source_location": "L61"
     },
     {
-      "community": 67,
+      "community": 66,
       "file_type": "code",
       "id": "savedbag_updatesavedbagowner",
       "label": "updateSavedBagOwner()",
@@ -53638,7 +53800,187 @@
       "source_location": "L109"
     },
     {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 663,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
+      "label": "security.test.ts",
+      "norm_label": "security.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 664,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
+      "label": "storefront.ts",
+      "norm_label": "storefront.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/storefront.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 665,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/upsells.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 666,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 667,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/userOffers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 668,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_health_test_ts",
+      "label": "health.test.ts",
+      "norm_label": "health.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/health.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 669,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_ts",
+      "label": "http.ts",
+      "norm_label": "http.ts",
+      "source_file": "packages/athena-webapp/convex/http.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
+    },
+    {
       "community": 670,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
+      "label": "athenaUser.ts",
+      "norm_label": "athenauser.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -53647,7 +53989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -53656,7 +53998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -53665,7 +54007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -53674,7 +54016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -53683,7 +54025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -53692,39 +54034,12 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
       "norm_label": "featureditem.ts",
       "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 677,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
-      "label": "inviteCode.ts",
-      "norm_label": "invitecode.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
-      "label": "organizationMembers.ts",
-      "norm_label": "organizationmembers.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_organizations_ts",
-      "label": "organizations.ts",
-      "norm_label": "organizations.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
       "source_location": "L1"
     },
     {
@@ -53793,6 +54108,33 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
+      "label": "inviteCode.ts",
+      "norm_label": "invitecode.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
+      "label": "organizationMembers.ts",
+      "norm_label": "organizationmembers.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_organizations_ts",
+      "label": "organizations.ts",
+      "norm_label": "organizations.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 683,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
       "norm_label": "poscustomers.ts",
@@ -53800,7 +54142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -53809,7 +54151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -53818,7 +54160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -53827,7 +54169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 687,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -53836,7 +54178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 688,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -53845,39 +54187,12 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 689,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
       "norm_label": "stockvalidation.ts",
       "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 687,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
-      "label": "storeConfigV2.test.ts",
-      "norm_label": "storeconfigv2.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
-      "label": "subcategories.ts",
-      "norm_label": "subcategories.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/subcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_test_ts",
-      "label": "currency.test.ts",
-      "norm_label": "currency.test.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
       "source_location": "L1"
     },
     {
@@ -53946,6 +54261,33 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
+      "label": "storeConfigV2.test.ts",
+      "norm_label": "storeconfigv2.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
+      "label": "subcategories.ts",
+      "norm_label": "subcategories.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/subcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_test_ts",
+      "label": "currency.test.ts",
+      "norm_label": "currency.test.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 693,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
       "norm_label": "storeinsights.ts",
@@ -53953,7 +54295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 694,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -53962,7 +54304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -53971,7 +54313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -53980,7 +54322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -53989,7 +54331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -53998,39 +54340,12 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/athena-webapp/convex/mtn/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 697,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
-      "label": "approvalRequests.test.ts",
-      "norm_label": "approvalrequests.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
-      "label": "customerProfiles.test.ts",
-      "norm_label": "customerprofiles.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
-      "label": "inventoryMovements.test.ts",
-      "norm_label": "inventorymovements.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.test.ts",
       "source_location": "L1"
     },
     {
@@ -54324,6 +54639,33 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
+      "label": "approvalRequests.test.ts",
+      "norm_label": "approvalrequests.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
+      "label": "customerProfiles.test.ts",
+      "norm_label": "customerprofiles.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
+      "label": "inventoryMovements.test.ts",
+      "norm_label": "inventorymovements.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 703,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
       "norm_label": "paymentallocations.test.ts",
@@ -54331,7 +54673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -54340,7 +54682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_resendotp_ts",
       "label": "ResendOTP.ts",
@@ -54349,7 +54691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -54358,7 +54700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -54367,7 +54709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -54376,39 +54718,12 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 707,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
-      "label": "bestSeller.ts",
-      "norm_label": "bestseller.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
-      "label": "cashier.ts",
-      "norm_label": "cashier.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/cashier.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
       "source_location": "L1"
     },
     {
@@ -54468,6 +54783,33 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
+      "label": "bestSeller.ts",
+      "norm_label": "bestseller.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
+      "label": "cashier.ts",
+      "norm_label": "cashier.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/cashier.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 713,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
       "norm_label": "color.ts",
@@ -54475,7 +54817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 714,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -54484,7 +54826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 715,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -54493,7 +54835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 716,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -54502,7 +54844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 717,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -54511,7 +54853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 718,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -54520,39 +54862,12 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 719,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
       "norm_label": "organizationmember.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/organizationMember.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 717,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
-      "label": "promoCode.ts",
-      "norm_label": "promocode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
-      "label": "redeemedPromoCode.ts",
-      "norm_label": "redeemedpromocode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
       "source_location": "L1"
     },
     {
@@ -54612,6 +54927,33 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
+      "label": "promoCode.ts",
+      "norm_label": "promocode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
+      "label": "redeemedPromoCode.ts",
+      "norm_label": "redeemedpromocode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 723,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
@@ -54619,7 +54961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 724,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -54628,7 +54970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 725,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -54637,7 +54979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -54646,7 +54988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -54655,7 +54997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -54664,39 +55006,12 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
       "norm_label": "operationalevent.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/operationalEvent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 727,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
-      "label": "operationalWorkItem.ts",
-      "norm_label": "operationalworkitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalWorkItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
-      "label": "paymentAllocation.ts",
-      "norm_label": "paymentallocation.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/paymentAllocation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
-      "label": "registerSession.ts",
-      "norm_label": "registersession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/registerSession.ts",
       "source_location": "L1"
     },
     {
@@ -54756,6 +55071,33 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
+      "label": "operationalWorkItem.ts",
+      "norm_label": "operationalworkitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalWorkItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
+      "label": "paymentAllocation.ts",
+      "norm_label": "paymentallocation.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/paymentAllocation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 732,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
+      "label": "registerSession.ts",
+      "norm_label": "registersession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/registerSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 733,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
       "norm_label": "staffprofile.ts",
@@ -54763,7 +55105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -54772,7 +55114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -54781,7 +55123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -54790,7 +55132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -54799,7 +55141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -54808,39 +55150,12 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
       "norm_label": "expensetransaction.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 737,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
-      "label": "expenseTransactionItem.ts",
-      "norm_label": "expensetransactionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransactionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
-      "label": "posSession.ts",
-      "norm_label": "possession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
       "source_location": "L1"
     },
     {
@@ -54900,6 +55215,33 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
+      "label": "expenseTransactionItem.ts",
+      "norm_label": "expensetransactionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransactionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 742,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
+      "label": "posSession.ts",
+      "norm_label": "possession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 743,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
       "norm_label": "possessionitem.ts",
@@ -54907,7 +55249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -54916,7 +55258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -54925,7 +55267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -54934,7 +55276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -54943,7 +55285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -54952,7 +55294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -54961,7 +55303,61 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 75,
+      "file_type": "code",
+      "id": "onlineorder_appendtransition",
+      "label": "appendTransition()",
+      "norm_label": "appendtransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "onlineorder_applyonlineorderupdate",
+      "label": "applyOnlineOrderUpdate()",
+      "norm_label": "applyonlineorderupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereplacementsourceid",
+      "label": "buildReturnExchangeReplacementSourceId()",
+      "norm_label": "buildreturnexchangereplacementsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L202"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereturnsourceid",
+      "label": "buildReturnExchangeReturnSourceId()",
+      "norm_label": "buildreturnexchangereturnsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L210"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "onlineorder_listorderitems",
+      "label": "listOrderItems()",
+      "norm_label": "listorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 750,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -54970,7 +55366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 751,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -54979,7 +55375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 749,
+      "community": 752,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -54988,61 +55384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 75,
-      "file_type": "code",
-      "id": "data_table_toolbar_datatabletoolbar",
-      "label": "DataTableToolbar()",
-      "norm_label": "datatabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 750,
+      "community": 753,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -55051,7 +55393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -55060,7 +55402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -55069,7 +55411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -55078,7 +55420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -55087,7 +55429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
       "label": "customer.ts",
@@ -55096,7 +55438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -55105,7 +55447,61 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 76,
+      "file_type": "code",
+      "id": "data_table_toolbar_datatabletoolbar",
+      "label": "DataTableToolbar()",
+      "norm_label": "datatabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 760,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -55114,7 +55510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 761,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -55123,7 +55519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 759,
+      "community": 762,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -55132,61 +55528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 760,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -55195,7 +55537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -55204,7 +55546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -55213,7 +55555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -55222,7 +55564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -55231,7 +55573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -55240,7 +55582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -55249,7 +55591,61 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 770,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -55258,7 +55654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 771,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -55267,7 +55663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 769,
+      "community": 772,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -55276,61 +55672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 77,
-      "file_type": "code",
-      "id": "cashiermanagement_buildusername",
-      "label": "buildUsername()",
-      "norm_label": "buildusername()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "cashiermanagement_handledelete",
-      "label": "handleDelete()",
-      "norm_label": "handledelete()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L320"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "cashiermanagement_handlepinkeydown",
-      "label": "handlePinKeyDown()",
-      "norm_label": "handlepinkeydown()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L169"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "cashiermanagement_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L109"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "cashiermanagement_normalizenamesegment",
-      "label": "normalizeNameSegment()",
-      "norm_label": "normalizenamesegment()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cashiers_cashiermanagement_tsx",
-      "label": "CashierManagement.tsx",
-      "norm_label": "cashiermanagement.tsx",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 770,
+      "community": 773,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -55339,7 +55681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -55348,7 +55690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -55357,7 +55699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -55366,7 +55708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -55375,7 +55717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -55384,7 +55726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -55393,7 +55735,61 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 78,
+      "file_type": "code",
+      "id": "cashiermanagement_buildusername",
+      "label": "buildUsername()",
+      "norm_label": "buildusername()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "cashiermanagement_handledelete",
+      "label": "handleDelete()",
+      "norm_label": "handledelete()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L320"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "cashiermanagement_handlepinkeydown",
+      "label": "handlePinKeyDown()",
+      "norm_label": "handlepinkeydown()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L169"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "cashiermanagement_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L109"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "cashiermanagement_normalizenamesegment",
+      "label": "normalizeNameSegment()",
+      "norm_label": "normalizenamesegment()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cashiers_cashiermanagement_tsx",
+      "label": "CashierManagement.tsx",
+      "norm_label": "cashiermanagement.tsx",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 780,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -55402,7 +55798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 781,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -55411,7 +55807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 779,
+      "community": 782,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -55420,61 +55816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 78,
-      "file_type": "code",
-      "id": "bannermessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L123"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleactivetoggle",
-      "label": "handleActiveToggle()",
-      "norm_label": "handleactivetoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleclear",
-      "label": "handleClear()",
-      "norm_label": "handleclear()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L113"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "label": "BannerMessageEditor.tsx",
-      "norm_label": "bannermessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 780,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -55483,7 +55825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -55492,7 +55834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -55501,7 +55843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -55510,7 +55852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -55519,7 +55861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -55528,7 +55870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -55537,7 +55879,61 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 79,
+      "file_type": "code",
+      "id": "bannermessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L123"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleactivetoggle",
+      "label": "handleActiveToggle()",
+      "norm_label": "handleactivetoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L113"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
+      "label": "BannerMessageEditor.tsx",
+      "norm_label": "bannermessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 790,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -55546,7 +55942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 791,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -55555,7 +55951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 789,
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -55564,61 +55960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 79,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
-      "label": "PaymentsAddedList.tsx",
-      "norm_label": "paymentsaddedlist.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "label": "getPaymentMethodLabel()",
-      "norm_label": "getpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handleremovepayment",
-      "label": "handleRemovePayment()",
-      "norm_label": "handleremovepayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handlestartedit",
-      "label": "handleStartEdit()",
-      "norm_label": "handlestartedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L59"
-    },
-    {
-      "community": 790,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -55627,7 +55969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -55636,7 +55978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -55645,7 +55987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -55654,7 +55996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -55663,7 +56005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -55672,39 +56014,12 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/athena-webapp/src/components/add-product/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 797,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
-      "label": "ConversionFunnelChart.tsx",
-      "norm_label": "conversionfunnelchart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
-      "label": "RevenueChart.tsx",
-      "norm_label": "revenuechart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
-      "label": "analytics-columns.tsx",
-      "norm_label": "analytics-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
       "source_location": "L1"
     },
     {
@@ -55908,59 +56223,86 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "label": "ReviewsView.tsx",
-      "norm_label": "reviewsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
+      "label": "PaymentsAddedList.tsx",
+      "norm_label": "paymentsaddedlist.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L1"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "reviewsview_handleapprove",
-      "label": "handleApprove()",
-      "norm_label": "handleapprove()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L42"
+      "id": "paymentsaddedlist_getpaymentmethodlabel",
+      "label": "getPaymentMethodLabel()",
+      "norm_label": "getpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L20"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "reviewsview_handlepublish",
-      "label": "handlePublish()",
-      "norm_label": "handlepublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L74"
+      "id": "paymentsaddedlist_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L95"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "reviewsview_handlereject",
-      "label": "handleReject()",
-      "norm_label": "handlereject()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L58"
+      "id": "paymentsaddedlist_handleremovepayment",
+      "label": "handleRemovePayment()",
+      "norm_label": "handleremovepayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L100"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "reviewsview_handleunpublish",
-      "label": "handleUnpublish()",
-      "norm_label": "handleunpublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L90"
+      "id": "paymentsaddedlist_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L64"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "reviewsview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L13"
+      "id": "paymentsaddedlist_handlestartedit",
+      "label": "handleStartEdit()",
+      "norm_label": "handlestartedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L59"
     },
     {
       "community": 800,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
+      "label": "ConversionFunnelChart.tsx",
+      "norm_label": "conversionfunnelchart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
+      "label": "RevenueChart.tsx",
+      "norm_label": "revenuechart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 802,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
+      "label": "analytics-columns.tsx",
+      "norm_label": "analytics-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -55969,7 +56311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -55978,7 +56320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -55987,7 +56329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -55996,7 +56338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56005,7 +56347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -56014,7 +56356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56023,7 +56365,61 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 81,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
+      "label": "ReviewsView.tsx",
+      "norm_label": "reviewsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "reviewsview_handleapprove",
+      "label": "handleApprove()",
+      "norm_label": "handleapprove()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "reviewsview_handlepublish",
+      "label": "handlePublish()",
+      "norm_label": "handlepublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "reviewsview_handlereject",
+      "label": "handleReject()",
+      "norm_label": "handlereject()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "reviewsview_handleunpublish",
+      "label": "handleUnpublish()",
+      "norm_label": "handleunpublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "reviewsview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 810,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56032,7 +56428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 811,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -56041,7 +56437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 809,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56050,61 +56446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 81,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 810,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -56113,7 +56455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56122,7 +56464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56131,7 +56473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -56140,7 +56482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -56149,7 +56491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56158,7 +56500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56167,7 +56509,61 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 82,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 820,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -56176,7 +56572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 821,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -56185,7 +56581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 819,
+      "community": 822,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56194,61 +56590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 82,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 820,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56257,7 +56599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56266,7 +56608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -56275,7 +56617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -56284,7 +56626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56293,7 +56635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56302,7 +56644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -56311,7 +56653,61 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 83,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 830,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -56320,7 +56716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 831,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56329,7 +56725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 829,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56338,61 +56734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 83,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 830,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -56401,7 +56743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56410,7 +56752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -56419,7 +56761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -56428,7 +56770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -56437,7 +56779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56446,7 +56788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56455,7 +56797,61 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 84,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 840,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56464,7 +56860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 841,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -56473,7 +56869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 839,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -56482,61 +56878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 84,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
-      "label": "usePOSCustomers.ts",
-      "norm_label": "useposcustomers.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomer",
-      "label": "usePOSCustomer()",
-      "norm_label": "useposcustomer()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomercreate",
-      "label": "usePOSCustomerCreate()",
-      "norm_label": "useposcustomercreate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomersearch",
-      "label": "usePOSCustomerSearch()",
-      "norm_label": "useposcustomersearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomertransactions",
-      "label": "usePOSCustomerTransactions()",
-      "norm_label": "useposcustomertransactions()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomerupdate",
-      "label": "usePOSCustomerUpdate()",
-      "norm_label": "useposcustomerupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 840,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -56545,7 +56887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -56554,7 +56896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -56563,7 +56905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56572,7 +56914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56581,7 +56923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -56590,7 +56932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56599,7 +56941,61 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 85,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 850,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -56608,7 +57004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 851,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -56617,7 +57013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 849,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56626,61 +57022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 85,
-      "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 850,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56689,7 +57031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56698,7 +57040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -56707,7 +57049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
       "label": "index.tsx",
@@ -56716,7 +57058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -56725,7 +57067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56734,7 +57076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56743,7 +57085,61 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 86,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
+      "label": "usePOSCustomers.ts",
+      "norm_label": "useposcustomers.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomer",
+      "label": "usePOSCustomer()",
+      "norm_label": "useposcustomer()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomercreate",
+      "label": "usePOSCustomerCreate()",
+      "norm_label": "useposcustomercreate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomersearch",
+      "label": "usePOSCustomerSearch()",
+      "norm_label": "useposcustomersearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomertransactions",
+      "label": "usePOSCustomerTransactions()",
+      "norm_label": "useposcustomertransactions()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomerupdate",
+      "label": "usePOSCustomerUpdate()",
+      "norm_label": "useposcustomerupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 860,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -56752,7 +57148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 861,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -56761,7 +57157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 859,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -56770,61 +57166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 86,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
-    },
-    {
-      "community": 860,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -56833,7 +57175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -56842,7 +57184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -56851,7 +57193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -56860,7 +57202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -56869,7 +57211,16 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 868,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
+      "label": "ReturnExchangeView.test.tsx",
+      "norm_label": "returnexchangeview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -56878,7 +57229,61 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 87,
+      "file_type": "code",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 870,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56887,7 +57292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 871,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56896,7 +57301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -56905,7 +57310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 869,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -56914,61 +57319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 87,
-      "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L198"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L71"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 870,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -56977,7 +57328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -56986,7 +57337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56995,7 +57346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -57004,7 +57355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -57013,7 +57364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -57022,7 +57373,61 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 88,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 880,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -57031,7 +57436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 881,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -57040,7 +57445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -57049,7 +57454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 879,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -57058,61 +57463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 88,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L232"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "storesettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 880,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -57121,7 +57472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -57130,7 +57481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -57139,7 +57490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -57148,7 +57499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -57157,7 +57508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -57166,7 +57517,61 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 89,
+      "file_type": "code",
+      "id": "organizationsettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L198"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L71"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 890,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -57175,7 +57580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 891,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -57184,7 +57589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -57193,7 +57598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 889,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -57202,61 +57607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 89,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 890,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -57265,7 +57616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -57274,7 +57625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -57283,7 +57634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
@@ -57292,7 +57643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -57301,48 +57652,12 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
       "norm_label": "analyticsinsights.tsx",
       "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 896,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
-      "label": "AttributesView.tsx",
-      "norm_label": "attributesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 897,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
-      "label": "DetailsView.tsx",
-      "norm_label": "detailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
-      "label": "ProductDetailView.tsx",
-      "norm_label": "productdetailview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
-      "label": "ProductStatus.tsx",
-      "norm_label": "productstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
       "source_location": "L1"
     },
     {
@@ -57537,59 +57852,95 @@
     {
       "community": 90,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L232"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L82"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L28"
     },
     {
       "community": 900,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
+      "label": "AttributesView.tsx",
+      "norm_label": "attributesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
+      "label": "DetailsView.tsx",
+      "norm_label": "detailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 902,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
+      "label": "ProductDetailView.tsx",
+      "norm_label": "productdetailview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 903,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
+      "label": "ProductStatus.tsx",
+      "norm_label": "productstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -57598,7 +57949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -57607,7 +57958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -57616,7 +57967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -57625,7 +57976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -57634,7 +57985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -57643,7 +57994,61 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 91,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 910,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -57652,7 +58057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 911,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -57661,7 +58066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -57670,7 +58075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 909,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -57679,61 +58084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 91,
-      "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 910,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -57742,7 +58093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -57751,7 +58102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -57760,7 +58111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -57769,7 +58120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -57778,7 +58129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -57787,7 +58138,61 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 92,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 920,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -57796,7 +58201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 921,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -57805,7 +58210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -57814,7 +58219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 919,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -57823,61 +58228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 92,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 920,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -57886,7 +58237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -57895,7 +58246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -57904,7 +58255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -57913,7 +58264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -57922,7 +58273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -57931,7 +58282,61 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 93,
+      "file_type": "code",
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 930,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -57940,7 +58345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 931,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -57949,7 +58354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -57958,7 +58363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 929,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -57967,61 +58372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 93,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 930,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -58030,7 +58381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -58039,7 +58390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -58048,7 +58399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -58057,7 +58408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -58066,7 +58417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -58075,7 +58426,61 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 94,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 940,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -58084,7 +58489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 941,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -58093,7 +58498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -58102,7 +58507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 939,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -58111,61 +58516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 94,
-      "file_type": "code",
-      "id": "feeutils_getremainingforfreedelivery",
-      "label": "getRemainingForFreeDelivery()",
-      "norm_label": "getremainingforfreedelivery()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "feeutils_haswaiverconfigured",
-      "label": "hasWaiverConfigured()",
-      "norm_label": "haswaiverconfigured()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "feeutils_isanyfeewaived",
-      "label": "isAnyFeeWaived()",
-      "norm_label": "isanyfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "feeutils_isfeewaived",
-      "label": "isFeeWaived()",
-      "norm_label": "isfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "feeutils_meetsthreshold",
-      "label": "meetsThreshold()",
-      "norm_label": "meetsthreshold()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
-      "label": "feeUtils.ts",
-      "norm_label": "feeutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 940,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -58174,7 +58525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -58183,7 +58534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -58192,7 +58543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -58201,7 +58552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -58210,7 +58561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -58219,7 +58570,61 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 95,
+      "file_type": "code",
+      "id": "feeutils_getremainingforfreedelivery",
+      "label": "getRemainingForFreeDelivery()",
+      "norm_label": "getremainingforfreedelivery()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "feeutils_haswaiverconfigured",
+      "label": "hasWaiverConfigured()",
+      "norm_label": "haswaiverconfigured()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "feeutils_isanyfeewaived",
+      "label": "isAnyFeeWaived()",
+      "norm_label": "isanyfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "feeutils_isfeewaived",
+      "label": "isFeeWaived()",
+      "norm_label": "isfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "feeutils_meetsthreshold",
+      "label": "meetsThreshold()",
+      "norm_label": "meetsthreshold()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
+      "label": "feeUtils.ts",
+      "norm_label": "feeutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 950,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -58228,7 +58633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 951,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -58237,7 +58642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -58246,7 +58651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 949,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -58255,61 +58660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 95,
-      "file_type": "code",
-      "id": "auth_verify_formattime",
-      "label": "formatTime()",
-      "norm_label": "formattime()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L149"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "auth_verify_handlecodechange",
-      "label": "handleCodeChange()",
-      "norm_label": "handlecodechange()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "auth_verify_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "auth_verify_reportauthfailure",
-      "label": "reportAuthFailure()",
-      "norm_label": "reportauthfailure()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "auth_verify_resendverificationcode",
-      "label": "resendVerificationCode()",
-      "norm_label": "resendverificationcode()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L282"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
-      "label": "auth.verify.tsx",
-      "norm_label": "auth.verify.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 950,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -58318,7 +58669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -58327,7 +58678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -58336,7 +58687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -58345,7 +58696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -58354,7 +58705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -58363,7 +58714,61 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 96,
+      "file_type": "code",
+      "id": "auth_verify_formattime",
+      "label": "formatTime()",
+      "norm_label": "formattime()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L149"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "auth_verify_handlecodechange",
+      "label": "handleCodeChange()",
+      "norm_label": "handlecodechange()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "auth_verify_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "auth_verify_reportauthfailure",
+      "label": "reportAuthFailure()",
+      "norm_label": "reportauthfailure()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L93"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "auth_verify_resendverificationcode",
+      "label": "resendVerificationCode()",
+      "norm_label": "resendverificationcode()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L282"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
+      "label": "auth.verify.tsx",
+      "norm_label": "auth.verify.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 960,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -58372,7 +58777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 961,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -58381,7 +58786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -58390,7 +58795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 959,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -58399,61 +58804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 96,
-      "file_type": "code",
-      "id": "graphify_check_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "graphify_check_collectstalegraphifyartifacts",
-      "label": "collectStaleGraphifyArtifacts()",
-      "norm_label": "collectstalegraphifyartifacts()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "graphify_check_copygraphifycheckinputs",
-      "label": "copyGraphifyCheckInputs()",
-      "norm_label": "copygraphifycheckinputs()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "graphify_check_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "graphify_check_rungraphifycheck",
-      "label": "runGraphifyCheck()",
-      "norm_label": "rungraphifycheck()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "scripts_graphify_check_ts",
-      "label": "graphify-check.ts",
-      "norm_label": "graphify-check.ts",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 960,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -58462,7 +58813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -58471,7 +58822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -58480,7 +58831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -58489,7 +58840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -58498,7 +58849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -58507,7 +58858,61 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 97,
+      "file_type": "code",
+      "id": "graphify_check_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "graphify_check_collectstalegraphifyartifacts",
+      "label": "collectStaleGraphifyArtifacts()",
+      "norm_label": "collectstalegraphifyartifacts()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "graphify_check_copygraphifycheckinputs",
+      "label": "copyGraphifyCheckInputs()",
+      "norm_label": "copygraphifycheckinputs()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "graphify_check_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "graphify_check_rungraphifycheck",
+      "label": "runGraphifyCheck()",
+      "norm_label": "rungraphifycheck()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "scripts_graphify_check_ts",
+      "label": "graphify-check.ts",
+      "norm_label": "graphify-check.ts",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 970,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -58516,7 +58921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 971,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -58525,7 +58930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -58534,7 +58939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 969,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -58543,61 +58948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 97,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
-      "label": "buildAthenaRuntimeUrl()",
-      "norm_label": "buildathenaruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
-      "label": "buildValkeyRuntimeUrl()",
-      "norm_label": "buildvalkeyruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
-      "label": "createAthenaRuntimeProcess()",
-      "norm_label": "createathenaruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
-      "label": "createStorefrontRuntimeProcesses()",
-      "norm_label": "createstorefrontruntimeprocesses()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
-      "label": "createValkeyRuntimeProcess()",
-      "norm_label": "createvalkeyruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_scenarios_ts",
-      "label": "harness-behavior-scenarios.ts",
-      "norm_label": "harness-behavior-scenarios.ts",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 970,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -58606,7 +58957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -58615,7 +58966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -58624,7 +58975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -58633,7 +58984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -58642,7 +58993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -58651,7 +59002,61 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 98,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
+      "label": "buildAthenaRuntimeUrl()",
+      "norm_label": "buildathenaruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
+      "label": "buildValkeyRuntimeUrl()",
+      "norm_label": "buildvalkeyruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
+      "label": "createAthenaRuntimeProcess()",
+      "norm_label": "createathenaruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
+      "label": "createStorefrontRuntimeProcesses()",
+      "norm_label": "createstorefrontruntimeprocesses()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
+      "label": "createValkeyRuntimeProcess()",
+      "norm_label": "createvalkeyruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_scenarios_ts",
+      "label": "harness-behavior-scenarios.ts",
+      "norm_label": "harness-behavior-scenarios.ts",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 980,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58660,7 +59065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 981,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -58669,7 +59074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -58678,7 +59083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 979,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -58687,52 +59092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 98,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "label": "r2.ts",
-      "norm_label": "r2.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "r2_deletedirectoryinr2",
-      "label": "deleteDirectoryInR2()",
-      "norm_label": "deletedirectoryinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "r2_deletefileinr2",
-      "label": "deleteFileInR2()",
-      "norm_label": "deletefileinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "r2_listitemsinr2directory",
-      "label": "listItemsInR2Directory()",
-      "norm_label": "listitemsinr2directory()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "r2_uploadfiletor2",
-      "label": "uploadFileToR2()",
-      "norm_label": "uploadfiletor2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 980,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -58741,7 +59101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -58750,7 +59110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -58759,7 +59119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -58768,7 +59128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58777,7 +59137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -58786,7 +59146,52 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 99,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
+      "label": "r2.ts",
+      "norm_label": "r2.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "r2_deletedirectoryinr2",
+      "label": "deleteDirectoryInR2()",
+      "norm_label": "deletedirectoryinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "r2_deletefileinr2",
+      "label": "deleteFileInR2()",
+      "norm_label": "deletefileinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "r2_listitemsinr2directory",
+      "label": "listItemsInR2Directory()",
+      "norm_label": "listitemsinr2directory()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "r2_uploadfiletor2",
+      "label": "uploadFileToR2()",
+      "norm_label": "uploadfiletor2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 990,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -58795,7 +59200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 991,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -58804,7 +59209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -58813,7 +59218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 989,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -58822,52 +59227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 99,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
-      "label": "validateExpenseItemBelongsToSession()",
-      "norm_label": "validateexpenseitembelongstosession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionactive",
-      "label": "validateExpenseSessionActive()",
-      "norm_label": "validateexpensesessionactive()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionexists",
-      "label": "validateExpenseSessionExists()",
-      "norm_label": "validateexpensesessionexists()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
-      "label": "validateExpenseSessionModifiable()",
-      "norm_label": "validateexpensesessionmodifiable()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
-      "label": "expenseSessionValidation.ts",
-      "norm_label": "expensesessionvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 990,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -58876,7 +59236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -58885,7 +59245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -58894,7 +59254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -58903,7 +59263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -58912,48 +59272,12 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
       "norm_label": "use-store-modal.tsx",
       "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 996,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 997,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_aws_ts",
-      "label": "aws.ts",
-      "norm_label": "aws.ts",
-      "source_file": "packages/athena-webapp/src/lib/aws.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/src/lib/countries.ts",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1308
-- Graph nodes: 3082
-- Graph edges: 2601
-- Communities: 1223
+- Code files discovered: 1312
+- Graph nodes: 3098
+- Graph edges: 2616
+- Communities: 1227
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 25) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 177) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 180) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 25) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 25) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 25) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts
+++ b/packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts
@@ -1,0 +1,235 @@
+import { Doc, Id } from "../../_generated/dataModel";
+
+type ReturnExchangeOrder = Pick<
+  Doc<"onlineOrder">,
+  "_id" | "amount" | "orderNumber" | "status"
+>;
+
+type ReturnExchangeOrderItem = Pick<
+  Doc<"onlineOrderItem">,
+  | "_id"
+  | "isReady"
+  | "isRefunded"
+  | "isRestocked"
+  | "price"
+  | "productId"
+  | "productName"
+  | "productSku"
+  | "productSkuId"
+  | "quantity"
+>;
+
+export type ReturnExchangeReplacementInput = {
+  inventoryCount: number;
+  productId: Id<"product">;
+  productName?: string;
+  productSkuId: Id<"productSku">;
+  quantity: number;
+  quantityAvailable: number;
+  skuLabel?: string;
+  unitPrice: number;
+};
+
+type ReturnExchangeMovement = {
+  orderItemId?: Id<"onlineOrderItem">;
+  productId: Id<"product">;
+  productName?: string;
+  productSkuId: Id<"productSku">;
+  quantity: number;
+  quantityDelta: number;
+  reasonCode: string;
+  skuLabel?: string;
+};
+
+type ReturnExchangePaymentAllocation = {
+  allocationType:
+    | "online_order_exchange_balance_collection"
+    | "online_order_return_refund";
+  amount: number;
+  direction: "in" | "out";
+};
+
+export type OnlineOrderReturnExchangePlan = {
+  approvalReason: string | null;
+  balanceDueAmount: number;
+  eventMessage: string;
+  eventType:
+    | "online_order_exchange_processed"
+    | "online_order_return_approval_requested"
+    | "online_order_return_processed";
+  exchangeMovements: ReturnExchangeMovement[];
+  kind: "exchange" | "full_return" | "partial_return";
+  paymentAllocation: ReturnExchangePaymentAllocation | null;
+  refundAmount: number;
+  replacementItems: ReturnExchangeReplacementInput[];
+  requiresApproval: boolean;
+  returnMovements: ReturnExchangeMovement[];
+  selectedItems: ReturnExchangeOrderItem[];
+};
+
+function getLineRefundAmount(item: ReturnExchangeOrderItem) {
+  return item.price * item.quantity * 100;
+}
+
+function getKind(args: {
+  replacementItems: ReturnExchangeReplacementInput[];
+  selectedCount: number;
+  totalRefundableCount: number;
+}): OnlineOrderReturnExchangePlan["kind"] {
+  if (args.replacementItems.length > 0) {
+    return "exchange";
+  }
+
+  if (args.selectedCount === args.totalRefundableCount) {
+    return "full_return";
+  }
+
+  return "partial_return";
+}
+
+function getApprovalReason(args: {
+  replacementItems: ReturnExchangeReplacementInput[];
+  restockReturnedItems: boolean;
+  selectedItems: ReturnExchangeOrderItem[];
+}) {
+  if (
+    args.restockReturnedItems &&
+    args.selectedItems.some((item) => item.isReady !== true)
+  ) {
+    return "Return requires inspection and approval before stock can be restored.";
+  }
+
+  if (
+    args.replacementItems.some(
+      (item) =>
+        item.inventoryCount < item.quantity ||
+        item.quantityAvailable < item.quantity,
+    )
+  ) {
+    return "Exchange requires approval because the replacement inventory cannot self-resolve.";
+  }
+
+  return null;
+}
+
+export function buildOnlineOrderReturnExchangePlan(args: {
+  order: ReturnExchangeOrder;
+  orderItems: ReturnExchangeOrderItem[];
+  replacementItems?: ReturnExchangeReplacementInput[];
+  restockReturnedItems: boolean;
+  returnItemIds: Array<Id<"onlineOrderItem">>;
+}): OnlineOrderReturnExchangePlan {
+  const returnItemIdSet = new Set(args.returnItemIds);
+  const selectedItems = args.orderItems.filter((item) =>
+    returnItemIdSet.has(item._id),
+  );
+
+  if (selectedItems.length === 0) {
+    throw new Error("Select at least one order line to return or exchange.");
+  }
+
+  if (selectedItems.some((item) => item.isRefunded || item.isRestocked)) {
+    throw new Error("Selected items have already been returned.");
+  }
+
+  const replacementItems = args.replacementItems ?? [];
+
+  if (replacementItems.length > 0 && replacementItems.some((item) => item.quantity <= 0)) {
+    throw new Error("Replacement quantities must be greater than zero.");
+  }
+
+  const totalRefundableCount = args.orderItems.filter(
+    (item) => !item.isRefunded && !item.isRestocked,
+  ).length;
+  const kind = getKind({
+    replacementItems,
+    selectedCount: selectedItems.length,
+    totalRefundableCount,
+  });
+  const returnSubtotal = selectedItems.reduce(
+    (sum, item) => sum + getLineRefundAmount(item),
+    0,
+  );
+  const replacementSubtotal = replacementItems.reduce(
+    (sum, item) => sum + item.unitPrice * item.quantity,
+    0,
+  );
+  const approvalReason = getApprovalReason({
+    replacementItems,
+    restockReturnedItems: args.restockReturnedItems,
+    selectedItems,
+  });
+
+  if (approvalReason) {
+    return {
+      approvalReason,
+      balanceDueAmount: 0,
+      eventMessage: approvalReason,
+      eventType: "online_order_return_approval_requested",
+      exchangeMovements: [],
+      kind,
+      paymentAllocation: null,
+      refundAmount: 0,
+      replacementItems,
+      requiresApproval: true,
+      returnMovements: [],
+      selectedItems,
+    };
+  }
+
+  const refundAmount = Math.max(returnSubtotal - replacementSubtotal, 0);
+  const balanceDueAmount = Math.max(replacementSubtotal - returnSubtotal, 0);
+
+  return {
+    approvalReason: null,
+    balanceDueAmount,
+    eventMessage:
+      kind === "exchange"
+        ? `Processed exchange for order #${args.order.orderNumber}.`
+        : `Processed ${kind.replaceAll("_", " ")} for order #${args.order.orderNumber}.`,
+    eventType:
+      kind === "exchange"
+        ? "online_order_exchange_processed"
+        : "online_order_return_processed",
+    exchangeMovements: replacementItems.map((item) => ({
+      productId: item.productId,
+      productName: item.productName,
+      productSkuId: item.productSkuId,
+      quantity: item.quantity,
+      quantityDelta: -item.quantity,
+      reasonCode: "online_order_exchange_issued",
+      skuLabel: item.skuLabel,
+    })),
+    kind,
+    paymentAllocation:
+      refundAmount > 0
+        ? {
+            allocationType: "online_order_return_refund",
+            amount: refundAmount,
+            direction: "out",
+          }
+        : balanceDueAmount > 0
+          ? {
+              allocationType: "online_order_exchange_balance_collection",
+              amount: balanceDueAmount,
+              direction: "in",
+            }
+          : null,
+    refundAmount,
+    replacementItems,
+    requiresApproval: false,
+    returnMovements: args.restockReturnedItems
+      ? selectedItems.map((item) => ({
+          orderItemId: item._id,
+          productId: item.productId,
+          productName: item.productName,
+          productSkuId: item.productSkuId,
+          quantity: item.quantity,
+          quantityDelta: item.quantity,
+          reasonCode: "online_order_return_restocked",
+          skuLabel: item.productSku,
+        }))
+      : [],
+    selectedItems,
+  };
+}

--- a/packages/athena-webapp/convex/storeFront/onlineOrder.ts
+++ b/packages/athena-webapp/convex/storeFront/onlineOrder.ts
@@ -16,6 +16,10 @@ import {
 import { internal } from "../_generated/api";
 import { Doc, Id } from "../_generated/dataModel";
 import { getDiscountValue } from "../inventory/utils";
+import { buildApprovalRequest } from "../operations/approvalRequests";
+import { recordInventoryMovementWithCtx } from "../operations/inventoryMovements";
+import { recordOperationalEventWithCtx } from "../operations/operationalEvents";
+import { recordPaymentAllocationWithCtx } from "../operations/paymentAllocations";
 import {
   createOrderFromCheckoutSession,
   findOrderByExternalReference,
@@ -24,22 +28,26 @@ import {
 } from "./helpers/onlineOrder";
 import {
   assertValidOnlineOrderStatusTransition,
+  getOnlineOrderPaymentMethodLabel,
   recordOnlineOrderRestockMovement,
   recordOnlineOrderPaymentCollected,
   recordOnlineOrderPaymentVerified,
   recordOnlineOrderStatusEvent,
 } from "./helpers/orderOperations";
+import { buildOnlineOrderReturnExchangePlan } from "./helpers/returnExchangeOperations";
 
 const entity = "onlineOrder";
 const MAX_ORDER_ITEMS = 200;
 const MAX_ORDERS = 500;
+const MAX_OPERATIONAL_EVENTS = 20;
+const MAX_PENDING_APPROVALS = 100;
 type SignedInAthenaUser = {
   id: Id<"athenaUser">;
   email: string;
 };
 
 async function listOrderItems(
-  ctx: QueryCtx,
+  ctx: QueryCtx | MutationCtx,
   orderId: Id<"onlineOrder">,
 ): Promise<Doc<"onlineOrderItem">[]> {
   return await ctx.db
@@ -189,6 +197,21 @@ async function applyOnlineOrderUpdate(
   }
 
   return nextOrder;
+}
+
+function buildReturnExchangeReplacementSourceId(
+  orderId: Id<"onlineOrder">,
+  productSkuId: Id<"productSku">,
+  index: number,
+) {
+  return `${orderId}:${productSkuId}:exchange:${index}`;
+}
+
+function buildReturnExchangeReturnSourceId(
+  orderId: Id<"onlineOrder">,
+  orderItemId: Id<"onlineOrderItem">,
+) {
+  return `${orderId}:${orderItemId}:return`;
 }
 
 export const create = mutation({
@@ -680,6 +703,402 @@ export const updateInternal = internalMutation({
 
       return true;
     }
+  },
+});
+
+export const getReturnExchangeOverview = query({
+  args: {
+    orderId: v.id("onlineOrder"),
+  },
+  returns: v.object({
+    balanceCollectedTotal: v.number(),
+    pendingApprovalCount: v.number(),
+    recentEvents: v.array(
+      v.object({
+        _id: v.id("operationalEvent"),
+        createdAt: v.number(),
+        eventType: v.string(),
+        message: v.string(),
+      }),
+    ),
+    refundTotal: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const order = await ctx.db.get("onlineOrder", args.orderId);
+
+    if (!order) {
+      return {
+        balanceCollectedTotal: 0,
+        pendingApprovalCount: 0,
+        recentEvents: [],
+        refundTotal: 0,
+      };
+    }
+
+    const [paymentAllocations, operationalEvents, pendingApprovals] =
+      await Promise.all([
+        ctx.db
+          .query("paymentAllocation")
+          .withIndex("by_storeId_target", (q) =>
+            q
+              .eq("storeId", order.storeId)
+              .eq("targetType", "online_order")
+              .eq("targetId", order._id),
+          )
+          .collect(),
+        ctx.db
+          .query("operationalEvent")
+          .withIndex("by_storeId_subject", (q) =>
+            q
+              .eq("storeId", order.storeId)
+              .eq("subjectType", "online_order")
+              .eq("subjectId", order._id),
+          )
+          .collect(),
+        ctx.db
+          .query("approvalRequest")
+          .withIndex("by_storeId_status", (q) =>
+            q.eq("storeId", order.storeId).eq("status", "pending"),
+          )
+          .take(MAX_PENDING_APPROVALS),
+      ]);
+
+    const relevantEvents = operationalEvents
+      .filter(
+        (event) =>
+          event.eventType.includes("return") || event.eventType.includes("exchange"),
+      )
+      .sort((a, b) => b.createdAt - a.createdAt)
+      .slice(0, MAX_OPERATIONAL_EVENTS)
+      .map((event) => ({
+        _id: event._id,
+        createdAt: event.createdAt,
+        eventType: event.eventType,
+        message: event.message,
+      }));
+
+    return {
+      balanceCollectedTotal: paymentAllocations
+        .filter(
+          (allocation) =>
+            allocation.allocationType === "online_order_exchange_balance_collection" &&
+            allocation.direction === "in",
+        )
+        .reduce((sum, allocation) => sum + allocation.amount, 0),
+      pendingApprovalCount: pendingApprovals.filter(
+        (request) =>
+          request.subjectType === "online_order" && request.subjectId === order._id,
+      ).length,
+      recentEvents: relevantEvents,
+      refundTotal: paymentAllocations
+        .filter(
+          (allocation) =>
+            allocation.allocationType === "online_order_return_refund" &&
+            allocation.direction === "out",
+        )
+        .reduce((sum, allocation) => sum + allocation.amount, 0),
+    };
+  },
+});
+
+export const processReturnExchange = mutation({
+  args: {
+    notes: v.optional(v.string()),
+    operationType: v.union(v.literal("exchange"), v.literal("return")),
+    orderId: v.id("onlineOrder"),
+    replacementItems: v.optional(
+      v.array(
+        v.object({
+          productId: v.optional(v.id("product")),
+          productName: v.optional(v.string()),
+          productSkuId: v.id("productSku"),
+          quantity: v.number(),
+          unitPrice: v.number(),
+        }),
+      ),
+    ),
+    restockReturnedItems: v.boolean(),
+    returnItemIds: v.array(v.id("onlineOrderItem")),
+    signedInAthenaUser: v.optional(
+      v.object({
+        id: v.id("athenaUser"),
+        email: v.string(),
+      }),
+    ),
+  },
+  returns: v.object({
+    approvalRequestId: v.optional(v.id("approvalRequest")),
+    balanceDueAmount: v.number(),
+    message: v.string(),
+    refundAmount: v.number(),
+    requiresApproval: v.boolean(),
+    success: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const order = await ctx.db.get("onlineOrder", args.orderId);
+
+    if (!order) {
+      throw new Error("Order not found.");
+    }
+
+    const store = await ctx.db.get("store", order.storeId);
+    const orderItems = await listOrderItems(ctx, order._id);
+    const replacementItems = await Promise.all(
+      (args.replacementItems ?? []).map(async (replacement) => {
+        const productSku = await ctx.db.get("productSku", replacement.productSkuId);
+
+        if (!productSku) {
+          throw new Error("Replacement SKU not found.");
+        }
+
+        const product =
+          (replacement.productId
+            ? await ctx.db.get("product", replacement.productId)
+            : null) ?? (await ctx.db.get("product", productSku.productId));
+
+        return {
+          inventoryCount: productSku.inventoryCount,
+          productId: replacement.productId ?? productSku.productId,
+          productName: replacement.productName ?? product?.name,
+          productSkuId: replacement.productSkuId,
+          quantity: replacement.quantity,
+          quantityAvailable: productSku.quantityAvailable,
+          skuLabel: productSku.sku,
+          unitPrice: replacement.unitPrice,
+        };
+      }),
+    );
+
+    if (args.operationType === "exchange" && replacementItems.length === 0) {
+      throw new Error("Exchange flows require a replacement item.");
+    }
+
+    const plan = buildOnlineOrderReturnExchangePlan({
+      order,
+      orderItems,
+      replacementItems,
+      restockReturnedItems: args.restockReturnedItems,
+      returnItemIds: args.returnItemIds,
+    });
+
+    if (plan.requiresApproval) {
+      const approvalRequestId = await ctx.db.insert(
+        "approvalRequest",
+        buildApprovalRequest({
+          metadata: {
+            operationType: args.operationType,
+            replacementItems: replacementItems.map((item) => ({
+              productName: item.productName ?? item.skuLabel ?? null,
+              productSkuId: item.productSkuId,
+              quantity: item.quantity,
+            })),
+            returnItemIds: args.returnItemIds,
+          },
+          notes: args.notes,
+          organizationId: store?.organizationId,
+          reason: plan.approvalReason ?? undefined,
+          requestType: "online_order_return_review",
+          requestedByUserId: args.signedInAthenaUser?.id,
+          storeId: order.storeId,
+          subjectId: order._id,
+          subjectType: "online_order",
+        }),
+      );
+
+      await recordOperationalEventWithCtx(ctx, {
+        actorUserId: args.signedInAthenaUser?.id,
+        approvalRequestId,
+        customerProfileId: order.customerProfileId,
+        eventType: plan.eventType,
+        message: plan.eventMessage,
+        metadata: {
+          operationType: args.operationType,
+          returnItemIds: args.returnItemIds,
+        },
+        onlineOrderId: order._id,
+        organizationId: store?.organizationId,
+        reason: plan.approvalReason ?? undefined,
+        storeId: order.storeId,
+        subjectId: order._id,
+        subjectLabel: order.orderNumber,
+        subjectType: "online_order",
+      });
+
+      return {
+        approvalRequestId,
+        balanceDueAmount: plan.balanceDueAmount,
+        message: "Return or exchange sent for approval.",
+        refundAmount: plan.refundAmount,
+        requiresApproval: true,
+        success: true,
+      };
+    }
+
+    const now = Date.now();
+
+    await Promise.all(
+      plan.selectedItems.map(async (item) => {
+        const nextFields = {
+          isRefunded: true,
+          ...(args.restockReturnedItems ? { isRestocked: true } : {}),
+        };
+
+        await ctx.db.patch("onlineOrderItem", item._id, nextFields);
+      }),
+    );
+
+    const returnMovementIds = await Promise.all(
+      plan.returnMovements.map(async (movement) => {
+        const productSku = await ctx.db.get("productSku", movement.productSkuId);
+
+        if (!productSku) {
+          throw new Error("Returned item SKU not found.");
+        }
+
+        await ctx.db.patch("productSku", movement.productSkuId, {
+          inventoryCount: productSku.inventoryCount + movement.quantity,
+          quantityAvailable: productSku.quantityAvailable + movement.quantity,
+        });
+
+        const inventoryMovement = await recordInventoryMovementWithCtx(ctx, {
+          actorUserId: args.signedInAthenaUser?.id,
+          customerProfileId: order.customerProfileId,
+          movementType: "restock",
+          notes: args.notes ?? order.orderNumber,
+          onlineOrderId: order._id,
+          organizationId: store?.organizationId,
+          productId: movement.productId,
+          productSkuId: movement.productSkuId,
+          quantityDelta: movement.quantityDelta,
+          reasonCode: movement.reasonCode,
+          sourceId: buildReturnExchangeReturnSourceId(
+            order._id,
+            movement.orderItemId!,
+          ),
+          sourceType: "online_order_return",
+          storeId: order.storeId,
+        });
+
+        return inventoryMovement?._id ?? null;
+      }),
+    );
+
+    const exchangeMovementIds = await Promise.all(
+      plan.exchangeMovements.map(async (movement, index) => {
+        const productSku = await ctx.db.get("productSku", movement.productSkuId);
+
+        if (!productSku) {
+          throw new Error("Replacement SKU not found.");
+        }
+
+        await ctx.db.patch("productSku", movement.productSkuId, {
+          inventoryCount: Math.max(productSku.inventoryCount - movement.quantity, 0),
+          quantityAvailable: Math.max(
+            productSku.quantityAvailable - movement.quantity,
+            0,
+          ),
+        });
+
+        const inventoryMovement = await recordInventoryMovementWithCtx(ctx, {
+          actorUserId: args.signedInAthenaUser?.id,
+          customerProfileId: order.customerProfileId,
+          movementType: "exchange",
+          notes: args.notes ?? order.orderNumber,
+          onlineOrderId: order._id,
+          organizationId: store?.organizationId,
+          productId: movement.productId,
+          productSkuId: movement.productSkuId,
+          quantityDelta: movement.quantityDelta,
+          reasonCode: movement.reasonCode,
+          sourceId: buildReturnExchangeReplacementSourceId(
+            order._id,
+            movement.productSkuId,
+            index,
+          ),
+          sourceType: "online_order_exchange",
+          storeId: order.storeId,
+        });
+
+        return inventoryMovement?._id ?? null;
+      }),
+    );
+
+    const paymentAllocation = plan.paymentAllocation
+      ? await recordPaymentAllocationWithCtx(ctx, {
+          actorUserId: args.signedInAthenaUser?.id,
+          allocationType: plan.paymentAllocation.allocationType,
+          amount: plan.paymentAllocation.amount,
+          collectedInStore: plan.paymentAllocation.direction === "in",
+          customerProfileId: order.customerProfileId,
+          direction: plan.paymentAllocation.direction,
+          method: getOnlineOrderPaymentMethodLabel(order),
+          notes: args.notes,
+          onlineOrderId: order._id,
+          organizationId: store?.organizationId,
+          storeId: order.storeId,
+          targetId: order._id,
+          targetType: "online_order",
+        })
+      : null;
+
+    const nextRefunds =
+      plan.refundAmount > 0
+        ? [
+            ...(order.refunds ?? []),
+            {
+              amount: plan.refundAmount,
+              date: now,
+              id: `return-exchange-${now}`,
+            },
+          ]
+        : order.refunds;
+
+    await ctx.db.patch("onlineOrder", order._id, {
+      refunds: nextRefunds,
+      updatedAt: now,
+    });
+
+    const inventoryMovementIds = [...returnMovementIds, ...exchangeMovementIds].filter(
+      Boolean,
+    );
+
+    await recordOperationalEventWithCtx(ctx, {
+      actorUserId: args.signedInAthenaUser?.id,
+      customerProfileId: order.customerProfileId,
+      eventType: plan.eventType,
+      inventoryMovementId: inventoryMovementIds[0] ?? undefined,
+      message: plan.eventMessage,
+      metadata: {
+        balanceDueAmount: plan.balanceDueAmount,
+        operationType: args.operationType,
+        replacementItems: replacementItems.map((item) => ({
+          productName: item.productName ?? item.skuLabel ?? null,
+          productSkuId: item.productSkuId,
+          quantity: item.quantity,
+        })),
+        refundAmount: plan.refundAmount,
+        returnItemIds: args.returnItemIds,
+      },
+      onlineOrderId: order._id,
+      organizationId: store?.organizationId,
+      paymentAllocationId: paymentAllocation?._id,
+      reason: plan.kind,
+      storeId: order.storeId,
+      subjectId: order._id,
+      subjectLabel: order.orderNumber,
+      subjectType: "online_order",
+    });
+
+    return {
+      balanceDueAmount: plan.balanceDueAmount,
+      message:
+        args.operationType === "exchange"
+          ? "Exchange recorded."
+          : "Return recorded.",
+      refundAmount: plan.refundAmount,
+      requiresApproval: false,
+      success: true,
+    };
   },
 });
 

--- a/packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts
+++ b/packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts
@@ -1,0 +1,201 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOnlineOrderReturnExchangePlan,
+  type ReturnExchangeReplacementInput,
+} from "./helpers/returnExchangeOperations";
+
+function getSource(relativePath: string) {
+  return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+function createOrderItem(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: "item-1",
+    isReady: true,
+    isRefunded: false,
+    isRestocked: false,
+    orderId: "order-1",
+    price: 45,
+    productId: "product-1",
+    productName: "Curly Closure",
+    productSku: "SKU-RETURN-1",
+    productSkuId: "sku-1",
+    quantity: 2,
+    storeFrontUserId: "guest-1",
+    ...overrides,
+  } as any;
+}
+
+function createReplacement(
+  overrides: Partial<ReturnExchangeReplacementInput> = {},
+): ReturnExchangeReplacementInput {
+  return {
+    productId: "product-2" as any,
+    productName: "Body Wave Closure",
+    productSkuId: "sku-2" as any,
+    quantity: 1,
+    quantityAvailable: 4,
+    inventoryCount: 4,
+    skuLabel: "SKU-EXCHANGE-2",
+    unitPrice: 110_00,
+    ...overrides,
+  };
+}
+
+describe("online order return and exchange planning", () => {
+  it("plans a partial return with a refund, safe restock, and operational events", () => {
+    const plan = buildOnlineOrderReturnExchangePlan({
+      order: {
+        _id: "order-1",
+        amount: 18_000,
+        deliveryMethod: "pickup",
+        orderNumber: "10001",
+        status: "picked-up",
+      } as any,
+      orderItems: [
+        createOrderItem(),
+        createOrderItem({
+          _id: "item-2",
+          price: 60,
+          productId: "product-3",
+          productName: "Frontal Unit",
+          productSku: "SKU-RETURN-2",
+          productSkuId: "sku-3",
+          quantity: 1,
+        }),
+      ],
+      restockReturnedItems: true,
+      returnItemIds: ["item-1" as any],
+    });
+
+    expect(plan).toMatchObject({
+      approvalReason: null,
+      balanceDueAmount: 0,
+      kind: "partial_return",
+      paymentAllocation: {
+        allocationType: "online_order_return_refund",
+        amount: 9_000,
+        direction: "out",
+      },
+      refundAmount: 9_000,
+      requiresApproval: false,
+    });
+    expect(plan.eventType).toBe("online_order_return_processed");
+    expect(plan.returnMovements).toEqual([
+      expect.objectContaining({
+        orderItemId: "item-1",
+        quantityDelta: 2,
+        reasonCode: "online_order_return_restocked",
+      }),
+    ]);
+  });
+
+  it("treats returning every remaining line as a full return and sums the total refund correctly", () => {
+    const plan = buildOnlineOrderReturnExchangePlan({
+      order: {
+        _id: "order-1",
+        amount: 15_000,
+        orderNumber: "10002",
+        status: "delivered",
+      } as any,
+      orderItems: [
+        createOrderItem({
+          _id: "item-1",
+          price: 45,
+          quantity: 2,
+        }),
+        createOrderItem({
+          _id: "item-2",
+          price: 60,
+          productId: "product-3",
+          productName: "Frontal Unit",
+          productSku: "SKU-RETURN-2",
+          productSkuId: "sku-3",
+          quantity: 1,
+        }),
+      ],
+      restockReturnedItems: true,
+      returnItemIds: ["item-1" as any, "item-2" as any],
+    });
+
+    expect(plan.kind).toBe("full_return");
+    expect(plan.refundAmount).toBe(15_000);
+    expect(plan.selectedItems).toHaveLength(2);
+  });
+
+  it("plans an exchange to a new item and only collects the price delta", () => {
+    const plan = buildOnlineOrderReturnExchangePlan({
+      order: {
+        _id: "order-1",
+        amount: 9_000,
+        orderNumber: "10003",
+        status: "picked-up",
+      } as any,
+      orderItems: [createOrderItem()],
+      replacementItems: [createReplacement()],
+      restockReturnedItems: true,
+      returnItemIds: ["item-1" as any],
+    });
+
+    expect(plan).toMatchObject({
+      balanceDueAmount: 2_000,
+      kind: "exchange",
+      paymentAllocation: {
+        allocationType: "online_order_exchange_balance_collection",
+        amount: 2_000,
+        direction: "in",
+      },
+      refundAmount: 0,
+      requiresApproval: false,
+    });
+    expect(plan.eventType).toBe("online_order_exchange_processed");
+    expect(plan.exchangeMovements).toEqual([
+      expect.objectContaining({
+        productSkuId: "sku-2",
+        quantityDelta: -1,
+        reasonCode: "online_order_exchange_issued",
+      }),
+    ]);
+  });
+
+  it("requires approval when the return path is not safe to self-resolve", () => {
+    const plan = buildOnlineOrderReturnExchangePlan({
+      order: {
+        _id: "order-1",
+        amount: 9_000,
+        orderNumber: "10004",
+        status: "open",
+      } as any,
+      orderItems: [
+        createOrderItem({
+          _id: "item-unsafe",
+          isReady: false,
+        }),
+      ],
+      restockReturnedItems: true,
+      returnItemIds: ["item-unsafe" as any],
+    });
+
+    expect(plan.requiresApproval).toBe(true);
+    expect(plan.approvalReason).toMatch(/inspection|approval/i);
+    expect(plan.paymentAllocation).toBeNull();
+    expect(plan.returnMovements).toEqual([]);
+  });
+});
+
+describe("online order return and exchange mutation wiring", () => {
+  it("routes storefront returns and exchanges through shared operational rails", () => {
+    const onlineOrderSource = getSource("./onlineOrder.ts");
+
+    expect(onlineOrderSource).toContain(
+      "export const processReturnExchange = mutation({",
+    );
+    expect(onlineOrderSource).toContain("buildOnlineOrderReturnExchangePlan");
+    expect(onlineOrderSource).toContain("recordPaymentAllocationWithCtx");
+    expect(onlineOrderSource).toContain("recordInventoryMovementWithCtx");
+    expect(onlineOrderSource).toContain("recordOperationalEventWithCtx");
+    expect(onlineOrderSource).toContain("buildApprovalRequest");
+  });
+});

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 61 file(s); key children: __root.tsx, _authed, _authed.tsx, index.tsx, join-team.index.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 478 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 480 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 43 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 5 file(s); key children: OnlineOrderContext.tsx, PermissionsContext.tsx, ProductContext.tsx, ThemeContext.tsx, UserContext.tsx.
 - [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 35 file(s); key children: aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts, countries.ts.
@@ -16,7 +16,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Backend and test surfaces
 
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 254 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 256 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 6 file(s); key children: README.md, SUMMARY.md, pos.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -42,6 +42,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/storeFront/customerObservabilityTimeline.test.ts`](../../convex/storeFront/customerObservabilityTimeline.test.ts)
 - [`convex/storeFront/helperOrchestration.test.ts`](../../convex/storeFront/helperOrchestration.test.ts)
 - [`convex/storeFront/orderOperations.test.ts`](../../convex/storeFront/orderOperations.test.ts)
+- [`convex/storeFront/returnExchangeOperations.test.ts`](../../convex/storeFront/returnExchangeOperations.test.ts)
 - [`convex/storeFront/storefrontObservabilityReport.test.ts`](../../convex/storeFront/storefrontObservabilityReport.test.ts)
 - [`convex/storeFront/timeQueryRefactors.test.ts`](../../convex/storeFront/timeQueryRefactors.test.ts)
 
@@ -50,6 +51,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/components/bulk-operations/BulkOperationsPreview.test.tsx`](../../src/components/bulk-operations/BulkOperationsPreview.test.tsx)
 - [`src/components/operations/OperationsQueueView.test.tsx`](../../src/components/operations/OperationsQueueView.test.tsx)
 - [`src/components/orders/OrderStatus.test.tsx`](../../src/components/orders/OrderStatus.test.tsx)
+- [`src/components/orders/ReturnExchangeView.test.tsx`](../../src/components/orders/ReturnExchangeView.test.tsx)
 - [`src/components/orders/utils.test.ts`](../../src/components/orders/utils.test.ts)
 - [`src/components/pos/TotalsDisplay.test.tsx`](../../src/components/pos/TotalsDisplay.test.tsx)
 - [`src/components/services/ServiceAppointmentsView.test.tsx`](../../src/components/services/ServiceAppointmentsView.test.tsx)

--- a/packages/athena-webapp/src/components/orders/OrderView.tsx
+++ b/packages/athena-webapp/src/components/orders/OrderView.tsx
@@ -48,6 +48,7 @@ import { OrderStatus } from "./OrderStatus";
 import { EmailStatusView } from "./EmailStatusView";
 import { ComposedPageHeader } from "../common/PageHeader";
 import { useAuth } from "~/src/hooks/useAuth";
+import { ReturnExchangeView } from "./ReturnExchangeView";
 
 export function RefundOptions() {
   const { order } = useOnlineOrder();
@@ -597,7 +598,10 @@ export const OrderView = () => {
               </div>
             </div>
 
-            <RefundsView />
+            <div className="space-y-8">
+              <ReturnExchangeView />
+              <RefundsView />
+            </div>
           </div>
 
           <ActivityView />

--- a/packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx
+++ b/packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ReturnExchangeViewContent } from "./ReturnExchangeView";
+
+const baseOrder = {
+  _creationTime: Date.now(),
+  _id: "order-1",
+  amount: 15_000,
+  deliveryMethod: "pickup",
+  orderNumber: "10001",
+  refunds: [],
+  status: "picked-up",
+  items: [
+    {
+      _id: "item-1",
+      isReady: true,
+      isRefunded: false,
+      isRestocked: false,
+      price: 45,
+      productId: "product-1",
+      productName: "Curly Closure",
+      productSku: "SKU-RETURN-1",
+      productSkuId: "sku-1",
+      quantity: 2,
+    },
+    {
+      _id: "item-2",
+      isReady: true,
+      isRefunded: false,
+      isRestocked: false,
+      price: 60,
+      productId: "product-2",
+      productName: "Frontal Unit",
+      productSku: "SKU-RETURN-2",
+      productSkuId: "sku-2",
+      quantity: 1,
+    },
+  ],
+} as any;
+
+describe("ReturnExchangeViewContent", () => {
+  it("submits selected line items as a return operation from the dedicated staff view", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ReturnExchangeViewContent
+        isSubmitting={false}
+        onSubmit={onSubmit}
+        order={baseOrder}
+        pendingApprovalCount={0}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /return & exchange/i }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("checkbox", { name: /curly closure/i }),
+    );
+    await user.click(screen.getByRole("button", { name: /process return/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({
+      operationType: "return",
+      replacementItems: [],
+      restockReturnedItems: true,
+      returnItemIds: ["item-1"],
+    });
+  });
+
+  it("captures exchange details and sends a replacement line payload", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ReturnExchangeViewContent
+        isSubmitting={false}
+        onSubmit={onSubmit}
+        order={baseOrder}
+        pendingApprovalCount={1}
+      />,
+    );
+
+    expect(screen.getByText(/1 approval pending/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: /frontal unit/i }));
+    await user.click(screen.getByLabelText(/exchange for a new item/i));
+    await user.type(screen.getByLabelText(/replacement sku id/i), "sku-9");
+    await user.type(screen.getByLabelText(/replacement product id/i), "product-9");
+    await user.type(screen.getByLabelText(/replacement product name/i), "Loose Wave Bundle");
+    await user.clear(screen.getByLabelText(/replacement quantity/i));
+    await user.type(screen.getByLabelText(/replacement quantity/i), "1");
+    await user.clear(screen.getByLabelText(/replacement unit price/i));
+    await user.type(screen.getByLabelText(/replacement unit price/i), "75");
+    await user.click(screen.getByRole("button", { name: /process exchange/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({
+      operationType: "exchange",
+      replacementItems: [
+        {
+          productId: "product-9",
+          productName: "Loose Wave Bundle",
+          productSkuId: "sku-9",
+          quantity: 1,
+          unitPrice: 7_500,
+        },
+      ],
+      restockReturnedItems: true,
+      returnItemIds: ["item-2"],
+    });
+  });
+});

--- a/packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx
+++ b/packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx
@@ -1,0 +1,435 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { CheckCircle2, RotateCcw } from "lucide-react";
+import { CheckCircledIcon } from "@radix-ui/react-icons";
+import { toast } from "sonner";
+
+import View from "../View";
+import { Checkbox } from "../ui/checkbox";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { LoadingButton } from "../ui/loading-button";
+import { RadioGroup, RadioGroupItem } from "../ui/radio-group";
+import { Switch } from "../ui/switch";
+import { useOnlineOrder } from "~/src/contexts/OnlineOrderContext";
+import useGetActiveStore from "~/src/hooks/useGetActiveStore";
+import { useAuth } from "~/src/hooks/useAuth";
+import { api } from "~/convex/_generated/api";
+import { currencyFormatter, getRelativeTime } from "~/src/lib/utils";
+
+export type ReturnExchangePayload = {
+  operationType: "exchange" | "return";
+  replacementItems: Array<{
+    productId?: string;
+    productName?: string;
+    productSkuId: string;
+    quantity: number;
+    unitPrice: number;
+  }>;
+  restockReturnedItems: boolean;
+  returnItemIds: string[];
+};
+
+type ReturnExchangeOverview = {
+  balanceCollectedTotal: number;
+  pendingApprovalCount: number;
+  recentEvents: Array<{
+    _id: string;
+    createdAt: number;
+    eventType: string;
+    message: string;
+  }>;
+  refundTotal: number;
+};
+
+type ReturnExchangeViewContentProps = {
+  activity?: ReturnExchangeOverview["recentEvents"];
+  balanceCollectedTotal?: number;
+  currency?: string;
+  isSubmitting: boolean;
+  onSubmit: (payload: ReturnExchangePayload) => Promise<void>;
+  order: any;
+  pendingApprovalCount: number;
+  refundTotal?: number;
+};
+
+export function ReturnExchangeViewContent({
+  activity = [],
+  balanceCollectedTotal = 0,
+  currency = "GHS",
+  isSubmitting,
+  onSubmit,
+  order,
+  pendingApprovalCount,
+  refundTotal = 0,
+}: ReturnExchangeViewContentProps) {
+  const [operationType, setOperationType] = useState<"exchange" | "return">(
+    "return",
+  );
+  const [replacementProductId, setReplacementProductId] = useState("");
+  const [replacementProductName, setReplacementProductName] = useState("");
+  const [replacementProductSkuId, setReplacementProductSkuId] = useState("");
+  const [replacementQuantity, setReplacementQuantity] = useState("1");
+  const [replacementUnitPrice, setReplacementUnitPrice] = useState("");
+  const [restockReturnedItems, setRestockReturnedItems] = useState(true);
+  const [selectedItemIds, setSelectedItemIds] = useState<Set<string>>(new Set());
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const formatter = currencyFormatter(currency);
+  const availableItems = order?.items?.filter((item: any) => !item.isRefunded) ?? [];
+
+  const toggleItem = (itemId: string) => {
+    setSelectedItemIds((previous) => {
+      const next = new Set(previous);
+
+      if (next.has(itemId)) {
+        next.delete(itemId);
+      } else {
+        next.add(itemId);
+      }
+
+      return next;
+    });
+  };
+
+  const resetReplacementFields = () => {
+    setReplacementProductId("");
+    setReplacementProductName("");
+    setReplacementProductSkuId("");
+    setReplacementQuantity("1");
+    setReplacementUnitPrice("");
+  };
+
+  const handleSubmit = async () => {
+    if (selectedItemIds.size === 0) {
+      setValidationError("Select at least one line item.");
+      return;
+    }
+
+    const payload: ReturnExchangePayload = {
+      operationType,
+      replacementItems: [],
+      restockReturnedItems,
+      returnItemIds: Array.from(selectedItemIds),
+    };
+
+    if (operationType === "exchange") {
+      const quantity = Number(replacementQuantity);
+      const unitPrice = Number(replacementUnitPrice);
+
+      if (!replacementProductSkuId || !replacementProductName || !replacementUnitPrice) {
+        setValidationError("Provide the replacement item details.");
+        return;
+      }
+
+      if (!Number.isFinite(quantity) || quantity <= 0) {
+        setValidationError("Replacement quantity must be greater than zero.");
+        return;
+      }
+
+      if (!Number.isFinite(unitPrice) || unitPrice <= 0) {
+        setValidationError("Replacement price must be greater than zero.");
+        return;
+      }
+
+      payload.replacementItems = [
+        {
+          productId: replacementProductId || undefined,
+          productName: replacementProductName,
+          productSkuId: replacementProductSkuId,
+          quantity,
+          unitPrice: Math.round(unitPrice * 100),
+        },
+      ];
+    }
+
+    setValidationError(null);
+    await onSubmit(payload);
+    setSelectedItemIds(new Set());
+    resetReplacementFields();
+    setOperationType("return");
+    setRestockReturnedItems(true);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h3 className="text-base font-medium">Return & Exchange</h3>
+        <p className="text-sm text-muted-foreground">
+          Record completed storefront returns and exchange-to-new-item flows.
+        </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        <div className="rounded-md border p-3">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Refunds recorded
+          </p>
+          <p className="mt-2 text-lg font-medium">
+            {formatter.format(refundTotal / 100)}
+          </p>
+        </div>
+        <div className="rounded-md border p-3">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Exchange balance collected
+          </p>
+          <p className="mt-2 text-lg font-medium">
+            {formatter.format(balanceCollectedTotal / 100)}
+          </p>
+        </div>
+        <div className="rounded-md border p-3">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Pending approvals
+          </p>
+          <p className="mt-2 text-lg font-medium">
+            {pendingApprovalCount} approval pending
+            {pendingApprovalCount === 1 ? "" : "s"}
+          </p>
+        </div>
+      </div>
+
+      {availableItems.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No eligible order lines remain for returns or exchanges.
+        </p>
+      ) : (
+        <div className="space-y-3 rounded-md border p-4">
+          <div>
+            <p className="text-sm font-medium">Select order lines</p>
+            <p className="text-sm text-muted-foreground">
+              Choose the purchased items being returned or exchanged.
+            </p>
+          </div>
+          {availableItems.map((item: any) => {
+            const checkboxId = `return-item-${item._id}`;
+
+            return (
+              <div
+                className="flex items-center justify-between gap-4 rounded-md border p-3"
+                key={item._id}
+              >
+                <div className="flex items-center gap-3">
+                  <Checkbox
+                    checked={selectedItemIds.has(item._id)}
+                    id={checkboxId}
+                    onCheckedChange={() => toggleItem(item._id)}
+                  />
+                  <Label className="cursor-pointer" htmlFor={checkboxId}>
+                    {item.productName ?? item.productSku}
+                  </Label>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  {item.quantity} x {formatter.format(item.price)}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="space-y-4 rounded-md border p-4">
+        <div>
+          <p className="text-sm font-medium">Flow</p>
+          <p className="text-sm text-muted-foreground">
+            Choose whether staff are completing a straight return or an exchange.
+          </p>
+        </div>
+        <RadioGroup
+          className="gap-3"
+          onValueChange={(value) => setOperationType(value as "exchange" | "return")}
+          value={operationType}
+        >
+          <div className="flex items-center gap-3">
+            <RadioGroupItem id="return-operation" value="return" />
+            <Label htmlFor="return-operation">Return selected items</Label>
+          </div>
+          <div className="flex items-center gap-3">
+            <RadioGroupItem id="exchange-operation" value="exchange" />
+            <Label htmlFor="exchange-operation">Exchange for a new item</Label>
+          </div>
+        </RadioGroup>
+      </div>
+
+      {operationType === "exchange" && (
+        <div className="grid gap-4 rounded-md border p-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="replacement-sku-id">Replacement SKU ID</Label>
+            <Input
+              id="replacement-sku-id"
+              onChange={(event) => setReplacementProductSkuId(event.target.value)}
+              value={replacementProductSkuId}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="replacement-product-id">Replacement product ID</Label>
+            <Input
+              id="replacement-product-id"
+              onChange={(event) => setReplacementProductId(event.target.value)}
+              value={replacementProductId}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="replacement-product-name">Replacement product name</Label>
+            <Input
+              id="replacement-product-name"
+              onChange={(event) => setReplacementProductName(event.target.value)}
+              value={replacementProductName}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="replacement-quantity">Replacement quantity</Label>
+            <Input
+              id="replacement-quantity"
+              onChange={(event) => setReplacementQuantity(event.target.value)}
+              type="number"
+              value={replacementQuantity}
+            />
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <Label htmlFor="replacement-unit-price">Replacement unit price</Label>
+            <Input
+              id="replacement-unit-price"
+              onChange={(event) => setReplacementUnitPrice(event.target.value)}
+              placeholder="75"
+              type="number"
+              value={replacementUnitPrice}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="flex items-center gap-3 rounded-md border p-4">
+        <Switch
+          checked={restockReturnedItems}
+          id="restock-returned-items"
+          onCheckedChange={setRestockReturnedItems}
+        />
+        <Label className="cursor-pointer" htmlFor="restock-returned-items">
+          Return accepted items back into stock
+        </Label>
+      </div>
+
+      {validationError && (
+        <p className="text-sm text-red-600">{validationError}</p>
+      )}
+
+      <LoadingButton
+        disabled={isSubmitting || availableItems.length === 0}
+        isLoading={isSubmitting}
+        onClick={handleSubmit}
+        variant="outline"
+      >
+        {operationType === "exchange" ? "Process exchange" : "Process return"}
+      </LoadingButton>
+
+      {activity.length > 0 && (
+        <div className="space-y-3 rounded-md border p-4">
+          <div>
+            <p className="text-sm font-medium">Recent return activity</p>
+            <p className="text-sm text-muted-foreground">
+              Operational milestones recorded for this order.
+            </p>
+          </div>
+          {activity.map((event) => (
+            <div
+              className="flex items-start justify-between gap-3 rounded-md border p-3"
+              key={event._id}
+            >
+              <div className="flex items-start gap-3">
+                {event.eventType.includes("exchange") ? (
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-emerald-600" />
+                ) : (
+                  <RotateCcw className="mt-0.5 h-4 w-4 text-amber-700" />
+                )}
+                <div>
+                  <p className="text-sm font-medium">{event.message}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {getRelativeTime(event.createdAt)}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ReturnExchangeView() {
+  const { order } = useOnlineOrder();
+  const { activeStore } = useGetActiveStore();
+  const { user } = useAuth();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const overview = useQuery(
+    api.storeFront.onlineOrder.getReturnExchangeOverview,
+    order?._id ? { orderId: order._id } : "skip",
+  ) as ReturnExchangeOverview | undefined;
+  const processReturnExchange = useMutation(
+    api.storeFront.onlineOrder.processReturnExchange,
+  );
+
+  if (!order || !activeStore) return null;
+
+  const handleSubmit = async (payload: ReturnExchangePayload) => {
+    try {
+      setIsSubmitting(true);
+      const result = await processReturnExchange({
+        orderId: order._id,
+        operationType: payload.operationType,
+        replacementItems: payload.replacementItems.map((item) => ({
+          productId: item.productId as any,
+          productName: item.productName,
+          productSkuId: item.productSkuId as any,
+          quantity: item.quantity,
+          unitPrice: item.unitPrice,
+        })),
+        restockReturnedItems: payload.restockReturnedItems,
+        returnItemIds: payload.returnItemIds.map((itemId) => itemId as any),
+        signedInAthenaUser: user
+          ? {
+              id: user._id,
+              email: user.email,
+            }
+          : undefined,
+      });
+
+      toast(
+        result.requiresApproval ? "Approval requested" : "Return flow recorded",
+        {
+          icon: <CheckCircledIcon className="w-4 h-4" />,
+          description: result.message,
+        },
+      );
+    } catch (error) {
+      console.error(error);
+      toast("Unable to process return or exchange", {
+        description: (error as Error).message,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <View
+      hideBorder
+      hideHeaderBottomBorder
+      className="h-auto w-full"
+      header={<p className="text-sm text-muted-foreground">Return & Exchange</p>}
+    >
+      <div className="py-4">
+        <ReturnExchangeViewContent
+          activity={overview?.recentEvents ?? []}
+          balanceCollectedTotal={overview?.balanceCollectedTotal ?? 0}
+          currency={activeStore.currency}
+          isSubmitting={isSubmitting}
+          onSubmit={handleSubmit}
+          order={order}
+          pendingApprovalCount={overview?.pendingApprovalCount ?? 0}
+          refundTotal={overview?.refundTotal ?? 0}
+        />
+      </div>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add dedicated return and exchange planning for storefront online orders
- route return/exchange processing through approval, payment allocation, inventory movement, and operational event rails
- add an Athena return and exchange view on the order page with focused tests

## Testing
- bun run --filter @athena/webapp test convex/storeFront/returnExchangeOperations.test.ts src/components/orders/ReturnExchangeView.test.tsx
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run --filter @athena/webapp audit:convex
- bun run pr:athena