### PR TITLE
V26-284: connect loyalty and follow-up milestones

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1312 files · ~0 words
+- 1314 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3098 nodes · 2616 edges · 1227 communities detected
+- 3105 nodes · 2623 edges · 1229 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1237,6 +1237,8 @@
 - [[_COMMUNITY_Community 1224|Community 1224]]
 - [[_COMMUNITY_Community 1225|Community 1225]]
 - [[_COMMUNITY_Community 1226|Community 1226]]
+- [[_COMMUNITY_Community 1227|Community 1227]]
+- [[_COMMUNITY_Community 1228|Community 1228]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1373,16 +1375,16 @@ Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
 ### Community 27 - "Community 27"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 28 - "Community 28"
 Cohesion: 0.33
 Nodes (9): usePOSActiveSession(), usePOSSessionComplete(), usePOSSessionCreate(), usePOSSessionHold(), usePOSSessionManager(), usePOSSessionResume(), usePOSSessionUpdate(), usePOSSessionVoid() (+1 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.18
 Nodes (0):
-
-### Community 29 - "Community 29"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 30 - "Community 30"
 Cohesion: 0.18
@@ -1861,8 +1863,8 @@ Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 149 - "Community 149"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 150 - "Community 150"
 Cohesion: 0.5
@@ -1885,24 +1887,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 155 - "Community 155"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 156 - "Community 156"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 156 - "Community 156"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 157 - "Community 157"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 158 - "Community 158"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 159 - "Community 159"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 159 - "Community 159"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 160 - "Community 160"
 Cohesion: 0.5
@@ -1917,40 +1919,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 163 - "Community 163"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 164 - "Community 164"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), parseDateTimeLocal()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 165 - "Community 165"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 166 - "Community 166"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 167 - "Community 167"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 168 - "Community 168"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 169 - "Community 169"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 170 - "Community 170"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 171 - "Community 171"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 172 - "Community 172"
 Cohesion: 0.5
@@ -1973,51 +1975,51 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 177 - "Community 177"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 178 - "Community 178"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 183 - "Community 183"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 184 - "Community 184"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 185 - "Community 185"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 186 - "Community 186"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 187 - "Community 187"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 188 - "Community 188"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 189 - "Community 189"
@@ -2045,20 +2047,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 195 - "Community 195"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 196 - "Community 196"
 Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 197 - "Community 197"
-Cohesion: 0.67
-Nodes (1): View()
+Cohesion: 1.0
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 198 - "Community 198"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.67
@@ -2073,16 +2075,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 202 - "Community 202"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 203 - "Community 203"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 204 - "Community 204"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.67
@@ -2090,11 +2092,11 @@ Nodes (0):
 
 ### Community 206 - "Community 206"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 207 - "Community 207"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.67
@@ -2102,11 +2104,11 @@ Nodes (0):
 
 ### Community 209 - "Community 209"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 210 - "Community 210"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 211 - "Community 211"
 Cohesion: 0.67
@@ -2150,75 +2152,75 @@ Nodes (0):
 
 ### Community 221 - "Community 221"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 222 - "Community 222"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 223 - "Community 223"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 224 - "Community 224"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 225 - "Community 225"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 226 - "Community 226"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 227 - "Community 227"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 228 - "Community 228"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 229 - "Community 229"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (0):
 
 ### Community 230 - "Community 230"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): AppContextMenu()
 
 ### Community 231 - "Community 231"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): Badge()
 
 ### Community 232 - "Community 232"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 233 - "Community 233"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 234 - "Community 234"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 235 - "Community 235"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 236 - "Community 236"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 237 - "Community 237"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 238 - "Community 238"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 239 - "Community 239"
 Cohesion: 0.67
@@ -2246,11 +2248,11 @@ Nodes (0):
 
 ### Community 245 - "Community 245"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 246 - "Community 246"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.67
@@ -2266,67 +2268,67 @@ Nodes (0):
 
 ### Community 250 - "Community 250"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 251 - "Community 251"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 252 - "Community 252"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 253 - "Community 253"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): App()
 
 ### Community 254 - "Community 254"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 255 - "Community 255"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 256 - "Community 256"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.67
 Nodes (1): useAppSession()
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.67
 Nodes (1): manualChunks()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 263 - "Community 263"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 264 - "Community 264"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 265 - "Community 265"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 266 - "Community 266"
 Cohesion: 0.67
@@ -2337,12 +2339,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 268 - "Community 268"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 269 - "Community 269"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 269 - "Community 269"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 270 - "Community 270"
 Cohesion: 0.67
@@ -2353,12 +2355,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 272 - "Community 272"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 273 - "Community 273"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 273 - "Community 273"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 274 - "Community 274"
 Cohesion: 0.67
@@ -2437,16 +2439,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 293 - "Community 293"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 294 - "Community 294"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 295 - "Community 295"
+### Community 294 - "Community 294"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 295 - "Community 295"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 296 - "Community 296"
 Cohesion: 1.0
@@ -2461,20 +2463,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 299 - "Community 299"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 300 - "Community 300"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 301 - "Community 301"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 302 - "Community 302"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 303 - "Community 303"
 Cohesion: 1.0
@@ -6172,1856 +6174,1866 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1227 - "Community 1227"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1228 - "Community 1228"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 302`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 303`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 304`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 305`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 306`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 307`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `authenticateHandler()`, `cashier.ts`
+- **Thin community `Community 308`** (2 nodes): `authenticateHandler()`, `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 309`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 310`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 311`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 312`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 313`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 314`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 315`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (2 nodes): `buildApprovalRequest()`, `approvalRequests.ts`
+- **Thin community `Community 316`** (2 nodes): `buildApprovalRequest()`, `approvalRequests.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 317`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (2 nodes): `registerSessions.ts`, `buildRegisterSession()`
+- **Thin community `Community 318`** (2 nodes): `registerSessions.ts`, `buildRegisterSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
+- **Thin community `Community 319`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
+- **Thin community `Community 320`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 321`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 322`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 323`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 324`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 325`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 326`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 327`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 328`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 329`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 329`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 330`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 331`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 331`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 332`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 332`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 333`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 334`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 334`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 335`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 335`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 336`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 336`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 337`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 337`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 338`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 338`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 339`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 339`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 340`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 340`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 341`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 341`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 342`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 342`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 343`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 343`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 344`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 344`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 345`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 345`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 346`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 346`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 347`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 347`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 348`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 348`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 349`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 349`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 350`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 350`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 351`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 351`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 352`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 352`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 353`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 354`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 355`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 356`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 357`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 358`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 359`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 360`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 361`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 362`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 363`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 364`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 365`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 366`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 367`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 368`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 369`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 370`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 371`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 372`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 373`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 374`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 375`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 376`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 377`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 378`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 379`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 380`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 381`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
+- **Thin community `Community 382`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 383`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 384`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 385`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 386`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 387`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
+- **Thin community `Community 388`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 389`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 390`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 391`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 392`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 393`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 394`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 395`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
+- **Thin community `Community 396`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 397`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 398`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 399`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `usePOSCashier()`, `hooks.ts`
+- **Thin community `Community 400`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
+- **Thin community `Community 401`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
+- **Thin community `Community 402`** (2 nodes): `usePOSCashier()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 403`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 404`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 405`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 406`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 407`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 408`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 409`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 410`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 411`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 412`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 413`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 414`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 415`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 416`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 417`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 418`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 419`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 420`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
+- **Thin community `Community 421`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 422`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 423`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 424`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 425`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 426`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 427`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 428`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 429`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 430`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 431`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 432`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 433`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 434`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 435`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 436`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
+- **Thin community `Community 437`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 438`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 439`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 440`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 441`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 442`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 443`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 444`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 445`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 446`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 447`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 448`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 449`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 450`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 451`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 452`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 453`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 454`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 455`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 456`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 457`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 458`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 459`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 460`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 461`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 462`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 463`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
+- **Thin community `Community 464`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 465`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 466`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
+- **Thin community `Community 467`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 468`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 469`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 470`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 471`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 472`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 473`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 474`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 475`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 476`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 477`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 478`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 479`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 480`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 481`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
+- **Thin community `Community 482`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 483`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
+- **Thin community `Community 484`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 485`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 486`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 487`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 488`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 489`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 490`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 491`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 492`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 493`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 494`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `LoginLayout()`, `_layout.tsx`
+- **Thin community `Community 495`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 496`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 497`** (2 nodes): `LoginLayout()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 498`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 499`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 500`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 501`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 502`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 503`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 504`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 505`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 506`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 507`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 508`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 509`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 510`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 511`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 512`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 513`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 514`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 515`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 516`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 517`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 518`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 519`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 520`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 521`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 522`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 523`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 524`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 525`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 526`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 527`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 528`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 529`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 530`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 531`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 532`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 533`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 534`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 535`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 536`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 537`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 538`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 539`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 540`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 541`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 542`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 543`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 544`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 545`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 546`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 547`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 548`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 549`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 550`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 551`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 552`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 553`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 554`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 555`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 556`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 557`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 558`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 559`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 560`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 561`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 562`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 563`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 564`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 565`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 566`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 567`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 568`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 569`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 570`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 571`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 572`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 573`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 574`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 575`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 576`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 577`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 578`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 579`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 580`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 581`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 582`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 583`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 584`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 585`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 586`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 587`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 588`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 589`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 590`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 591`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 592`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 593`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 594`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 595`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 596`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 597`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 598`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 599`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 600`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 601`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 602`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 603`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 604`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 605`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 606`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 607`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 608`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 609`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 610`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 611`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 612`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 613`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 614`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 615`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 616`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 617`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 618`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 619`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 620`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 621`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 622`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 623`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 624`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (1 nodes): `api.d.ts`
+- **Thin community `Community 625`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (1 nodes): `api.js`
+- **Thin community `Community 626`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 627`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (1 nodes): `server.d.ts`
+- **Thin community `Community 628`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (1 nodes): `server.js`
+- **Thin community `Community 629`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (1 nodes): `app.ts`
+- **Thin community `Community 630`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (1 nodes): `auth.config.js`
+- **Thin community `Community 631`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (1 nodes): `auth.ts`
+- **Thin community `Community 632`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (1 nodes): `countries.ts`
+- **Thin community `Community 633`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (1 nodes): `email.ts`
+- **Thin community `Community 634`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (1 nodes): `ghana.ts`
+- **Thin community `Community 635`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (1 nodes): `payment.ts`
+- **Thin community `Community 636`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (1 nodes): `crons.ts`
+- **Thin community `Community 637`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 638`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 639`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 640`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 641`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (1 nodes): `env.ts`
+- **Thin community `Community 642`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (1 nodes): `analytics.ts`
+- **Thin community `Community 643`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (1 nodes): `auth.ts`
+- **Thin community `Community 644`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 645`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (1 nodes): `categories.ts`
+- **Thin community `Community 646`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (1 nodes): `colors.ts`
+- **Thin community `Community 647`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (1 nodes): `index.ts`
+- **Thin community `Community 648`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (1 nodes): `organizations.ts`
+- **Thin community `Community 649`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (1 nodes): `products.ts`
+- **Thin community `Community 650`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (1 nodes): `stores.ts`
+- **Thin community `Community 651`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 652`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (1 nodes): `index.ts`
+- **Thin community `Community 653`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (1 nodes): `bag.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (1 nodes): `guest.ts`
+- **Thin community `Community 654`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 655`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (1 nodes): `me.ts`
+- **Thin community `Community 656`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (1 nodes): `offers.ts`
+- **Thin community `Community 657`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 658`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (1 nodes): `paystack.ts`
+- **Thin community `Community 659`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (1 nodes): `reviews.ts`
+- **Thin community `Community 660`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (1 nodes): `rewards.ts`
+- **Thin community `Community 661`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 662`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (1 nodes): `security.test.ts`
+- **Thin community `Community 663`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (1 nodes): `storefront.ts`
+- **Thin community `Community 664`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (1 nodes): `upsells.ts`
+- **Thin community `Community 665`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (1 nodes): `user.ts`
+- **Thin community `Community 666`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 667`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (1 nodes): `health.test.ts`
+- **Thin community `Community 668`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (1 nodes): `http.ts`
+- **Thin community `Community 669`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 670`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `auth.ts`
+- **Thin community `Community 671`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 672`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 673`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `categories.ts`
+- **Thin community `Community 674`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `colors.ts`
+- **Thin community `Community 675`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 676`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 677`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 678`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 679`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 680`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 681`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `organizations.ts`
+- **Thin community `Community 682`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 683`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 684`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 685`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `productSku.ts`
+- **Thin community `Community 686`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 687`** (1 nodes): `posSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 688`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 689`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 690`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 691`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 692`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 693`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 694`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 695`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `client.test.ts`
+- **Thin community `Community 696`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `config.test.ts`
+- **Thin community `Community 697`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 698`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `types.ts`
+- **Thin community `Community 699`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `approvalRequests.test.ts`
+- **Thin community `Community 700`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 701`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 702`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 703`** (1 nodes): `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `staffProfiles.test.ts`
+- **Thin community `Community 704`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `ResendOTP.ts`
+- **Thin community `Community 705`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `schema.ts`
+- **Thin community `Community 706`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 707`** (1 nodes): `staffProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 708`** (1 nodes): `ResendOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 709`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 710`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `cashier.ts`
+- **Thin community `Community 711`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `category.ts`
+- **Thin community `Community 712`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `color.ts`
+- **Thin community `Community 713`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 714`** (1 nodes): `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 715`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `index.ts`
+- **Thin community `Community 716`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 717`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `organization.ts`
+- **Thin community `Community 718`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 719`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `product.ts`
+- **Thin community `Community 720`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 721`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 722`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `store.ts`
+- **Thin community `Community 723`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 724`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 725`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 726`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `index.ts`
+- **Thin community `Community 727`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 728`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 729`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 730`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 731`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 732`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 733`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 734`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 735`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `customer.ts`
+- **Thin community `Community 736`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 737`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 738`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 739`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 740`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `index.ts`
+- **Thin community `Community 741`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `posSession.ts`
+- **Thin community `Community 742`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 743`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 744`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 745`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 746`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `index.ts`
+- **Thin community `Community 747`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 748`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 749`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 750`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 751`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 752`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `analytics.ts`
+- **Thin community `Community 753`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `bag.ts`
+- **Thin community `Community 754`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 755`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 756`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 757`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `customer.ts`
+- **Thin community `Community 758`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `guest.ts`
+- **Thin community `Community 759`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `index.ts`
+- **Thin community `Community 760`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `offer.ts`
+- **Thin community `Community 761`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 762`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 763`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `review.ts`
+- **Thin community `Community 764`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `rewards.ts`
+- **Thin community `Community 765`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 766`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 767`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 768`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 769`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 770`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 771`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 772`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `bag.ts`
+- **Thin community `Community 773`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 774`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `customer.ts`
+- **Thin community `Community 775`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `guest.ts`
+- **Thin community `Community 776`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 777`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 778`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `payment.ts`
+- **Thin community `Community 779`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 780`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `rewards.ts`
+- **Thin community `Community 781`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 782`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 783`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `users.ts`
+- **Thin community `Community 784`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `payment.ts`
+- **Thin community `Community 785`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 786`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `index.ts`
+- **Thin community `Community 787`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 788`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 789`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 790`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 791`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 792`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 793`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 794`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `constants.ts`
+- **Thin community `Community 795`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 796`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 797`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 798`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `types.ts`
+- **Thin community `Community 799`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 800`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 801`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 802`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 803`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 804`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 805`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 806`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 807`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `columns.tsx`
+- **Thin community `Community 808`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 809`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 810`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 811`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 812`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `columns.tsx`
+- **Thin community `Community 813`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 814`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 815`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `chart.tsx`
+- **Thin community `Community 816`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `columns.tsx`
+- **Thin community `Community 817`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 818`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 819`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `columns.tsx`
+- **Thin community `Community 820`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `constants.ts`
+- **Thin community `Community 821`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 822`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 823`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 824`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `data.ts`
+- **Thin community `Community 825`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `columns.tsx`
+- **Thin community `Community 826`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 827`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 828`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `columns.tsx`
+- **Thin community `Community 829`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 830`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 831`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 832`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 833`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 834`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 835`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 836`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `constants.ts`
+- **Thin community `Community 837`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 838`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 839`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 840`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `data.ts`
+- **Thin community `Community 841`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 842`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 843`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `columns.tsx`
+- **Thin community `Community 844`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 845`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 846`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 847`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 848`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 849`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `columns.tsx`
+- **Thin community `Community 850`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `constants.ts`
+- **Thin community `Community 851`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 852`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 853`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 854`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 855`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `index.tsx`
+- **Thin community `Community 856`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `columns.tsx`
+- **Thin community `Community 857`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 858`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 859`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 860`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 861`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 862`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `OperationsQueueView.tsx`
+- **Thin community `Community 863`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 864`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 865`** (1 nodes): `OperationsQueueView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 866`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 867`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 868`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `constants.ts`
+- **Thin community `Community 869`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 870`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 871`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 872`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `data.ts`
+- **Thin community `Community 873`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 874`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `constants.ts`
+- **Thin community `Community 875`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 876`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 877`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 878`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 879`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `data.ts`
+- **Thin community `Community 880`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 881`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `constants.ts`
+- **Thin community `Community 882`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 883`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 884`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 885`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 886`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `data.ts`
+- **Thin community `Community 887`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 888`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 889`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 890`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 891`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 892`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 893`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 894`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 895`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 896`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 897`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `types.ts`
+- **Thin community `Community 898`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 899`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 900`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 901`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 902`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 903`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 904`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 905`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `Products.tsx`
+- **Thin community `Community 906`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 907`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 908`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 909`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 910`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 911`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 912`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 913`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 914`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 915`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `data.ts`
+- **Thin community `Community 916`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 917`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `PromoCodePreview.tsx`
+- **Thin community `Community 918`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 919`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 920`** (1 nodes): `PromoCodePreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 921`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `columns.tsx`
+- **Thin community `Community 922`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 923`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 924`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 925`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 926`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 927`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `columns.tsx`
+- **Thin community `Community 928`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `constants.ts`
+- **Thin community `Community 929`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 930`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 931`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 932`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `data.ts`
+- **Thin community `Community 933`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `types.ts`
+- **Thin community `Community 934`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 935`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 936`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 937`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 938`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `ServiceAppointmentsView.test.tsx`
+- **Thin community `Community 939`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `ServiceCasesView.test.tsx`
+- **Thin community `Community 940`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `ServiceCatalogView.test.tsx`
+- **Thin community `Community 941`** (1 nodes): `ServiceAppointmentsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `ServiceIntakeView.test.tsx`
+- **Thin community `Community 942`** (1 nodes): `ServiceCasesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 943`** (1 nodes): `ServiceCatalogView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `index.tsx`
+- **Thin community `Community 944`** (1 nodes): `ServiceIntakeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 945`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 946`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `button.tsx`
+- **Thin community `Community 947`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 948`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `card.tsx`
+- **Thin community `Community 949`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 950`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 951`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `command.tsx`
+- **Thin community `Community 952`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 953`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 954`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 955`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `form.tsx`
+- **Thin community `Community 956`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `icons.tsx`
+- **Thin community `Community 957`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 958`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `input.tsx`
+- **Thin community `Community 959`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 960`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `popover.tsx`
+- **Thin community `Community 961`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 962`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 963`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 964`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `select.tsx`
+- **Thin community `Community 965`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `separator.tsx`
+- **Thin community `Community 966`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 967`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `switch.tsx`
+- **Thin community `Community 968`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `table.tsx`
+- **Thin community `Community 969`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 970`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 971`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 972`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 973`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 974`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 975`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 976`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `columns.tsx`
+- **Thin community `Community 977`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `constants.ts`
+- **Thin community `Community 978`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 979`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 980`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 981`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `data.ts`
+- **Thin community `Community 982`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 983`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 984`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `columns.tsx`
+- **Thin community `Community 985`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 986`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 987`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 988`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 989`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 990`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 991`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 992`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 993`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 994`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 995`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `index.ts`
+- **Thin community `Community 996`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `config.ts`
+- **Thin community `Community 997`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 998`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 999`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1000`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `aws.ts`
+- **Thin community `Community 1001`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `constants.ts`
+- **Thin community `Community 1002`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `countries.ts`
+- **Thin community `Community 1003`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1004`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1005`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `constants.ts`
+- **Thin community `Community 1006`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1007`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1008`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `category.ts`
+- **Thin community `Community 1009`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `product.ts`
+- **Thin community `Community 1010`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `store.ts`
+- **Thin community `Community 1011`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1012`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `user.ts`
+- **Thin community `Community 1013`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1014`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1015`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1016`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1017`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `index.tsx`
+- **Thin community `Community 1018`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `index.tsx`
+- **Thin community `Community 1019`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1020`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1021`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1022`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1023`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1024`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1025`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `index.tsx`
+- **Thin community `Community 1026`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1027`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1028`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1029`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `home.tsx`
+- **Thin community `Community 1030`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1031`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1032`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1033`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `index.tsx`
+- **Thin community `Community 1034`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `index.tsx`
+- **Thin community `Community 1035`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1036`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1037`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1038`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `index.tsx`
+- **Thin community `Community 1039`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1040`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1041`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1042`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1043`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1044`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1045`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1046`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `index.tsx`
+- **Thin community `Community 1047`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1048`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1049`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1050`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1051`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1052`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `index.tsx`
+- **Thin community `Community 1053`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `index.tsx`
+- **Thin community `Community 1054`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `new.tsx`
+- **Thin community `Community 1055`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1056`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1057`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1058`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1059`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `index.tsx`
+- **Thin community `Community 1060`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `new.tsx`
+- **Thin community `Community 1061`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1062`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1063`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1064`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1065`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1066`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1067`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1068`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `index.tsx`
+- **Thin community `Community 1069`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1070`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1071`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1072`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1073`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `posStore.ts`
+- **Thin community `Community 1074`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1075`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1076`** (1 nodes): `posStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1077`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1078`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1079`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1080`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1081`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1082`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1083`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1084`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1085`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1086`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `setup.ts`
+- **Thin community `Community 1087`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1088`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1089`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `types.ts`
+- **Thin community `Community 1090`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1091`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1092`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1093`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1094`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1095`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1096`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `types.ts`
+- **Thin community `Community 1097`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1098`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `client.tsx`
+- **Thin community `Community 1099`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1100`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1101`** (1 nodes): `client.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1102`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1103`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1104`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1105`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1106`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1107`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `schema.ts`
+- **Thin community `Community 1108`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1109`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1110`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1111`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1112`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1113`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1114`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1115`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1116`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1117`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `types.ts`
+- **Thin community `Community 1118`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1119`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1120`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1121`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1122`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1123`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1124`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1125`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `constants.ts`
+- **Thin community `Community 1126`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1127`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `About.tsx`
+- **Thin community `Community 1128`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1129`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1130`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1131`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1132`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1133`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1134`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1135`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1136`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1137`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `types.ts`
+- **Thin community `Community 1138`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1139`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1140`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1141`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1142`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1143`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1144`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1145`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1146`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1147`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1148`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `button.tsx`
+- **Thin community `Community 1149`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `card.tsx`
+- **Thin community `Community 1150`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1151`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `command.tsx`
+- **Thin community `Community 1152`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1153`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1154`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1155`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `form.tsx`
+- **Thin community `Community 1156`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1157`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1158`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1159`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1160`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `input.tsx`
+- **Thin community `Community 1161`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `label.tsx`
+- **Thin community `Community 1162`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1163`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1164`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1165`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `index.ts`
+- **Thin community `Community 1166`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `types.ts`
+- **Thin community `Community 1167`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1168`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1169`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1170`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1171`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `select.tsx`
+- **Thin community `Community 1172`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1173`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1174`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `table.tsx`
+- **Thin community `Community 1175`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1176`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1177`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1178`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1179`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1180`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `config.ts`
+- **Thin community `Community 1181`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1182`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1183`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1184`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `constants.ts`
+- **Thin community `Community 1185`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `countries.ts`
+- **Thin community `Community 1186`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1187`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1188`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1189`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1190`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `index.ts`
+- **Thin community `Community 1191`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `store.ts`
+- **Thin community `Community 1192`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `bag.ts`
+- **Thin community `Community 1193`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1194`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `category.ts`
+- **Thin community `Community 1195`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `organization.ts`
+- **Thin community `Community 1196`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `product.ts`
+- **Thin community `Community 1197`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `store.ts`
+- **Thin community `Community 1198`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1199`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `user.ts`
+- **Thin community `Community 1200`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `states.ts`
+- **Thin community `Community 1201`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1202`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1203`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1204`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1205`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1206`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1207`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1208`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `index.tsx`
+- **Thin community `Community 1209`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1210`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1211`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1212`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1213`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1214`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1215`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1216`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `index.tsx`
+- **Thin community `Community 1217`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1218`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `ssr.tsx`
+- **Thin community `Community 1219`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1220`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1221`** (1 nodes): `ssr.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1222`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `index.js`
+- **Thin community `Community 1223`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1224`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1225`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1226`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1227`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1228`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -712,6 +712,30 @@
       "weight": 1
     },
     {
+      "_src": "customerengagementevents_recordstorefrontcustomermilestone",
+      "_tgt": "customerengagementevents_findexistingcustomerprofileid",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "customerengagementevents_findexistingcustomerprofileid",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L77",
+      "target": "customerengagementevents_recordstorefrontcustomermilestone",
+      "weight": 1
+    },
+    {
+      "_src": "customerengagementevents_recordstorefrontcustomermilestone",
+      "_tgt": "customerengagementevents_getstoreorganizationid",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "customerengagementevents_getstoreorganizationid",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L75",
+      "target": "customerengagementevents_recordstorefrontcustomermilestone",
+      "weight": 1
+    },
+    {
       "_src": "customerobservabilitytimelinedata_getoperationaleventjourney",
       "_tgt": "customerobservabilitytimelinedata_getnonemptystring",
       "confidence": "EXTRACTED",
@@ -5339,7 +5363,7 @@
       "relation": "calls",
       "source": "offers_isduplicate",
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L107",
+      "source_location": "L108",
       "target": "offers_createoffer",
       "weight": 1
     },
@@ -5351,7 +5375,7 @@
       "relation": "calls",
       "source": "offers_updatestorefrontactoremail",
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L134",
+      "source_location": "L135",
       "target": "offers_createoffer",
       "weight": 1
     },
@@ -8807,7 +8831,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
-      "source_location": "L5",
+      "source_location": "L8",
       "target": "customerbehaviortimeline_test_createqueryctx",
       "weight": 1
     },
@@ -9025,6 +9049,54 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L14",
       "target": "bag_loadbagwithitems",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
+      "_tgt": "customerengagementevents_test_createmutationctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
+      "source_location": "L5",
+      "target": "customerengagementevents_test_createmutationctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
+      "_tgt": "customerengagementevents_findexistingcustomerprofileid",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L21",
+      "target": "customerengagementevents_findexistingcustomerprofileid",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
+      "_tgt": "customerengagementevents_getstoreorganizationid",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L63",
+      "target": "customerengagementevents_getstoreorganizationid",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
+      "_tgt": "customerengagementevents_recordstorefrontcustomermilestone",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L71",
+      "target": "customerengagementevents_recordstorefrontcustomermilestone",
       "weight": 1
     },
     {
@@ -9479,7 +9551,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_offers_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L88",
+      "source_location": "L89",
       "target": "offers_createoffer",
       "weight": 1
     },
@@ -9491,7 +9563,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_offers_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L685",
+      "source_location": "L765",
       "target": "offers_getupsellproducts",
       "weight": 1
     },
@@ -9503,7 +9575,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_offers_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L36",
+      "source_location": "L37",
       "target": "offers_isduplicate",
       "weight": 1
     },
@@ -9515,7 +9587,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_offers_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L59",
+      "source_location": "L60",
       "target": "offers_updatestorefrontactoremail",
       "weight": 1
     },
@@ -9637,6 +9709,18 @@
       "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
       "source_location": "L17",
       "target": "reviews_getstorefrontactorbyid",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_rewards_ts",
+      "_tgt": "rewards_formatpointslabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_rewards_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L7",
+      "target": "rewards_formatpointslabel",
       "weight": 1
     },
     {
@@ -32463,6 +32547,24 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
+      "label": "ThemeContext.tsx",
+      "norm_label": "themecontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
       "norm_label": "useorganizationmodal.tsx",
@@ -32470,7 +32572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
@@ -32479,7 +32581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -32488,7 +32590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -32497,7 +32599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -32506,7 +32608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -32515,7 +32617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -32524,30 +32626,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
       "norm_label": "displayamounts.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1008,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
-      "label": "productUtils.test.ts",
-      "norm_label": "productutils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
       "source_location": "L1"
     },
     {
@@ -32598,6 +32682,24 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
+      "label": "productUtils.test.ts",
+      "norm_label": "productutils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1012,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
@@ -32605,7 +32707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -32614,7 +32716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -32623,7 +32725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -32632,7 +32734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -32641,7 +32743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -32650,7 +32752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -32659,30 +32761,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
       "norm_label": "__root.tsx",
       "source_file": "packages/athena-webapp/src/routes/__root.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1018,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
       "source_location": "L1"
     },
     {
@@ -32733,6 +32817,24 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1022,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -32740,7 +32842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -32749,7 +32851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -32758,7 +32860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -32767,7 +32869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -32776,7 +32878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -32785,7 +32887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -32794,30 +32896,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
       "norm_label": "checkout-sessions.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1028,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
-      "label": "configuration.index.tsx",
-      "norm_label": "configuration.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
-      "label": "dashboard.index.tsx",
-      "norm_label": "dashboard.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
       "source_location": "L1"
     },
     {
@@ -32868,6 +32952,24 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
+      "label": "configuration.index.tsx",
+      "norm_label": "configuration.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
+      "label": "dashboard.index.tsx",
+      "norm_label": "dashboard.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1032,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
       "norm_label": "home.tsx",
@@ -32875,7 +32977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -32884,7 +32986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -32893,7 +32995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -32902,7 +33004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
@@ -32911,7 +33013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -32920,7 +33022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -32929,30 +33031,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
       "norm_label": "cancelled.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1038,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
-      "label": "completed.index.tsx",
-      "norm_label": "completed.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
       "source_location": "L1"
     },
     {
@@ -33003,6 +33087,24 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
+      "label": "completed.index.tsx",
+      "norm_label": "completed.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1042,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
       "norm_label": "open.index.tsx",
@@ -33010,7 +33112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -33019,7 +33121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -33028,7 +33130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -33037,7 +33139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -33046,7 +33148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -33055,7 +33157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -33064,30 +33166,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1048,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
-      "label": "register.index.tsx",
-      "norm_label": "register.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
-      "label": "settings.index.tsx",
-      "norm_label": "settings.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
       "source_location": "L1"
     },
     {
@@ -33138,6 +33222,24 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
+      "label": "register.index.tsx",
+      "norm_label": "register.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
+      "label": "settings.index.tsx",
+      "norm_label": "settings.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1052,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
       "norm_label": "$transactionid.tsx",
@@ -33145,7 +33247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -33154,7 +33256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -33163,7 +33265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -33172,7 +33274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -33181,7 +33283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -33190,7 +33292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -33199,30 +33301,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1058,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
-      "label": "unresolved.tsx",
-      "norm_label": "unresolved.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
-      "label": "$promoCodeSlug.tsx",
-      "norm_label": "$promocodeslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
       "source_location": "L1"
     },
     {
@@ -33273,6 +33357,24 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
+      "label": "unresolved.tsx",
+      "norm_label": "unresolved.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
+      "label": "$promoCodeSlug.tsx",
+      "norm_label": "$promocodeslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1062,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -33280,7 +33382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -33289,7 +33391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -33298,7 +33400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -33307,7 +33409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -33316,7 +33418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -33325,7 +33427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -33334,30 +33436,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
       "norm_label": "intake.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1068,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
-      "label": "users.$userId.tsx",
-      "norm_label": "users.$userid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
       "source_location": "L1"
     },
     {
@@ -33408,6 +33492,24 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
+      "label": "users.$userId.tsx",
+      "norm_label": "users.$userid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1072,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
       "norm_label": "join-team.index.tsx",
@@ -33415,7 +33517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -33424,7 +33526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -33433,7 +33535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -33442,7 +33544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_posstore_ts",
       "label": "posStore.ts",
@@ -33451,7 +33553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -33460,7 +33562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -33469,30 +33571,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
       "norm_label": "introduction.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1078,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
-      "label": "introduction-content.test.tsx",
-      "norm_label": "introduction-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
-      "label": "introduction-content.tsx",
-      "norm_label": "introduction-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
       "source_location": "L1"
     },
     {
@@ -33543,6 +33627,24 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
+      "label": "introduction-content.test.tsx",
+      "norm_label": "introduction-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
+      "label": "introduction-content.tsx",
+      "norm_label": "introduction-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1082,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
       "norm_label": "adminshell.stories.tsx",
@@ -33550,7 +33652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -33559,7 +33661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -33568,7 +33670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -33577,7 +33679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -33586,7 +33688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -33595,7 +33697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -33604,30 +33706,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
       "norm_label": "setup.ts",
       "source_file": "packages/athena-webapp/src/test/setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1088,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
-      "label": "usePrint.test.ts",
-      "norm_label": "useprint.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_tailwind_config_js",
-      "label": "tailwind.config.js",
-      "norm_label": "tailwind.config.js",
-      "source_file": "packages/athena-webapp/tailwind.config.js",
       "source_location": "L1"
     },
     {
@@ -33637,7 +33721,7 @@
       "label": "createOffer()",
       "norm_label": "createoffer()",
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L88"
+      "source_location": "L89"
     },
     {
       "community": 109,
@@ -33646,7 +33730,7 @@
       "label": "getUpsellProducts()",
       "norm_label": "getupsellproducts()",
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L685"
+      "source_location": "L765"
     },
     {
       "community": 109,
@@ -33655,7 +33739,7 @@
       "label": "isDuplicate()",
       "norm_label": "isduplicate()",
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L36"
+      "source_location": "L37"
     },
     {
       "community": 109,
@@ -33664,7 +33748,7 @@
       "label": "updateStoreFrontActorEmail()",
       "norm_label": "updatestorefrontactoremail()",
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L59"
+      "source_location": "L60"
     },
     {
       "community": 109,
@@ -33678,6 +33762,24 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
+      "label": "usePrint.test.ts",
+      "norm_label": "useprint.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
+      "id": "packages_athena_webapp_tailwind_config_js",
+      "label": "tailwind.config.js",
+      "norm_label": "tailwind.config.js",
+      "source_file": "packages/athena-webapp/tailwind.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1092,
+      "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -33685,7 +33787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -33694,7 +33796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -33703,7 +33805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -33712,7 +33814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -33721,7 +33823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -33730,7 +33832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -33739,30 +33841,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/storefront-webapp/src/api/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1098,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
-      "label": "HeartIconFilled.tsx",
-      "norm_label": "hearticonfilled.tsx",
-      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_client_tsx",
-      "label": "client.tsx",
-      "norm_label": "client.tsx",
-      "source_file": "packages/storefront-webapp/src/client.tsx",
       "source_location": "L1"
     },
     {
@@ -33993,6 +34077,24 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
+      "label": "HeartIconFilled.tsx",
+      "norm_label": "hearticonfilled.tsx",
+      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_client_tsx",
+      "label": "client.tsx",
+      "norm_label": "client.tsx",
+      "source_file": "packages/storefront-webapp/src/client.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1102,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
       "norm_label": "defaultcatchboundary.tsx",
@@ -34000,7 +34102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -34009,7 +34111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -34018,7 +34120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -34027,7 +34129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -34036,7 +34138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -34045,7 +34147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -34054,30 +34156,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
       "norm_label": "customerinfosection.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1108,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
-      "label": "schema.ts",
-      "norm_label": "schema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
-      "label": "DeliveryDetailsSection.tsx",
-      "norm_label": "deliverydetailssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
       "source_location": "L1"
     },
     {
@@ -34128,6 +34212,24 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
+      "label": "schema.ts",
+      "norm_label": "schema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
+      "label": "DeliveryDetailsSection.tsx",
+      "norm_label": "deliverydetailssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1112,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
       "norm_label": "checkoutstorage.test.ts",
@@ -34135,7 +34237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -34144,7 +34246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -34153,7 +34255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -34162,7 +34264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -34171,7 +34273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -34180,7 +34282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -34189,30 +34291,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
       "norm_label": "weborderschema.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1118,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.test.ts",
       "source_location": "L1"
     },
     {
@@ -34263,6 +34347,24 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1122,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
       "norm_label": "productfilterbar.tsx",
@@ -34270,7 +34372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -34279,7 +34381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -34288,7 +34390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -34297,7 +34399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -34306,7 +34408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -34315,7 +34417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -34324,30 +34426,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
       "norm_label": "navbarconstants.ts",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1128,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
-      "label": "About.tsx",
-      "norm_label": "about.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
-      "label": "AboutProduct.tsx",
-      "norm_label": "aboutproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
       "source_location": "L1"
     },
     {
@@ -34398,6 +34482,24 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
+      "label": "About.tsx",
+      "norm_label": "about.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
+      "label": "AboutProduct.tsx",
+      "norm_label": "aboutproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1132,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
       "norm_label": "productactions.test.tsx",
@@ -34405,7 +34507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -34414,7 +34516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -34423,7 +34525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -34432,7 +34534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -34441,7 +34543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -34450,7 +34552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -34459,30 +34561,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
       "norm_label": "successmessage.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1138,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
-      "label": "SavedBag.tsx",
-      "norm_label": "savedbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
       "source_location": "L1"
     },
     {
@@ -34533,6 +34617,24 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
+      "label": "SavedBag.tsx",
+      "norm_label": "savedbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1142,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
       "norm_label": "savedicon.tsx",
@@ -34540,7 +34642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -34549,7 +34651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -34558,7 +34660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -34567,7 +34669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -34576,7 +34678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -34585,7 +34687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -34594,30 +34696,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
       "norm_label": "alert.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1148,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
-      "label": "breadcrumb.tsx",
-      "norm_label": "breadcrumb.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
-      "label": "button.tsx",
-      "norm_label": "button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
       "source_location": "L1"
     },
     {
@@ -34668,6 +34752,24 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
+      "label": "breadcrumb.tsx",
+      "norm_label": "breadcrumb.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
+      "label": "button.tsx",
+      "norm_label": "button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1152,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
       "norm_label": "card.tsx",
@@ -34675,7 +34777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -34684,7 +34786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -34693,7 +34795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -34702,7 +34804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -34711,7 +34813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -34720,7 +34822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -34729,30 +34831,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
       "norm_label": "icons.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1158,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
-      "label": "image-with-fallback.tsx",
-      "norm_label": "image-with-fallback.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
-      "label": "input-otp.tsx",
-      "norm_label": "input-otp.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1"
     },
     {
@@ -34803,6 +34887,24 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
+      "label": "image-with-fallback.tsx",
+      "norm_label": "image-with-fallback.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
+      "label": "input-otp.tsx",
+      "norm_label": "input-otp.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1162,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
       "norm_label": "input-with-end-button.tsx",
@@ -34810,7 +34912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -34819,7 +34921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -34828,7 +34930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -34837,7 +34939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -34846,7 +34948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -34855,7 +34957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -34864,30 +34966,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1168,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
-      "label": "navigation-menu.tsx",
-      "norm_label": "navigation-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
-      "label": "popover.tsx",
-      "norm_label": "popover.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
       "source_location": "L1"
     },
     {
@@ -34938,6 +35022,24 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
+      "label": "navigation-menu.tsx",
+      "norm_label": "navigation-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
+      "label": "popover.tsx",
+      "norm_label": "popover.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1172,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
@@ -34945,7 +35047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -34954,7 +35056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -34963,7 +35065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -34972,7 +35074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -34981,7 +35083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -34990,7 +35092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -34999,30 +35101,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
       "norm_label": "textarea.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1178,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
-      "label": "toggle.tsx",
-      "norm_label": "toggle.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1"
     },
     {
@@ -35073,6 +35157,24 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
+      "label": "toggle.tsx",
+      "norm_label": "toggle.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1182,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
       "norm_label": "tooltip.tsx",
@@ -35080,7 +35182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -35089,7 +35191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -35098,7 +35200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -35107,7 +35209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -35116,7 +35218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -35125,7 +35227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -35134,30 +35236,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
       "norm_label": "feeutils.test.ts",
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1188,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/storefront-webapp/src/lib/ghana.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
-      "label": "ghanaRegions.ts",
-      "norm_label": "ghanaregions.ts",
-      "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1"
     },
     {
@@ -35208,6 +35292,24 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/storefront-webapp/src/lib/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
+      "label": "ghanaRegions.ts",
+      "norm_label": "ghanaregions.ts",
+      "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1192,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
       "norm_label": "maintenanceutils.test.ts",
@@ -35215,7 +35317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -35224,7 +35326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -35233,7 +35335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -35242,7 +35344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -35251,7 +35353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -35260,7 +35362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -35269,30 +35371,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1198,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
       "source_location": "L1"
     },
     {
@@ -35505,6 +35589,24 @@
     {
       "community": 1200,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1202,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
@@ -35512,7 +35614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -35521,7 +35623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -35530,7 +35632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -35539,7 +35641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -35548,7 +35650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -35557,7 +35659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -35566,30 +35668,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
       "norm_label": "__root.tsx",
       "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1208,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
-      "label": "$orderItemId.review.tsx",
-      "norm_label": "$orderitemid.review.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
       "source_location": "L1"
     },
     {
@@ -35640,6 +35724,24 @@
     {
       "community": 1210,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
+      "label": "$orderItemId.review.tsx",
+      "norm_label": "$orderitemid.review.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1211,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1212,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
       "norm_label": "$subcategoryslug.tsx",
@@ -35647,7 +35749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -35656,7 +35758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -35665,7 +35767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -35674,7 +35776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -35683,7 +35785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -35692,7 +35794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -35701,30 +35803,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1218,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
-      "label": "pending.tsx",
-      "norm_label": "pending.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_ssr_tsx",
-      "label": "ssr.tsx",
-      "norm_label": "ssr.tsx",
-      "source_file": "packages/storefront-webapp/src/ssr.tsx",
       "source_location": "L1"
     },
     {
@@ -35775,6 +35859,24 @@
     {
       "community": 1220,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
+      "label": "pending.tsx",
+      "norm_label": "pending.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_ssr_tsx",
+      "label": "ssr.tsx",
+      "norm_label": "ssr.tsx",
+      "source_file": "packages/storefront-webapp/src/ssr.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1222,
+      "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
       "norm_label": "tailwind.config.js",
@@ -35782,7 +35884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -35791,7 +35893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -35800,7 +35902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -35809,7 +35911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1226,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -35818,7 +35920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1227,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -35827,7 +35929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1228,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -37224,38 +37326,38 @@
     {
       "community": 149,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
-      "label": "returnExchangeOperations.test.ts",
-      "norm_label": "returnexchangeoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "id": "customerengagementevents_findexistingcustomerprofileid",
+      "label": "findExistingCustomerProfileId()",
+      "norm_label": "findexistingcustomerprofileid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "customerengagementevents_getstoreorganizationid",
+      "label": "getStoreOrganizationId()",
+      "norm_label": "getstoreorganizationid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "customerengagementevents_recordstorefrontcustomermilestone",
+      "label": "recordStoreFrontCustomerMilestone()",
+      "norm_label": "recordstorefrontcustomermilestone()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
+      "label": "customerEngagementEvents.ts",
+      "norm_label": "customerengagementevents.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createorderitem",
-      "label": "createOrderItem()",
-      "norm_label": "createorderitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createreplacement",
-      "label": "createReplacement()",
-      "norm_label": "createreplacement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L9"
     },
     {
       "community": 15,
@@ -37413,6 +37515,42 @@
     {
       "community": 150,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "label": "returnExchangeOperations.test.ts",
+      "norm_label": "returnexchangeoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createorderitem",
+      "label": "createOrderItem()",
+      "norm_label": "createorderitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createreplacement",
+      "label": "createReplacement()",
+      "norm_label": "createreplacement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
       "norm_label": "attributesmanager()",
@@ -37420,7 +37558,7 @@
       "source_location": "L228"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -37429,7 +37567,7 @@
       "source_location": "L45"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -37438,7 +37576,7 @@
       "source_location": "L26"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -37447,7 +37585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -37456,7 +37594,7 @@
       "source_location": "L55"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -37465,7 +37603,7 @@
       "source_location": "L32"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -37474,7 +37612,7 @@
       "source_location": "L210"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -37483,7 +37621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -37492,7 +37630,7 @@
       "source_location": "L51"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -37501,7 +37639,7 @@
       "source_location": "L26"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -37510,7 +37648,7 @@
       "source_location": "L290"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -37519,7 +37657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -37528,7 +37666,7 @@
       "source_location": "L48"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -37537,7 +37675,7 @@
       "source_location": "L88"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -37546,7 +37684,7 @@
       "source_location": "L14"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -37555,7 +37693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -37564,7 +37702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -37573,7 +37711,7 @@
       "source_location": "L15"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -37582,7 +37720,7 @@
       "source_location": "L28"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -37591,7 +37729,7 @@
       "source_location": "L19"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -37600,7 +37738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -37609,7 +37747,7 @@
       "source_location": "L52"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -37618,7 +37756,7 @@
       "source_location": "L3"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -37627,7 +37765,7 @@
       "source_location": "L90"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -37636,7 +37774,7 @@
       "source_location": "L86"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -37645,7 +37783,7 @@
       "source_location": "L76"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -37654,7 +37792,7 @@
       "source_location": "L52"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -37663,7 +37801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -37672,7 +37810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -37681,7 +37819,7 @@
       "source_location": "L67"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -37690,7 +37828,7 @@
       "source_location": "L90"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -37699,7 +37837,7 @@
       "source_location": "L73"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -37708,7 +37846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -37717,7 +37855,7 @@
       "source_location": "L103"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -37726,49 +37864,13 @@
       "source_location": "L95"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
       "norm_label": "toggleitem()",
       "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
       "source_location": "L81"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "newtransactionview_handlequickstart",
-      "label": "handleQuickStart()",
-      "norm_label": "handlequickstart()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "newtransactionview_handlestarttransaction",
-      "label": "handleStartTransaction()",
-      "norm_label": "handlestarttransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L68"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "newtransactionview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
-      "label": "NewTransactionView.tsx",
-      "norm_label": "newtransactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 16,
@@ -37926,6 +38028,42 @@
     {
       "community": 160,
       "file_type": "code",
+      "id": "newtransactionview_handlequickstart",
+      "label": "handleQuickStart()",
+      "norm_label": "handlequickstart()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "newtransactionview_handlestarttransaction",
+      "label": "handleStartTransaction()",
+      "norm_label": "handlestarttransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L68"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "newtransactionview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
+      "label": "NewTransactionView.tsx",
+      "norm_label": "newtransactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
       "norm_label": "possettingsview.tsx",
@@ -37933,7 +38071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -37942,7 +38080,7 @@
       "source_location": "L247"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -37951,7 +38089,7 @@
       "source_location": "L284"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -37960,7 +38098,7 @@
       "source_location": "L166"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -37969,7 +38107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -37978,7 +38116,7 @@
       "source_location": "L63"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -37987,7 +38125,7 @@
       "source_location": "L54"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -37996,7 +38134,7 @@
       "source_location": "L11"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -38005,7 +38143,7 @@
       "source_location": "L16"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -38014,7 +38152,7 @@
       "source_location": "L35"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -38023,7 +38161,7 @@
       "source_location": "L6"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -38032,7 +38170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "label": "ServiceAppointmentsView.tsx",
@@ -38041,7 +38179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "serviceappointmentsview_handlesubmit",
       "label": "handleSubmit()",
@@ -38050,7 +38188,7 @@
       "source_location": "L115"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "serviceappointmentsview_parsedatetimelocal",
       "label": "parseDateTimeLocal()",
@@ -38059,7 +38197,7 @@
       "source_location": "L77"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "serviceappointmentsview_withsavestate",
       "label": "withSaveState()",
@@ -38068,7 +38206,7 @@
       "source_location": "L441"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -38077,7 +38215,7 @@
       "source_location": "L75"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -38086,7 +38224,7 @@
       "source_location": "L82"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -38095,7 +38233,7 @@
       "source_location": "L93"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -38104,7 +38242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -38113,7 +38251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -38122,7 +38260,7 @@
       "source_location": "L15"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -38131,7 +38269,7 @@
       "source_location": "L28"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -38140,7 +38278,7 @@
       "source_location": "L54"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -38149,7 +38287,7 @@
       "source_location": "L66"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -38158,7 +38296,7 @@
       "source_location": "L121"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -38167,7 +38305,7 @@
       "source_location": "L74"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -38176,7 +38314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -38185,7 +38323,7 @@
       "source_location": "L51"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -38194,7 +38332,7 @@
       "source_location": "L92"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -38203,7 +38341,7 @@
       "source_location": "L16"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -38212,7 +38350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -38221,7 +38359,7 @@
       "source_location": "L13"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -38230,7 +38368,7 @@
       "source_location": "L46"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -38239,49 +38377,13 @@
       "source_location": "L21"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
       "norm_label": "offers.ts",
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "stores_getallstores",
-      "label": "getAllStores()",
-      "norm_label": "getallstores()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "stores_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "stores_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L20"
     },
     {
       "community": 17,
@@ -38430,6 +38532,42 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "stores_getallstores",
+      "label": "getAllStores()",
+      "norm_label": "getallstores()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "stores_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "stores_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -38437,7 +38575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -38446,7 +38584,7 @@
       "source_location": "L11"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -38455,7 +38593,7 @@
       "source_location": "L9"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -38464,7 +38602,7 @@
       "source_location": "L25"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -38473,7 +38611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -38482,7 +38620,7 @@
       "source_location": "L50"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -38491,7 +38629,7 @@
       "source_location": "L92"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -38500,7 +38638,7 @@
       "source_location": "L74"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -38509,7 +38647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -38518,7 +38656,7 @@
       "source_location": "L62"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -38527,7 +38665,7 @@
       "source_location": "L109"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -38536,7 +38674,7 @@
       "source_location": "L177"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -38545,7 +38683,7 @@
       "source_location": "L18"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -38554,7 +38692,7 @@
       "source_location": "L52"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -38563,7 +38701,7 @@
       "source_location": "L68"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -38572,7 +38710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -38581,7 +38719,7 @@
       "source_location": "L68"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -38590,7 +38728,7 @@
       "source_location": "L26"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -38599,7 +38737,7 @@
       "source_location": "L7"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -38608,7 +38746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -38617,7 +38755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -38626,7 +38764,7 @@
       "source_location": "L43"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -38635,7 +38773,7 @@
       "source_location": "L13"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -38644,7 +38782,7 @@
       "source_location": "L88"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -38653,7 +38791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -38662,7 +38800,7 @@
       "source_location": "L111"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -38671,7 +38809,7 @@
       "source_location": "L66"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -38680,7 +38818,7 @@
       "source_location": "L127"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -38689,7 +38827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -38698,7 +38836,7 @@
       "source_location": "L115"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -38707,7 +38845,7 @@
       "source_location": "L105"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -38716,7 +38854,7 @@
       "source_location": "L110"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -38725,7 +38863,7 @@
       "source_location": "L121"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -38734,7 +38872,7 @@
       "source_location": "L26"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -38743,48 +38881,12 @@
       "source_location": "L71"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "bootstrap_bootstrapcheckout",
-      "label": "bootstrapCheckout()",
-      "norm_label": "bootstrapcheckout()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "bootstrap_createbootstraptoken",
-      "label": "createBootstrapToken()",
-      "norm_label": "createbootstraptoken()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "bootstrap_createmarker",
-      "label": "createMarker()",
-      "norm_label": "createmarker()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
-      "label": "bootstrap.ts",
-      "norm_label": "bootstrap.ts",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L1"
     },
     {
@@ -38934,6 +39036,42 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "bootstrap_bootstrapcheckout",
+      "label": "bootstrapCheckout()",
+      "norm_label": "bootstrapcheckout()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "bootstrap_createbootstraptoken",
+      "label": "createBootstrapToken()",
+      "norm_label": "createbootstraptoken()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "bootstrap_createmarker",
+      "label": "createMarker()",
+      "norm_label": "createmarker()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
+      "label": "bootstrap.ts",
+      "norm_label": "bootstrap.ts",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
       "norm_label": "createinmemoryredis()",
@@ -38941,7 +39079,7 @@
       "source_location": "L33"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -38950,7 +39088,7 @@
       "source_location": "L6"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -38959,7 +39097,7 @@
       "source_location": "L25"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -38968,7 +39106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -38977,7 +39115,7 @@
       "source_location": "L17"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -38986,7 +39124,7 @@
       "source_location": "L11"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -38995,7 +39133,7 @@
       "source_location": "L24"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -39004,7 +39142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -39013,7 +39151,7 @@
       "source_location": "L20"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -39022,7 +39160,7 @@
       "source_location": "L65"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -39031,7 +39169,7 @@
       "source_location": "L14"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -39040,7 +39178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -39049,7 +39187,7 @@
       "source_location": "L126"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -39058,7 +39196,7 @@
       "source_location": "L130"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -39067,7 +39205,7 @@
       "source_location": "L543"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -39076,7 +39214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -39085,7 +39223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -39094,7 +39232,7 @@
       "source_location": "L8"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -39103,7 +39241,7 @@
       "source_location": "L79"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -39112,7 +39250,7 @@
       "source_location": "L61"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -39121,7 +39259,7 @@
       "source_location": "L49"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -39130,7 +39268,7 @@
       "source_location": "L17"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -39139,7 +39277,7 @@
       "source_location": "L11"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -39148,7 +39286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -39157,7 +39295,7 @@
       "source_location": "L26"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -39166,7 +39304,7 @@
       "source_location": "L72"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -39175,7 +39313,7 @@
       "source_location": "L36"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -39184,7 +39322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -39193,7 +39331,7 @@
       "source_location": "L90"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -39202,7 +39340,7 @@
       "source_location": "L88"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -39211,7 +39349,7 @@
       "source_location": "L89"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -39220,7 +39358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -39229,7 +39367,7 @@
       "source_location": "L98"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -39238,39 +39376,12 @@
       "source_location": "L33"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
       "norm_label": "discountcode.tsx",
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "discountreminder_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "discountreminder_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
-      "label": "DiscountReminder.tsx",
-      "norm_label": "discountreminder.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L1"
     },
     {
@@ -39411,6 +39522,33 @@
     {
       "community": 190,
       "file_type": "code",
+      "id": "discountreminder_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "discountreminder_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
+      "label": "DiscountReminder.tsx",
+      "norm_label": "discountreminder.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
       "norm_label": "utils.ts",
@@ -39418,7 +39556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -39427,7 +39565,7 @@
       "source_location": "L5"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -39436,7 +39574,7 @@
       "source_location": "L12"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -39445,7 +39583,7 @@
       "source_location": "L43"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -39454,7 +39592,7 @@
       "source_location": "L11"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -39463,7 +39601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
       "label": "staffProfiles.ts",
@@ -39472,7 +39610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "staffprofiles_buildfullname",
       "label": "buildFullName()",
@@ -39481,7 +39619,7 @@
       "source_location": "L12"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "staffprofiles_buildroleassignmentdrafts",
       "label": "buildRoleAssignmentDrafts()",
@@ -39490,7 +39628,7 @@
       "source_location": "L17"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -39499,7 +39637,7 @@
       "source_location": "L7"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -39508,7 +39646,7 @@
       "source_location": "L109"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -39517,7 +39655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -39526,7 +39664,7 @@
       "source_location": "L16"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -39535,7 +39673,7 @@
       "source_location": "L42"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -39544,7 +39682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -39553,7 +39691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -39562,7 +39700,7 @@
       "source_location": "L23"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -39571,7 +39709,7 @@
       "source_location": "L16"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -39580,7 +39718,7 @@
       "source_location": "L7"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -39589,7 +39727,7 @@
       "source_location": "L14"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -39598,7 +39736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -39607,7 +39745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -39616,7 +39754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -39625,7 +39763,7 @@
       "source_location": "L4"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -39634,7 +39772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -39643,40 +39781,13 @@
       "source_location": "L18"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
       "norm_label": "productavailabilityview()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
-      "label": "SheetProvider.tsx",
-      "norm_label": "sheetprovider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "sheetprovider_sheetprovider",
-      "label": "SheetProvider()",
-      "norm_label": "sheetprovider()",
-      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "sheetprovider_usesheet",
-      "label": "useSheet()",
-      "norm_label": "usesheet()",
-      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
-      "source_location": "L11"
     },
     {
       "community": 2,
@@ -40113,6 +40224,33 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
+      "label": "SheetProvider.tsx",
+      "norm_label": "sheetprovider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "sheetprovider_sheetprovider",
+      "label": "SheetProvider()",
+      "norm_label": "sheetprovider()",
+      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "sheetprovider_usesheet",
+      "label": "useSheet()",
+      "norm_label": "usesheet()",
+      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
       "norm_label": "wigtype.tsx",
@@ -40120,7 +40258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -40129,7 +40267,7 @@
       "source_location": "L21"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -40138,7 +40276,7 @@
       "source_location": "L8"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -40147,7 +40285,7 @@
       "source_location": "L21"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -40156,7 +40294,7 @@
       "source_location": "L13"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -40165,7 +40303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -40174,7 +40312,7 @@
       "source_location": "L100"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -40183,7 +40321,7 @@
       "source_location": "L10"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -40192,7 +40330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -40201,7 +40339,7 @@
       "source_location": "L100"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -40210,7 +40348,7 @@
       "source_location": "L10"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -40219,7 +40357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -40228,7 +40366,7 @@
       "source_location": "L15"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -40237,7 +40375,7 @@
       "source_location": "L39"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -40246,7 +40384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -40255,7 +40393,7 @@
       "source_location": "L48"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -40264,7 +40402,7 @@
       "source_location": "L56"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -40273,7 +40411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -40282,7 +40420,7 @@
       "source_location": "L3"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -40291,7 +40429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -40300,7 +40438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -40309,7 +40447,7 @@
       "source_location": "L53"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -40318,7 +40456,7 @@
       "source_location": "L65"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -40327,7 +40465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -40336,7 +40474,7 @@
       "source_location": "L47"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -40345,40 +40483,13 @@
       "source_location": "L53"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
       "norm_label": "featuredsection.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
-      "label": "VideoPlayer.tsx",
-      "norm_label": "videoplayer.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
-      "label": "VideoPlayer.tsx",
-      "norm_label": "videoplayer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "videoplayer_videoplayer",
-      "label": "VideoPlayer()",
-      "norm_label": "videoplayer()",
-      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
-      "source_location": "L9"
     },
     {
       "community": 21,
@@ -40509,6 +40620,33 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
+      "label": "VideoPlayer.tsx",
+      "norm_label": "videoplayer.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
+      "label": "VideoPlayer.tsx",
+      "norm_label": "videoplayer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "videoplayer_videoplayer",
+      "label": "VideoPlayer()",
+      "norm_label": "videoplayer()",
+      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
       "norm_label": "pickupdetailsview.tsx",
@@ -40516,7 +40654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -40525,7 +40663,7 @@
       "source_location": "L67"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -40534,7 +40672,7 @@
       "source_location": "L9"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
@@ -40543,7 +40681,7 @@
       "source_location": "L99"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -40552,7 +40690,7 @@
       "source_location": "L94"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -40561,7 +40699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -40570,7 +40708,7 @@
       "source_location": "L59"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -40579,7 +40717,7 @@
       "source_location": "L55"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -40588,7 +40726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -40597,7 +40735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -40606,7 +40744,7 @@
       "source_location": "L20"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -40615,7 +40753,7 @@
       "source_location": "L26"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -40624,7 +40762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -40633,7 +40771,7 @@
       "source_location": "L65"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -40642,7 +40780,7 @@
       "source_location": "L20"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -40651,7 +40789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -40660,7 +40798,7 @@
       "source_location": "L16"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -40669,7 +40807,7 @@
       "source_location": "L60"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -40678,7 +40816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -40687,7 +40825,7 @@
       "source_location": "L45"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -40696,7 +40834,7 @@
       "source_location": "L19"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -40705,7 +40843,7 @@
       "source_location": "L128"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -40714,7 +40852,7 @@
       "source_location": "L40"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -40723,7 +40861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -40732,7 +40870,7 @@
       "source_location": "L24"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -40741,39 +40879,12 @@
       "source_location": "L20"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
       "norm_label": "color-picker.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "currency_provider_currencyprovider",
-      "label": "CurrencyProvider()",
-      "norm_label": "currencyprovider()",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "currency_provider_usestorecurrency",
-      "label": "useStoreCurrency()",
-      "norm_label": "usestorecurrency()",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
-      "label": "currency-provider.tsx",
-      "norm_label": "currency-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1"
     },
     {
@@ -40896,6 +41007,33 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "currency_provider_currencyprovider",
+      "label": "CurrencyProvider()",
+      "norm_label": "currencyprovider()",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "currency_provider_usestorecurrency",
+      "label": "useStoreCurrency()",
+      "norm_label": "usestorecurrency()",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
+      "label": "currency-provider.tsx",
+      "norm_label": "currency-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
       "norm_label": "serviceintakeview.tsx",
@@ -40903,7 +41041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "serviceintakeview_handlecreateintake",
       "label": "handleCreateIntake()",
@@ -40912,7 +41050,7 @@
       "source_location": "L238"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -40921,7 +41059,7 @@
       "source_location": "L69"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -40930,7 +41068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -40939,7 +41077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -40948,7 +41086,7 @@
       "source_location": "L3"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -40957,7 +41095,7 @@
       "source_location": "L9"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -40966,7 +41104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -40975,7 +41113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -40984,7 +41122,7 @@
       "source_location": "L3"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -40993,7 +41131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -41002,7 +41140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -41011,7 +41149,7 @@
       "source_location": "L3"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -41020,7 +41158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -41029,7 +41167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -41038,7 +41176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -41047,7 +41185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -41056,7 +41194,7 @@
       "source_location": "L3"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -41065,7 +41203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -41074,7 +41212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -41083,7 +41221,7 @@
       "source_location": "L3"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -41092,7 +41230,7 @@
       "source_location": "L4"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -41101,7 +41239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -41110,7 +41248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -41119,7 +41257,7 @@
       "source_location": "L104"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -41128,39 +41266,12 @@
       "source_location": "L36"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
       "norm_label": "feesview.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "app_context_menu_appcontextmenu",
-      "label": "AppContextMenu()",
-      "norm_label": "appcontextmenu()",
-      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
-      "label": "app-context-menu.tsx",
-      "norm_label": "app-context-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/app-context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
-      "label": "app-context-menu.tsx",
-      "norm_label": "app-context-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1"
     },
     {
@@ -41283,6 +41394,33 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "app_context_menu_appcontextmenu",
+      "label": "AppContextMenu()",
+      "norm_label": "appcontextmenu()",
+      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
+      "label": "app-context-menu.tsx",
+      "norm_label": "app-context-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/app-context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
+      "label": "app-context-menu.tsx",
+      "norm_label": "app-context-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
       "norm_label": "badge()",
@@ -41290,7 +41428,7 @@
       "source_location": "L30"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -41299,7 +41437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -41308,7 +41446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -41317,7 +41455,7 @@
       "source_location": "L9"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -41326,7 +41464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -41335,7 +41473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -41344,7 +41482,7 @@
       "source_location": "L38"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -41353,7 +41491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -41362,7 +41500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -41371,7 +41509,7 @@
       "source_location": "L20"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -41380,7 +41518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -41389,7 +41527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -41398,7 +41536,7 @@
       "source_location": "L12"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -41407,7 +41545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -41416,7 +41554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -41425,7 +41563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -41434,7 +41572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -41443,7 +41581,7 @@
       "source_location": "L3"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -41452,7 +41590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -41461,7 +41599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -41470,7 +41608,7 @@
       "source_location": "L6"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -41479,7 +41617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -41488,7 +41626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -41497,7 +41635,7 @@
       "source_location": "L3"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -41506,7 +41644,7 @@
       "source_location": "L44"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -41515,40 +41653,13 @@
       "source_location": "L19"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
       "norm_label": "activitysummarycards.tsx",
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
-      "label": "TimelineEventCard.tsx",
-      "norm_label": "timelineeventcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "timelineeventcard_formatobservabilitylabel",
-      "label": "formatObservabilityLabel()",
-      "norm_label": "formatobservabilitylabel()",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
-      "source_location": "L159"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "timelineeventcard_loadmore",
-      "label": "loadMore()",
-      "norm_label": "loadmore()",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
-      "source_location": "L195"
     },
     {
       "community": 24,
@@ -41670,6 +41781,33 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
+      "label": "TimelineEventCard.tsx",
+      "norm_label": "timelineeventcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "timelineeventcard_formatobservabilitylabel",
+      "label": "formatObservabilityLabel()",
+      "norm_label": "formatobservabilitylabel()",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
+      "source_location": "L159"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "timelineeventcard_loadmore",
+      "label": "loadMore()",
+      "norm_label": "loadmore()",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
+      "source_location": "L195"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
       "norm_label": "useractivity.tsx",
@@ -41677,7 +41815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -41686,7 +41824,7 @@
       "source_location": "L22"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -41695,7 +41833,7 @@
       "source_location": "L45"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -41704,7 +41842,7 @@
       "source_location": "L24"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -41713,7 +41851,7 @@
       "source_location": "L38"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -41722,7 +41860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -41731,7 +41869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -41740,7 +41878,7 @@
       "source_location": "L23"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -41749,7 +41887,7 @@
       "source_location": "L51"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -41758,7 +41896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -41767,7 +41905,7 @@
       "source_location": "L54"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -41776,7 +41914,7 @@
       "source_location": "L282"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -41785,7 +41923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -41794,7 +41932,7 @@
       "source_location": "L12"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -41803,7 +41941,7 @@
       "source_location": "L37"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -41812,7 +41950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -41821,7 +41959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -41830,7 +41968,7 @@
       "source_location": "L4"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -41839,7 +41977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -41848,7 +41986,7 @@
       "source_location": "L9"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -41857,7 +41995,7 @@
       "source_location": "L50"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -41866,7 +42004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -41875,7 +42013,7 @@
       "source_location": "L6"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -41884,7 +42022,7 @@
       "source_location": "L31"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -41893,7 +42031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -41902,40 +42040,13 @@
       "source_location": "L5"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
       "norm_label": "usegetunresolvedproducts()",
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L31"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposoperations_ts",
-      "label": "usePOSOperations.ts",
-      "norm_label": "useposoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "useposoperations_useposoperations",
-      "label": "usePOSOperations()",
-      "norm_label": "useposoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "useposoperations_useposstate",
-      "label": "usePOSState()",
-      "norm_label": "useposstate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
-      "source_location": "L580"
     },
     {
       "community": 25,
@@ -42048,6 +42159,33 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useposoperations_ts",
+      "label": "usePOSOperations.ts",
+      "norm_label": "useposoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "useposoperations_useposoperations",
+      "label": "usePOSOperations()",
+      "norm_label": "useposoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "useposoperations_useposstate",
+      "label": "usePOSState()",
+      "norm_label": "useposstate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
+      "source_location": "L580"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
       "norm_label": "isinmaintenancemode()",
@@ -42055,7 +42193,7 @@
       "source_location": "L7"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -42064,7 +42202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -42073,7 +42211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -42082,7 +42220,7 @@
       "source_location": "L3"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -42091,7 +42229,7 @@
       "source_location": "L10"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -42100,7 +42238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -42109,7 +42247,7 @@
       "source_location": "L38"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -42118,7 +42256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -42127,7 +42265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -42136,7 +42274,7 @@
       "source_location": "L18"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -42145,7 +42283,7 @@
       "source_location": "L38"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -42154,7 +42292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -42163,7 +42301,7 @@
       "source_location": "L127"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -42172,7 +42310,7 @@
       "source_location": "L106"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -42181,7 +42319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -42190,7 +42328,7 @@
       "source_location": "L66"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -42199,7 +42337,7 @@
       "source_location": "L20"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -42208,7 +42346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -42217,7 +42355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -42226,7 +42364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -42235,7 +42373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_session_ts",
       "label": "session.ts",
@@ -42244,7 +42382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_session_ts",
       "label": "session.ts",
@@ -42253,7 +42391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "session_useappsession",
       "label": "useAppSession()",
@@ -42262,7 +42400,7 @@
       "source_location": "L8"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -42271,7 +42409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -42280,40 +42418,13 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
       "norm_label": "createversionchecker()",
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L16"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vite_config_ts",
-      "label": "vite.config.ts",
-      "norm_label": "vite.config.ts",
-      "source_file": "packages/athena-webapp/vite.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vite_config_ts",
-      "label": "vite.config.ts",
-      "norm_label": "vite.config.ts",
-      "source_file": "packages/storefront-webapp/vite.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "vite_config_manualchunks",
-      "label": "manualChunks()",
-      "norm_label": "manualchunks()",
-      "source_file": "packages/storefront-webapp/vite.config.ts",
-      "source_location": "L19"
     },
     {
       "community": 26,
@@ -42417,6 +42528,33 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_athena_webapp_vite_config_ts",
+      "label": "vite.config.ts",
+      "norm_label": "vite.config.ts",
+      "source_file": "packages/athena-webapp/vite.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_vite_config_ts",
+      "label": "vite.config.ts",
+      "norm_label": "vite.config.ts",
+      "source_file": "packages/storefront-webapp/vite.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "vite_config_manualchunks",
+      "label": "manualChunks()",
+      "norm_label": "manualchunks()",
+      "source_file": "packages/storefront-webapp/vite.config.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
       "norm_label": "logout()",
@@ -42424,7 +42562,7 @@
       "source_location": "L32"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -42433,7 +42571,7 @@
       "source_location": "L3"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -42442,7 +42580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -42451,7 +42589,7 @@
       "source_location": "L7"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -42460,7 +42598,7 @@
       "source_location": "L5"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -42469,7 +42607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -42478,7 +42616,7 @@
       "source_location": "L6"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -42487,7 +42625,7 @@
       "source_location": "L18"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -42496,7 +42634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -42505,7 +42643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -42514,7 +42652,7 @@
       "source_location": "L3"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -42523,7 +42661,7 @@
       "source_location": "L5"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -42532,7 +42670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -42541,7 +42679,7 @@
       "source_location": "L18"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -42550,7 +42688,7 @@
       "source_location": "L23"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -42559,7 +42697,7 @@
       "source_location": "L22"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -42568,7 +42706,7 @@
       "source_location": "L55"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -42577,7 +42715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -42586,7 +42724,7 @@
       "source_location": "L77"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -42595,7 +42733,7 @@
       "source_location": "L11"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -42604,7 +42742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -42613,7 +42751,7 @@
       "source_location": "L11"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -42622,7 +42760,7 @@
       "source_location": "L22"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -42631,7 +42769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -42640,7 +42778,7 @@
       "source_location": "L110"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -42649,7 +42787,7 @@
       "source_location": "L89"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -42658,772 +42796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 269,
-      "file_type": "code",
-      "id": "checkoutstorage_loadcheckoutstate",
-      "label": "loadCheckoutState()",
-      "norm_label": "loadcheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "checkoutstorage_savecheckoutstate",
-      "label": "saveCheckoutState()",
-      "norm_label": "savecheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
-      "label": "checkoutStorage.ts",
-      "norm_label": "checkoutstorage.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L1"
-    },
-    {
       "community": 27,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usepossessions_ts",
-      "label": "usePOSSessions.ts",
-      "norm_label": "usepossessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "usepossessions_useposactivesession",
-      "label": "usePOSActiveSession()",
-      "norm_label": "useposactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "usepossessions_usepossession",
-      "label": "usePOSSession()",
-      "norm_label": "usepossession()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "usepossessions_usepossessioncomplete",
-      "label": "usePOSSessionComplete()",
-      "norm_label": "usepossessioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "usepossessions_usepossessioncreate",
-      "label": "usePOSSessionCreate()",
-      "norm_label": "usepossessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "usepossessions_usepossessionhold",
-      "label": "usePOSSessionHold()",
-      "norm_label": "usepossessionhold()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "usepossessions_usepossessionmanager",
-      "label": "usePOSSessionManager()",
-      "norm_label": "usepossessionmanager()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "usepossessions_usepossessionresume",
-      "label": "usePOSSessionResume()",
-      "norm_label": "usepossessionresume()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "usepossessions_usepossessionupdate",
-      "label": "usePOSSessionUpdate()",
-      "norm_label": "usepossessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "usepossessions_usepossessionvoid",
-      "label": "usePOSSessionVoid()",
-      "norm_label": "usepossessionvoid()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "usepossessions_useposstoresessions",
-      "label": "usePOSStoreSessions()",
-      "norm_label": "useposstoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 270,
-      "file_type": "code",
-      "id": "footer_enablecategories",
-      "label": "enableCategories()",
-      "norm_label": "enablecategories()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 270,
-      "file_type": "code",
-      "id": "footer_linkgroup",
-      "label": "LinkGroup()",
-      "norm_label": "linkgroup()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 270,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
-      "label": "Footer.tsx",
-      "norm_label": "footer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 271,
-      "file_type": "code",
-      "id": "featuredproductssection_featuredproductssection",
-      "label": "FeaturedProductsSection()",
-      "norm_label": "featuredproductssection()",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 271,
-      "file_type": "code",
-      "id": "featuredproductssection_featuredsection",
-      "label": "FeaturedSection()",
-      "norm_label": "featuredsection()",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 271,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
-      "label": "FeaturedProductsSection.tsx",
-      "norm_label": "featuredproductssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 272,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
-      "label": "PromoAlert.tsx",
-      "norm_label": "promoalert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 272,
-      "file_type": "code",
-      "id": "promoalert_getpromoalertcopy",
-      "label": "getPromoAlertCopy()",
-      "norm_label": "getpromoalertcopy()",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 272,
-      "file_type": "code",
-      "id": "promoalert_promoalert",
-      "label": "PromoAlert()",
-      "norm_label": "promoalert()",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L59"
-    },
-    {
-      "community": 273,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
-      "label": "RewardsAlert.tsx",
-      "norm_label": "rewardsalert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 273,
-      "file_type": "code",
-      "id": "rewardsalert_handleshopnow",
-      "label": "handleShopNow()",
-      "norm_label": "handleshopnow()",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 273,
-      "file_type": "code",
-      "id": "rewardsalert_onrewardsalertclose",
-      "label": "onRewardsAlertClose()",
-      "norm_label": "onrewardsalertclose()",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 274,
-      "file_type": "code",
-      "id": "navigationbar_navigationbar",
-      "label": "NavigationBar()",
-      "norm_label": "navigationbar()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 274,
-      "file_type": "code",
-      "id": "navigationbar_storecategoriessubmenu",
-      "label": "StoreCategoriesSubmenu()",
-      "norm_label": "storecategoriessubmenu()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 274,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
-      "label": "NavigationBar.tsx",
-      "norm_label": "navigationbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 275,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
-      "label": "ProductAttribute.tsx",
-      "norm_label": "productattribute.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 275,
-      "file_type": "code",
-      "id": "productattribute_findsize",
-      "label": "findSize()",
-      "norm_label": "findsize()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 275,
-      "file_type": "code",
-      "id": "productattribute_handleclick",
-      "label": "handleClick()",
-      "norm_label": "handleclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
-      "label": "ReviewEditor.tsx",
-      "norm_label": "revieweditor.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "revieweditor_handleformdatachange",
-      "label": "handleFormDataChange()",
-      "norm_label": "handleformdatachange()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "revieweditor_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L157"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
-      "label": "UpsellModalForm.tsx",
-      "norm_label": "upsellmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "upsellmodalform_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "upsellmodalform_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
-      "label": "WelcomeBackModal.tsx",
-      "norm_label": "welcomebackmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "welcomebackmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "welcomebackmodal_handlesuccess",
-      "label": "handleSuccess()",
-      "norm_label": "handlesuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
-      "label": "WelcomeBackModalForm.tsx",
-      "norm_label": "welcomebackmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "welcomebackmodalform_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L51"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "welcomebackmodalform_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L36"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "navigationbarprovider_navigationbarprovider",
-      "label": "NavigationBarProvider()",
-      "norm_label": "navigationbarprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "navigationbarprovider_usenavigationbarcontext",
-      "label": "useNavigationBarContext()",
-      "norm_label": "usenavigationbarcontext()",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L39"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
-      "label": "NavigationBarProvider.tsx",
-      "norm_label": "navigationbarprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 281,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
-      "label": "StoreContext.tsx",
-      "norm_label": "storecontext.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 281,
-      "file_type": "code",
-      "id": "storecontext_storeprovider",
-      "label": "StoreProvider()",
-      "norm_label": "storeprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 281,
-      "file_type": "code",
-      "id": "storecontext_usestorecontext",
-      "label": "useStoreContext()",
-      "norm_label": "usestorecontext()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 282,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
-      "label": "StorefrontObservabilityProvider.tsx",
-      "norm_label": "storefrontobservabilityprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 282,
-      "file_type": "code",
-      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "label": "StorefrontObservabilityProvider()",
-      "norm_label": "storefrontobservabilityprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 282,
-      "file_type": "code",
-      "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "label": "useStorefrontObservability()",
-      "norm_label": "usestorefrontobservability()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 283,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
-      "label": "useProductDiscount.ts",
-      "norm_label": "useproductdiscount.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 283,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscount",
-      "label": "useProductDiscount()",
-      "norm_label": "useproductdiscount()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 283,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscounts",
-      "label": "useProductDiscounts()",
-      "norm_label": "useproductdiscounts()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
-      "label": "useShoppingBag.ts",
-      "norm_label": "useshoppingbag.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "useshoppingbag_isunavailableproductlist",
-      "label": "isUnavailableProductList()",
-      "norm_label": "isunavailableproductlist()",
-      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
-      "source_location": "L556"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "useshoppingbag_useshoppingbag",
-      "label": "useShoppingBag()",
-      "norm_label": "useshoppingbag()",
-      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 285,
-      "file_type": "code",
-      "id": "index_getordermessage",
-      "label": "getOrderMessage()",
-      "norm_label": "getordermessage()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L429"
-    },
-    {
-      "community": 285,
-      "file_type": "code",
-      "id": "index_getpaymenttext",
-      "label": "getPaymentText()",
-      "norm_label": "getpaymenttext()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 285,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
-      "label": "review.tsx",
-      "norm_label": "review.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "review_getordermessage",
-      "label": "getOrderMessage()",
-      "norm_label": "getordermessage()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L250"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "review_ordernavigation",
-      "label": "OrderNavigation()",
-      "norm_label": "ordernavigation()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "account_accountbeforeload",
-      "label": "accountBeforeLoad()",
-      "norm_label": "accountbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "account_handleonsubmitform",
-      "label": "handleOnSubmitForm()",
-      "norm_label": "handleonsubmitform()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
-      "label": "account.tsx",
-      "norm_label": "account.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "login_loginbeforeload",
-      "label": "loginBeforeLoad()",
-      "norm_label": "loginbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "login_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "label": "login.tsx",
-      "norm_label": "login.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
-      "label": "verify.index.tsx",
-      "norm_label": "verify.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "verify_index_verify",
-      "label": "Verify()",
-      "norm_label": "verify()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "verify_index_verifycheckoutsessionpayment",
-      "label": "VerifyCheckoutSessionPayment()",
-      "norm_label": "verifycheckoutsessionpayment()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L107"
-    },
-    {
-      "community": 29,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_utils_ts",
       "label": "utils.ts",
@@ -43432,7 +42805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 29,
+      "community": 27,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_ts",
       "label": "utils.ts",
@@ -43441,7 +42814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 29,
+      "community": 27,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
       "label": "utils.ts",
@@ -43450,7 +42823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 29,
+      "community": 27,
       "file_type": "code",
       "id": "utils_formatdeliveryaddress",
       "label": "formatDeliveryAddress()",
@@ -43459,7 +42832,7 @@
       "source_location": "L74"
     },
     {
-      "community": 29,
+      "community": 27,
       "file_type": "code",
       "id": "utils_getamountpaidfororder",
       "label": "getAmountPaidForOrder()",
@@ -43468,7 +42841,7 @@
       "source_location": "L128"
     },
     {
-      "community": 29,
+      "community": 27,
       "file_type": "code",
       "id": "utils_getdiscountvalue",
       "label": "getDiscountValue()",
@@ -43477,7 +42850,7 @@
       "source_location": "L17"
     },
     {
-      "community": 29,
+      "community": 27,
       "file_type": "code",
       "id": "utils_getorderamount",
       "label": "getOrderAmount()",
@@ -43486,7 +42859,7 @@
       "source_location": "L51"
     },
     {
-      "community": 29,
+      "community": 27,
       "file_type": "code",
       "id": "utils_getorderstate",
       "label": "getOrderState()",
@@ -43495,7 +42868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 29,
+      "community": 27,
       "file_type": "code",
       "id": "utils_getpickupactionstate",
       "label": "getPickupActionState()",
@@ -43504,7 +42877,7 @@
       "source_location": "L61"
     },
     {
-      "community": 29,
+      "community": 27,
       "file_type": "code",
       "id": "utils_getpotentialpoints",
       "label": "getPotentialPoints()",
@@ -43513,7 +42886,7 @@
       "source_location": "L107"
     },
     {
-      "community": 29,
+      "community": 27,
       "file_type": "code",
       "id": "utils_getproductdiscountvalue",
       "label": "getProductDiscountValue()",
@@ -43522,7 +42895,772 @@
       "source_location": "L75"
     },
     {
+      "community": 270,
+      "file_type": "code",
+      "id": "checkoutstorage_loadcheckoutstate",
+      "label": "loadCheckoutState()",
+      "norm_label": "loadcheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "checkoutstorage_savecheckoutstate",
+      "label": "saveCheckoutState()",
+      "norm_label": "savecheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
+      "label": "checkoutStorage.ts",
+      "norm_label": "checkoutstorage.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
+      "id": "footer_enablecategories",
+      "label": "enableCategories()",
+      "norm_label": "enablecategories()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
+      "id": "footer_linkgroup",
+      "label": "LinkGroup()",
+      "norm_label": "linkgroup()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
+      "label": "Footer.tsx",
+      "norm_label": "footer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 272,
+      "file_type": "code",
+      "id": "featuredproductssection_featuredproductssection",
+      "label": "FeaturedProductsSection()",
+      "norm_label": "featuredproductssection()",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 272,
+      "file_type": "code",
+      "id": "featuredproductssection_featuredsection",
+      "label": "FeaturedSection()",
+      "norm_label": "featuredsection()",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 272,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
+      "label": "FeaturedProductsSection.tsx",
+      "norm_label": "featuredproductssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
+      "label": "PromoAlert.tsx",
+      "norm_label": "promoalert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "promoalert_getpromoalertcopy",
+      "label": "getPromoAlertCopy()",
+      "norm_label": "getpromoalertcopy()",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "promoalert_promoalert",
+      "label": "PromoAlert()",
+      "norm_label": "promoalert()",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
+      "label": "RewardsAlert.tsx",
+      "norm_label": "rewardsalert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "rewardsalert_handleshopnow",
+      "label": "handleShopNow()",
+      "norm_label": "handleshopnow()",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "rewardsalert_onrewardsalertclose",
+      "label": "onRewardsAlertClose()",
+      "norm_label": "onrewardsalertclose()",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 275,
+      "file_type": "code",
+      "id": "navigationbar_navigationbar",
+      "label": "NavigationBar()",
+      "norm_label": "navigationbar()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 275,
+      "file_type": "code",
+      "id": "navigationbar_storecategoriessubmenu",
+      "label": "StoreCategoriesSubmenu()",
+      "norm_label": "storecategoriessubmenu()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 275,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
+      "label": "NavigationBar.tsx",
+      "norm_label": "navigationbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 276,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
+      "label": "ProductAttribute.tsx",
+      "norm_label": "productattribute.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 276,
+      "file_type": "code",
+      "id": "productattribute_findsize",
+      "label": "findSize()",
+      "norm_label": "findsize()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 276,
+      "file_type": "code",
+      "id": "productattribute_handleclick",
+      "label": "handleClick()",
+      "norm_label": "handleclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 277,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
+      "label": "ReviewEditor.tsx",
+      "norm_label": "revieweditor.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 277,
+      "file_type": "code",
+      "id": "revieweditor_handleformdatachange",
+      "label": "handleFormDataChange()",
+      "norm_label": "handleformdatachange()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 277,
+      "file_type": "code",
+      "id": "revieweditor_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L157"
+    },
+    {
+      "community": 278,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
+      "label": "UpsellModalForm.tsx",
+      "norm_label": "upsellmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 278,
+      "file_type": "code",
+      "id": "upsellmodalform_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 278,
+      "file_type": "code",
+      "id": "upsellmodalform_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
+      "label": "WelcomeBackModal.tsx",
+      "norm_label": "welcomebackmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "welcomebackmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "welcomebackmodal_handlesuccess",
+      "label": "handleSuccess()",
+      "norm_label": "handlesuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usepossessions_ts",
+      "label": "usePOSSessions.ts",
+      "norm_label": "usepossessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "usepossessions_useposactivesession",
+      "label": "usePOSActiveSession()",
+      "norm_label": "useposactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "usepossessions_usepossession",
+      "label": "usePOSSession()",
+      "norm_label": "usepossession()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "usepossessions_usepossessioncomplete",
+      "label": "usePOSSessionComplete()",
+      "norm_label": "usepossessioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "usepossessions_usepossessioncreate",
+      "label": "usePOSSessionCreate()",
+      "norm_label": "usepossessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "usepossessions_usepossessionhold",
+      "label": "usePOSSessionHold()",
+      "norm_label": "usepossessionhold()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "usepossessions_usepossessionmanager",
+      "label": "usePOSSessionManager()",
+      "norm_label": "usepossessionmanager()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "usepossessions_usepossessionresume",
+      "label": "usePOSSessionResume()",
+      "norm_label": "usepossessionresume()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L137"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "usepossessions_usepossessionupdate",
+      "label": "usePOSSessionUpdate()",
+      "norm_label": "usepossessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "usepossessions_usepossessionvoid",
+      "label": "usePOSSessionVoid()",
+      "norm_label": "usepossessionvoid()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "usepossessions_useposstoresessions",
+      "label": "usePOSStoreSessions()",
+      "norm_label": "useposstoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
+      "label": "WelcomeBackModalForm.tsx",
+      "norm_label": "welcomebackmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "welcomebackmodalform_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "welcomebackmodalform_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "navigationbarprovider_navigationbarprovider",
+      "label": "NavigationBarProvider()",
+      "norm_label": "navigationbarprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "navigationbarprovider_usenavigationbarcontext",
+      "label": "useNavigationBarContext()",
+      "norm_label": "usenavigationbarcontext()",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
+      "label": "NavigationBarProvider.tsx",
+      "norm_label": "navigationbarprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
+      "label": "StoreContext.tsx",
+      "norm_label": "storecontext.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "storecontext_storeprovider",
+      "label": "StoreProvider()",
+      "norm_label": "storeprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "storecontext_usestorecontext",
+      "label": "useStoreContext()",
+      "norm_label": "usestorecontext()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 283,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
+      "label": "StorefrontObservabilityProvider.tsx",
+      "norm_label": "storefrontobservabilityprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 283,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
+      "label": "StorefrontObservabilityProvider()",
+      "norm_label": "storefrontobservabilityprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 283,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_usestorefrontobservability",
+      "label": "useStorefrontObservability()",
+      "norm_label": "usestorefrontobservability()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 284,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
+      "label": "useProductDiscount.ts",
+      "norm_label": "useproductdiscount.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 284,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscount",
+      "label": "useProductDiscount()",
+      "norm_label": "useproductdiscount()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 284,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscounts",
+      "label": "useProductDiscounts()",
+      "norm_label": "useproductdiscounts()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
+      "label": "useShoppingBag.ts",
+      "norm_label": "useshoppingbag.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "useshoppingbag_isunavailableproductlist",
+      "label": "isUnavailableProductList()",
+      "norm_label": "isunavailableproductlist()",
+      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
+      "source_location": "L556"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "useshoppingbag_useshoppingbag",
+      "label": "useShoppingBag()",
+      "norm_label": "useshoppingbag()",
+      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "index_getordermessage",
+      "label": "getOrderMessage()",
+      "norm_label": "getordermessage()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L429"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "index_getpaymenttext",
+      "label": "getPaymentText()",
+      "norm_label": "getpaymenttext()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
+      "label": "review.tsx",
+      "norm_label": "review.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "review_getordermessage",
+      "label": "getOrderMessage()",
+      "norm_label": "getordermessage()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L250"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "review_ordernavigation",
+      "label": "OrderNavigation()",
+      "norm_label": "ordernavigation()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 288,
+      "file_type": "code",
+      "id": "account_accountbeforeload",
+      "label": "accountBeforeLoad()",
+      "norm_label": "accountbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 288,
+      "file_type": "code",
+      "id": "account_handleonsubmitform",
+      "label": "handleOnSubmitForm()",
+      "norm_label": "handleonsubmitform()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 288,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
+      "label": "account.tsx",
+      "norm_label": "account.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "login_loginbeforeload",
+      "label": "loginBeforeLoad()",
+      "norm_label": "loginbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "login_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_login_tsx",
+      "label": "login.tsx",
+      "norm_label": "login.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L1"
+    },
+    {
       "community": 290,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
+      "label": "verify.index.tsx",
+      "norm_label": "verify.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "verify_index_verify",
+      "label": "Verify()",
+      "norm_label": "verify()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "verify_index_verifycheckoutsessionpayment",
+      "label": "VerifyCheckoutSessionPayment()",
+      "norm_label": "verifycheckoutsessionpayment()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L107"
+    },
+    {
+      "community": 291,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -43531,7 +43669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -43540,7 +43678,7 @@
       "source_location": "L161"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -43549,7 +43687,7 @@
       "source_location": "L66"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -43558,7 +43696,7 @@
       "source_location": "L11"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -43567,7 +43705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -43576,7 +43714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -43585,7 +43723,7 @@
       "source_location": "L16"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -43594,7 +43732,7 @@
       "source_location": "L10"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -43603,7 +43741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -43612,7 +43750,7 @@
       "source_location": "L17"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -43621,7 +43759,7 @@
       "source_location": "L11"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -43630,7 +43768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -43639,7 +43777,7 @@
       "source_location": "L21"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -43648,7 +43786,7 @@
       "source_location": "L15"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -43657,7 +43795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -43666,7 +43804,7 @@
       "source_location": "L48"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -43675,7 +43813,7 @@
       "source_location": "L42"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -43684,7 +43822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -43693,7 +43831,7 @@
       "source_location": "L16"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -43702,7 +43840,7 @@
       "source_location": "L10"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -43711,7 +43849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -43720,7 +43858,7 @@
       "source_location": "L19"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -43729,7 +43867,7 @@
       "source_location": "L13"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -43738,7 +43876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -43747,7 +43885,7 @@
       "source_location": "L16"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -43756,39 +43894,12 @@
       "source_location": "L10"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
       "norm_label": "harness-self-review.test.ts",
       "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "harness_test_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "harness_test_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "scripts_harness_test_test_ts",
-      "label": "harness-test.test.ts",
-      "norm_label": "harness-test.test.ts",
-      "source_file": "scripts/harness-test.test.ts",
       "source_location": "L1"
     },
     {
@@ -44172,6 +44283,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "harness_test_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "harness_test_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "scripts_harness_test_test_ts",
+      "label": "harness-test.test.ts",
+      "norm_label": "harness-test.test.ts",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
       "norm_label": "log()",
@@ -44179,7 +44317,7 @@
       "source_location": "L26"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -44188,7 +44326,7 @@
       "source_location": "L18"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -44197,7 +44335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
@@ -44206,7 +44344,7 @@
       "source_location": "L45"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
       "label": "stageTrackedGraphifyArtifacts()",
@@ -44215,7 +44353,7 @@
       "source_location": "L20"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -44224,7 +44362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -44233,7 +44371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -44242,7 +44380,7 @@
       "source_location": "L8"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -44251,7 +44389,7 @@
       "source_location": "L10"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -44260,7 +44398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -44269,7 +44407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -44278,7 +44416,7 @@
       "source_location": "L18"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -44287,7 +44425,7 @@
       "source_location": "L10"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -44296,7 +44434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -44305,7 +44443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -44314,7 +44452,7 @@
       "source_location": "L6"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "cashier_authenticatehandler",
       "label": "authenticateHandler()",
@@ -44323,7 +44461,7 @@
       "source_location": "L239"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -44332,7 +44470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -44341,31 +44479,13 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
       "norm_label": "readprojectfile()",
       "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
       "source_location": "L8"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
-      "label": "sessionQueryIndexes.test.ts",
-      "norm_label": "sessionqueryindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "sessionqueryindexes_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
-      "source_location": "L6"
     },
     {
       "community": 31,
@@ -44469,6 +44589,24 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
+      "label": "sessionQueryIndexes.test.ts",
+      "norm_label": "sessionqueryindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "sessionqueryindexes_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
       "norm_label": "stores.ts",
@@ -44476,7 +44614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -44485,7 +44623,7 @@
       "source_location": "L27"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -44494,7 +44632,7 @@
       "source_location": "L4"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -44503,7 +44641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -44512,7 +44650,7 @@
       "source_location": "L3"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -44521,7 +44659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -44530,7 +44668,7 @@
       "source_location": "L3"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -44539,7 +44677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -44548,7 +44686,7 @@
       "source_location": "L6"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -44557,7 +44695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "approvalrequests_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -44566,7 +44704,7 @@
       "source_location": "L5"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "label": "approvalRequests.ts",
@@ -44575,7 +44713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -44584,7 +44722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -44593,7 +44731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_ts",
       "label": "registerSessions.ts",
@@ -44602,7 +44740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "registersessions_buildregistersession",
       "label": "buildRegisterSession()",
@@ -44611,7 +44749,7 @@
       "source_location": "L5"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
@@ -44620,31 +44758,13 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
       "norm_label": "getsource()",
       "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
       "source_location": "L7"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_otp_verificationcodeemail_tsx",
-      "label": "VerificationCodeEmail.tsx",
-      "norm_label": "verificationcodeemail.tsx",
-      "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "verificationcodeemail_verificationcodeemail",
-      "label": "VerificationCodeEmail()",
-      "norm_label": "verificationcodeemail()",
-      "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
-      "source_location": "L11"
     },
     {
       "community": 32,
@@ -44739,6 +44859,24 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_otp_verificationcodeemail_tsx",
+      "label": "VerificationCodeEmail.tsx",
+      "norm_label": "verificationcodeemail.tsx",
+      "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "verificationcodeemail_verificationcodeemail",
+      "label": "VerificationCodeEmail()",
+      "norm_label": "verificationcodeemail()",
+      "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
       "norm_label": "buildservicecatalogitem()",
@@ -44746,7 +44884,7 @@
       "source_location": "L8"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -44755,7 +44893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -44764,7 +44902,7 @@
       "source_location": "L4"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -44773,7 +44911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -44782,7 +44920,7 @@
       "source_location": "L15"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -44791,16 +44929,16 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
       "norm_label": "createqueryctx()",
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
-      "source_location": "L5"
+      "source_location": "L8"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -44809,7 +44947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -44818,7 +44956,7 @@
       "source_location": "L17"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -44827,7 +44965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -44836,7 +44974,7 @@
       "source_location": "L6"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -44845,7 +44983,25 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
+      "file_type": "code",
+      "id": "customerengagementevents_test_createmutationctx",
+      "label": "createMutationCtx()",
+      "norm_label": "createmutationctx()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 327,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
+      "label": "customerEngagementEvents.test.ts",
+      "norm_label": "customerengagementevents.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 328,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -44854,7 +45010,7 @@
       "source_location": "L25"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -44863,7 +45019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -44872,49 +45028,13 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
       "norm_label": "getstorefrontactorbyid()",
       "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
       "source_location": "L17"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "savedbag_listsavedbagitems",
-      "label": "listSavedBagItems()",
-      "norm_label": "listsavedbagitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
-      "label": "storefrontObservabilityReport.test.ts",
-      "norm_label": "storefrontobservabilityreport.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_test_createanalyticsevent",
-      "label": "createAnalyticsEvent()",
-      "norm_label": "createanalyticsevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
-      "source_location": "L8"
     },
     {
       "community": 33,
@@ -45009,6 +45129,60 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "rewards_formatpointslabel",
+      "label": "formatPointsLabel()",
+      "norm_label": "formatpointslabel()",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "savedbag_listsavedbagitems",
+      "label": "listSavedBagItems()",
+      "norm_label": "listsavedbagitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
+      "label": "storefrontObservabilityReport.test.ts",
+      "norm_label": "storefrontobservabilityreport.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_test_createanalyticsevent",
+      "label": "createAnalyticsEvent()",
+      "norm_label": "createanalyticsevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 333,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
       "norm_label": "syntheticmonitor.ts",
@@ -45016,7 +45190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 333,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -45025,7 +45199,7 @@
       "source_location": "L3"
     },
     {
-      "community": 331,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -45034,7 +45208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 334,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -45043,7 +45217,7 @@
       "source_location": "L5"
     },
     {
-      "community": 332,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -45052,7 +45226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 335,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -45061,7 +45235,7 @@
       "source_location": "L16"
     },
     {
-      "community": 333,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -45070,7 +45244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 336,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -45079,7 +45253,7 @@
       "source_location": "L30"
     },
     {
-      "community": 334,
+      "community": 337,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -45088,7 +45262,7 @@
       "source_location": "L7"
     },
     {
-      "community": 334,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -45097,7 +45271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 338,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -45106,7 +45280,7 @@
       "source_location": "L12"
     },
     {
-      "community": 335,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -45115,7 +45289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -45124,67 +45298,13 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 339,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
       "norm_label": "permissiongate()",
       "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 337,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_protectedroute_tsx",
-      "label": "ProtectedRoute.tsx",
-      "norm_label": "protectedroute.tsx",
-      "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 337,
-      "file_type": "code",
-      "id": "protectedroute_protectedroute",
-      "label": "ProtectedRoute()",
-      "norm_label": "protectedroute()",
-      "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_settingsview_tsx",
-      "label": "SettingsView.tsx",
-      "norm_label": "settingsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "settingsview_settingsview",
-      "label": "SettingsView()",
-      "norm_label": "settingsview()",
-      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeactions_tsx",
-      "label": "StoreActions.tsx",
-      "norm_label": "storeactions.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "storeactions_storeactions",
-      "label": "StoreActions()",
-      "norm_label": "storeactions()",
-      "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
-      "source_location": "L12"
     },
     {
       "community": 34,
@@ -45279,6 +45399,60 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_protectedroute_tsx",
+      "label": "ProtectedRoute.tsx",
+      "norm_label": "protectedroute.tsx",
+      "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "protectedroute_protectedroute",
+      "label": "ProtectedRoute()",
+      "norm_label": "protectedroute()",
+      "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_settingsview_tsx",
+      "label": "SettingsView.tsx",
+      "norm_label": "settingsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "settingsview_settingsview",
+      "label": "SettingsView()",
+      "norm_label": "settingsview()",
+      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeactions_tsx",
+      "label": "StoreActions.tsx",
+      "norm_label": "storeactions.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
+      "id": "storeactions_storeactions",
+      "label": "StoreActions()",
+      "norm_label": "storeactions()",
+      "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 343,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
       "norm_label": "storedropdown.tsx",
@@ -45286,7 +45460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 340,
+      "community": 343,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -45295,7 +45469,7 @@
       "source_location": "L42"
     },
     {
-      "community": 341,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -45304,7 +45478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 344,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -45313,7 +45487,7 @@
       "source_location": "L13"
     },
     {
-      "community": 342,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -45322,7 +45496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 345,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -45331,7 +45505,7 @@
       "source_location": "L42"
     },
     {
-      "community": 343,
+      "community": 346,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -45340,7 +45514,7 @@
       "source_location": "L31"
     },
     {
-      "community": 343,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -45349,7 +45523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -45358,7 +45532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 347,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -45367,7 +45541,7 @@
       "source_location": "L10"
     },
     {
-      "community": 345,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -45376,7 +45550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 348,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -45385,7 +45559,7 @@
       "source_location": "L14"
     },
     {
-      "community": 346,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -45394,67 +45568,13 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 349,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
       "norm_label": "productavailabilitytogglegroup()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 347,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
-      "label": "ProductDetails.tsx",
-      "norm_label": "productdetails.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 347,
-      "file_type": "code",
-      "id": "productdetails_handlenamechange",
-      "label": "handleNameChange()",
-      "norm_label": "handlenamechange()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
-      "label": "ProductImages.tsx",
-      "norm_label": "productimages.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "productimages_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
-      "label": "ProductPage.tsx",
-      "norm_label": "productpage.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "productpage_productpage",
-      "label": "ProductPage()",
-      "norm_label": "productpage()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
-      "source_location": "L13"
     },
     {
       "community": 35,
@@ -45549,6 +45669,60 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
+      "label": "ProductDetails.tsx",
+      "norm_label": "productdetails.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "productdetails_handlenamechange",
+      "label": "handleNameChange()",
+      "norm_label": "handlenamechange()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
+      "label": "ProductImages.tsx",
+      "norm_label": "productimages.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "productimages_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
+      "label": "ProductPage.tsx",
+      "norm_label": "productpage.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
+      "id": "productpage_productpage",
+      "label": "ProductPage()",
+      "norm_label": "productpage()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 353,
+      "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
       "norm_label": "setisupdatingsku()",
@@ -45556,7 +45730,7 @@
       "source_location": "L116"
     },
     {
-      "community": 350,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -45565,7 +45739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -45574,7 +45748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 354,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -45583,7 +45757,7 @@
       "source_location": "L47"
     },
     {
-      "community": 352,
+      "community": 355,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -45592,7 +45766,7 @@
       "source_location": "L151"
     },
     {
-      "community": 352,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -45601,7 +45775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 356,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -45610,7 +45784,7 @@
       "source_location": "L6"
     },
     {
-      "community": 353,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -45619,7 +45793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 357,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -45628,7 +45802,7 @@
       "source_location": "L19"
     },
     {
-      "community": 354,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -45637,7 +45811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 358,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -45646,7 +45820,7 @@
       "source_location": "L7"
     },
     {
-      "community": 355,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -45655,7 +45829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 359,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -45664,66 +45838,12 @@
       "source_location": "L42"
     },
     {
-      "community": 356,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
       "norm_label": "enhancedanalyticsview.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 357,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
-      "label": "StoreInsights.tsx",
-      "norm_label": "storeinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 357,
-      "file_type": "code",
-      "id": "storeinsights_gettrendicon",
-      "label": "getTrendIcon()",
-      "norm_label": "gettrendicon()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
-      "label": "VisitorChart.tsx",
-      "norm_label": "visitorchart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "visitorchart_formathour",
-      "label": "formatHour()",
-      "norm_label": "formathour()",
-      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "logitems_logitems",
-      "label": "LogItems()",
-      "norm_label": "logitems()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
-      "label": "LogItems.tsx",
-      "norm_label": "logitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L1"
     },
     {
@@ -45819,6 +45939,60 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
+      "label": "StoreInsights.tsx",
+      "norm_label": "storeinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "storeinsights_gettrendicon",
+      "label": "getTrendIcon()",
+      "norm_label": "gettrendicon()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
+      "label": "VisitorChart.tsx",
+      "norm_label": "visitorchart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "visitorchart_formathour",
+      "label": "formatHour()",
+      "norm_label": "formathour()",
+      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
+      "id": "logitems_logitems",
+      "label": "LogItems()",
+      "norm_label": "logitems()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
+      "label": "LogItems.tsx",
+      "norm_label": "logitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 363,
+      "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
       "norm_label": "header()",
@@ -45826,7 +46000,7 @@
       "source_location": "L10"
     },
     {
-      "community": 360,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -45835,7 +46009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 364,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -45844,7 +46018,7 @@
       "source_location": "L27"
     },
     {
-      "community": 361,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -45853,7 +46027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -45862,7 +46036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 365,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -45871,7 +46045,7 @@
       "source_location": "L12"
     },
     {
-      "community": 363,
+      "community": 366,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -45880,7 +46054,7 @@
       "source_location": "L3"
     },
     {
-      "community": 363,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -45889,7 +46063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 367,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -45898,7 +46072,7 @@
       "source_location": "L5"
     },
     {
-      "community": 364,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -45907,7 +46081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 368,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -45916,7 +46090,7 @@
       "source_location": "L49"
     },
     {
-      "community": 365,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -45925,7 +46099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 369,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -45934,66 +46108,12 @@
       "source_location": "L23"
     },
     {
-      "community": 366,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
       "norm_label": "bulkoperationspreview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 367,
-      "file_type": "code",
-      "id": "bulkoperationspreview_formatprice",
-      "label": "formatPrice()",
-      "norm_label": "formatprice()",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 367,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
-      "label": "BulkOperationsPreview.tsx",
-      "norm_label": "bulkoperationspreview.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "checkoutsessionstable_checkoutsessionstable",
-      "label": "CheckoutSessionsTable()",
-      "norm_label": "checkoutsessionstable()",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
-      "label": "CheckoutSessionsTable.tsx",
-      "norm_label": "checkoutsessionstable.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "checkoutsesssionsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
-      "label": "CheckoutSesssionsView.tsx",
-      "norm_label": "checkoutsesssionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
       "source_location": "L1"
     },
     {
@@ -46089,6 +46209,60 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "bulkoperationspreview_formatprice",
+      "label": "formatPrice()",
+      "norm_label": "formatprice()",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
+      "label": "BulkOperationsPreview.tsx",
+      "norm_label": "bulkoperationspreview.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "checkoutsessionstable_checkoutsessionstable",
+      "label": "CheckoutSessionsTable()",
+      "norm_label": "checkoutsessionstable()",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
+      "label": "CheckoutSessionsTable.tsx",
+      "norm_label": "checkoutsessionstable.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
+      "id": "checkoutsesssionsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
+      "label": "CheckoutSesssionsView.tsx",
+      "norm_label": "checkoutsesssionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 373,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
       "norm_label": "pageheader.tsx",
@@ -46096,7 +46270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 373,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -46105,7 +46279,7 @@
       "source_location": "L7"
     },
     {
-      "community": 371,
+      "community": 374,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -46114,7 +46288,7 @@
       "source_location": "L29"
     },
     {
-      "community": 371,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -46123,7 +46297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 375,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -46132,7 +46306,7 @@
       "source_location": "L37"
     },
     {
-      "community": 372,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -46141,7 +46315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 376,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -46150,7 +46324,7 @@
       "source_location": "L25"
     },
     {
-      "community": 373,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -46159,7 +46333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 377,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -46168,7 +46342,7 @@
       "source_location": "L83"
     },
     {
-      "community": 374,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -46177,7 +46351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -46186,7 +46360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 378,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -46195,7 +46369,7 @@
       "source_location": "L35"
     },
     {
-      "community": 376,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -46204,67 +46378,13 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 379,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
       "norm_label": "shoplookimageuploader()",
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
       "source_location": "L28"
-    },
-    {
-      "community": 377,
-      "file_type": "code",
-      "id": "index_jointeam",
-      "label": "JoinTeam()",
-      "norm_label": "jointeam()",
-      "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 377,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_join_team_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "customerdetailsview_customerdetailsview",
-      "label": "CustomerDetailsView()",
-      "norm_label": "customerdetailsview()",
-      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
-      "label": "CustomerDetailsView.tsx",
-      "norm_label": "customerdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "emailstatusview_handlesendorderemail",
-      "label": "handleSendOrderEmail()",
-      "norm_label": "handlesendorderemail()",
-      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
-      "label": "EmailStatusView.tsx",
-      "norm_label": "emailstatusview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 38,
@@ -46350,6 +46470,60 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "index_jointeam",
+      "label": "JoinTeam()",
+      "norm_label": "jointeam()",
+      "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_join_team_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "customerdetailsview_customerdetailsview",
+      "label": "CustomerDetailsView()",
+      "norm_label": "customerdetailsview()",
+      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
+      "label": "CustomerDetailsView.tsx",
+      "norm_label": "customerdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
+      "id": "emailstatusview_handlesendorderemail",
+      "label": "handleSendOrderEmail()",
+      "norm_label": "handlesendorderemail()",
+      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
+      "label": "EmailStatusView.tsx",
+      "norm_label": "emailstatusview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 383,
+      "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
       "norm_label": "handletimerangechange()",
@@ -46357,7 +46531,7 @@
       "source_location": "L33"
     },
     {
-      "community": 380,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -46366,7 +46540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 384,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -46375,7 +46549,7 @@
       "source_location": "L68"
     },
     {
-      "community": 381,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -46384,7 +46558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 385,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -46393,7 +46567,7 @@
       "source_location": "L35"
     },
     {
-      "community": 382,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -46402,7 +46576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -46411,7 +46585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 386,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -46420,7 +46594,7 @@
       "source_location": "L79"
     },
     {
-      "community": 384,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -46429,7 +46603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 387,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -46438,7 +46612,7 @@
       "source_location": "L6"
     },
     {
-      "community": 385,
+      "community": 388,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -46447,7 +46621,7 @@
       "source_location": "L34"
     },
     {
-      "community": 385,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -46456,7 +46630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 389,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -46465,66 +46639,12 @@
       "source_location": "L89"
     },
     {
-      "community": 386,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
       "norm_label": "ordercolumns.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 387,
-      "file_type": "code",
-      "id": "cashierview_handlesignout",
-      "label": "handleSignOut()",
-      "norm_label": "handlesignout()",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 387,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
-      "label": "CashierView.tsx",
-      "norm_label": "cashierview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "debugproducts_debugproducts",
-      "label": "DebugProducts()",
-      "norm_label": "debugproducts()",
-      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
-      "label": "DebugProducts.tsx",
-      "norm_label": "debugproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "noresultsmessage_noresultsmessage",
-      "label": "NoResultsMessage()",
-      "norm_label": "noresultsmessage()",
-      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
-      "label": "NoResultsMessage.tsx",
-      "norm_label": "noresultsmessage.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L1"
     },
     {
@@ -46611,6 +46731,60 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "cashierview_handlesignout",
+      "label": "handleSignOut()",
+      "norm_label": "handlesignout()",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
+      "label": "CashierView.tsx",
+      "norm_label": "cashierview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "debugproducts_debugproducts",
+      "label": "DebugProducts()",
+      "norm_label": "debugproducts()",
+      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
+      "label": "DebugProducts.tsx",
+      "norm_label": "debugproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 392,
+      "file_type": "code",
+      "id": "noresultsmessage_noresultsmessage",
+      "label": "NoResultsMessage()",
+      "norm_label": "noresultsmessage()",
+      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 392,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
+      "label": "NoResultsMessage.tsx",
+      "norm_label": "noresultsmessage.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 393,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
       "norm_label": "pininput.tsx",
@@ -46618,7 +46792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 393,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -46627,7 +46801,7 @@
       "source_location": "L13"
     },
     {
-      "community": 391,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -46636,7 +46810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 394,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
@@ -46645,7 +46819,7 @@
       "source_location": "L35"
     },
     {
-      "community": 392,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -46654,7 +46828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 395,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -46663,7 +46837,7 @@
       "source_location": "L3"
     },
     {
-      "community": 393,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -46672,7 +46846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 396,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -46681,7 +46855,7 @@
       "source_location": "L14"
     },
     {
-      "community": 394,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -46690,7 +46864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 397,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -46699,7 +46873,7 @@
       "source_location": "L86"
     },
     {
-      "community": 395,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_quickactionsbar_tsx",
       "label": "QuickActionsBar.tsx",
@@ -46708,7 +46882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 398,
       "file_type": "code",
       "id": "quickactionsbar_quickactionsbar",
       "label": "QuickActionsBar()",
@@ -46717,7 +46891,7 @@
       "source_location": "L11"
     },
     {
-      "community": 396,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -46726,67 +46900,13 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 399,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
       "norm_label": "sessiondemo()",
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L15"
-    },
-    {
-      "community": 397,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
-      "label": "TotalsDisplay.tsx",
-      "norm_label": "totalsdisplay.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 397,
-      "file_type": "code",
-      "id": "totalsdisplay_totalsdisplay",
-      "label": "TotalsDisplay()",
-      "norm_label": "totalsdisplay()",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "expensereportsview_istoday",
-      "label": "isToday()",
-      "norm_label": "istoday()",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
-      "label": "ExpenseReportsView.tsx",
-      "norm_label": "expensereportsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "hooks_useposcashier",
-      "label": "usePOSCashier()",
-      "norm_label": "useposcashier()",
-      "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
-      "source_location": "L1"
     },
     {
       "community": 4,
@@ -47124,6 +47244,60 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
+      "label": "TotalsDisplay.tsx",
+      "norm_label": "totalsdisplay.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "totalsdisplay_totalsdisplay",
+      "label": "TotalsDisplay()",
+      "norm_label": "totalsdisplay()",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "expensereportsview_istoday",
+      "label": "isToday()",
+      "norm_label": "istoday()",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
+      "label": "ExpenseReportsView.tsx",
+      "norm_label": "expensereportsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "hooks_useposcashier",
+      "label": "usePOSCashier()",
+      "norm_label": "useposcashier()",
+      "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
       "id": "holdsessiondialog_holdsessiondialog",
       "label": "HoldSessionDialog()",
       "norm_label": "holdsessiondialog()",
@@ -47131,7 +47305,7 @@
       "source_location": "L19"
     },
     {
-      "community": 400,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_holdsessiondialog_tsx",
       "label": "HoldSessionDialog.tsx",
@@ -47140,7 +47314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_voidsessiondialog_tsx",
       "label": "VoidSessionDialog.tsx",
@@ -47149,7 +47323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 404,
       "file_type": "code",
       "id": "voidsessiondialog_voidsessiondialog",
       "label": "VoidSessionDialog()",
@@ -47158,7 +47332,7 @@
       "source_location": "L19"
     },
     {
-      "community": 402,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -47167,7 +47341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 405,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
@@ -47176,7 +47350,7 @@
       "source_location": "L22"
     },
     {
-      "community": 403,
+      "community": 406,
       "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
@@ -47185,7 +47359,7 @@
       "source_location": "L14"
     },
     {
-      "community": 403,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -47194,7 +47368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 407,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -47203,7 +47377,7 @@
       "source_location": "L6"
     },
     {
-      "community": 404,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -47212,7 +47386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 408,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -47221,7 +47395,7 @@
       "source_location": "L38"
     },
     {
-      "community": 405,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -47230,7 +47404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -47239,67 +47413,13 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 409,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
       "norm_label": "skuselector()",
       "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
       "source_location": "L10"
-    },
-    {
-      "community": 407,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_actions_tsx",
-      "label": "product-actions.tsx",
-      "norm_label": "product-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 407,
-      "file_type": "code",
-      "id": "product_actions_usedeleteproduct",
-      "label": "useDeleteProduct()",
-      "norm_label": "usedeleteproduct()",
-      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productsview_tsx",
-      "label": "ProductsView.tsx",
-      "norm_label": "productsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "productsview_productsview",
-      "label": "ProductsView()",
-      "norm_label": "productsview()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "add_product_command_addproductcommand",
-      "label": "AddProductCommand()",
-      "norm_label": "addproductcommand()",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
-      "label": "add-product-command.tsx",
-      "norm_label": "add-product-command.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
-      "source_location": "L1"
     },
     {
       "community": 41,
@@ -47385,6 +47505,60 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_actions_tsx",
+      "label": "product-actions.tsx",
+      "norm_label": "product-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "product_actions_usedeleteproduct",
+      "label": "useDeleteProduct()",
+      "norm_label": "usedeleteproduct()",
+      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productsview_tsx",
+      "label": "ProductsView.tsx",
+      "norm_label": "productsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "productsview_productsview",
+      "label": "ProductsView()",
+      "norm_label": "productsview()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 412,
+      "file_type": "code",
+      "id": "add_product_command_addproductcommand",
+      "label": "AddProductCommand()",
+      "norm_label": "addproductcommand()",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 412,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
+      "label": "add-product-command.tsx",
+      "norm_label": "add-product-command.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 413,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
       "norm_label": "products.tsx",
@@ -47392,7 +47566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 413,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -47401,7 +47575,7 @@
       "source_location": "L4"
     },
     {
-      "community": 411,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -47410,7 +47584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 414,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -47419,7 +47593,7 @@
       "source_location": "L84"
     },
     {
-      "community": 412,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -47428,7 +47602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 415,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -47437,7 +47611,7 @@
       "source_location": "L22"
     },
     {
-      "community": 413,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -47446,7 +47620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 416,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -47455,7 +47629,7 @@
       "source_location": "L9"
     },
     {
-      "community": 414,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -47464,7 +47638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 417,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -47473,7 +47647,7 @@
       "source_location": "L23"
     },
     {
-      "community": 415,
+      "community": 418,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -47482,7 +47656,7 @@
       "source_location": "L5"
     },
     {
-      "community": 415,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -47491,7 +47665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -47500,67 +47674,13 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 419,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
       "norm_label": "promocodespantogglegroup()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L4"
-    },
-    {
-      "community": 417,
-      "file_type": "code",
-      "id": "capturedemails_capturedemails",
-      "label": "CapturedEmails()",
-      "norm_label": "capturedemails()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 417,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
-      "label": "CapturedEmails.tsx",
-      "norm_label": "capturedemails.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
-      "label": "promo-code-modal.tsx",
-      "norm_label": "promo-code-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "promo_code_modal_promocodemodal",
-      "label": "PromoCodeModal()",
-      "norm_label": "promocodemodal()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
-      "label": "ReviewActions.tsx",
-      "norm_label": "reviewactions.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "reviewactions_reviewactions",
-      "label": "ReviewActions()",
-      "norm_label": "reviewactions()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
-      "source_location": "L20"
     },
     {
       "community": 42,
@@ -47646,6 +47766,60 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "capturedemails_capturedemails",
+      "label": "CapturedEmails()",
+      "norm_label": "capturedemails()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
+      "label": "CapturedEmails.tsx",
+      "norm_label": "capturedemails.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
+      "label": "promo-code-modal.tsx",
+      "norm_label": "promo-code-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "promo_code_modal_promocodemodal",
+      "label": "PromoCodeModal()",
+      "norm_label": "promocodemodal()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
+      "label": "ReviewActions.tsx",
+      "norm_label": "reviewactions.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
+      "id": "reviewactions_reviewactions",
+      "label": "ReviewActions()",
+      "norm_label": "reviewactions()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 423,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
       "norm_label": "servicecasesview.tsx",
@@ -47653,7 +47827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 423,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -47662,7 +47836,7 @@
       "source_location": "L171"
     },
     {
-      "community": 421,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -47671,7 +47845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 424,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -47680,7 +47854,7 @@
       "source_location": "L52"
     },
     {
-      "community": 422,
+      "community": 425,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -47689,7 +47863,7 @@
       "source_location": "L29"
     },
     {
-      "community": 422,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -47698,7 +47872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 426,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -47707,7 +47881,7 @@
       "source_location": "L3"
     },
     {
-      "community": 423,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -47716,7 +47890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 427,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -47725,7 +47899,7 @@
       "source_location": "L4"
     },
     {
-      "community": 424,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -47734,7 +47908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 428,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -47743,7 +47917,7 @@
       "source_location": "L4"
     },
     {
-      "community": 425,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -47752,7 +47926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 429,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -47761,67 +47935,13 @@
       "source_location": "L9"
     },
     {
-      "community": 426,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
       "norm_label": "contactview.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 427,
-      "file_type": "code",
-      "id": "header_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 427,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
-      "label": "Header.tsx",
-      "norm_label": "header.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "maintenanceview_maintenanceview",
-      "label": "MaintenanceView()",
-      "norm_label": "maintenanceview()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
-      "label": "MaintenanceView.tsx",
-      "norm_label": "maintenanceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
-      "label": "TaxView.tsx",
-      "norm_label": "taxview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "taxview_handleupdatetaxsettings",
-      "label": "handleUpdateTaxSettings()",
-      "norm_label": "handleupdatetaxsettings()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
-      "source_location": "L25"
     },
     {
       "community": 43,
@@ -47907,6 +48027,60 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "header_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
+      "label": "Header.tsx",
+      "norm_label": "header.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "maintenanceview_maintenanceview",
+      "label": "MaintenanceView()",
+      "norm_label": "maintenanceview()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
+      "label": "MaintenanceView.tsx",
+      "norm_label": "maintenanceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
+      "label": "TaxView.tsx",
+      "norm_label": "taxview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
+      "id": "taxview_handleupdatetaxsettings",
+      "label": "handleUpdateTaxSettings()",
+      "norm_label": "handleupdatetaxsettings()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 433,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
       "norm_label": "usestoreconfigupdate.ts",
@@ -47914,7 +48088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 433,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -47923,7 +48097,7 @@
       "source_location": "L19"
     },
     {
-      "community": 431,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -47932,7 +48106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 434,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -47941,7 +48115,7 @@
       "source_location": "L63"
     },
     {
-      "community": 432,
+      "community": 435,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -47950,7 +48124,7 @@
       "source_location": "L7"
     },
     {
-      "community": 432,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -47959,7 +48133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 436,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -47968,7 +48142,7 @@
       "source_location": "L25"
     },
     {
-      "community": 433,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -47977,7 +48151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 437,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -47986,7 +48160,7 @@
       "source_location": "L15"
     },
     {
-      "community": 434,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -47995,7 +48169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 438,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -48004,7 +48178,7 @@
       "source_location": "L21"
     },
     {
-      "community": 435,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -48013,7 +48187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 439,
       "file_type": "code",
       "id": "date_time_picker_datetimepicker",
       "label": "DateTimePicker()",
@@ -48022,66 +48196,12 @@
       "source_location": "L21"
     },
     {
-      "community": 436,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
       "norm_label": "date-time-picker.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "label_label",
-      "label": "Label()",
-      "norm_label": "label()",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "custom_modal_custommodal",
-      "label": "CustomModal()",
-      "norm_label": "custommodal()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
-      "label": "custom-modal.tsx",
-      "norm_label": "custom-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "organization_modal_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
-      "label": "organization-modal.tsx",
-      "norm_label": "organization-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -48168,6 +48288,60 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "label_label",
+      "label": "Label()",
+      "norm_label": "label()",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "custom_modal_custommodal",
+      "label": "CustomModal()",
+      "norm_label": "custommodal()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
+      "label": "custom-modal.tsx",
+      "norm_label": "custom-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
+      "id": "organization_modal_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
+      "label": "organization-modal.tsx",
+      "norm_label": "organization-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 443,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
       "norm_label": "store-modal.tsx",
@@ -48175,7 +48349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 443,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -48184,7 +48358,7 @@
       "source_location": "L63"
     },
     {
-      "community": 441,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -48193,7 +48367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 444,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -48202,7 +48376,7 @@
       "source_location": "L5"
     },
     {
-      "community": 442,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -48211,7 +48385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 445,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -48220,7 +48394,7 @@
       "source_location": "L12"
     },
     {
-      "community": 443,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -48229,7 +48403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 446,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -48238,7 +48412,7 @@
       "source_location": "L15"
     },
     {
-      "community": 444,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -48247,7 +48421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 447,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -48256,7 +48430,7 @@
       "source_location": "L3"
     },
     {
-      "community": 445,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -48265,7 +48439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 448,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -48274,7 +48448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 449,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -48283,66 +48457,12 @@
       "source_location": "L5"
     },
     {
-      "community": 446,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
       "norm_label": "bagitems.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 447,
-      "file_type": "code",
-      "id": "bagitemsview_bagitemsview",
-      "label": "BagItemsView()",
-      "norm_label": "bagitemsview()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 447,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
-      "label": "BagItemsView.tsx",
-      "norm_label": "bagitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "bags_bags",
-      "label": "Bags()",
-      "norm_label": "bags()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
-      "label": "Bags.tsx",
-      "norm_label": "bags.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_string",
-      "label": "String()",
-      "norm_label": "string()",
-      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
-      "label": "CustomerBehaviorTimeline.tsx",
-      "norm_label": "customerbehaviortimeline.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L1"
     },
     {
@@ -48429,6 +48549,60 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "bagitemsview_bagitemsview",
+      "label": "BagItemsView()",
+      "norm_label": "bagitemsview()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
+      "label": "BagItemsView.tsx",
+      "norm_label": "bagitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "bags_bags",
+      "label": "Bags()",
+      "norm_label": "bags()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
+      "label": "Bags.tsx",
+      "norm_label": "bags.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_string",
+      "label": "String()",
+      "norm_label": "string()",
+      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
+      "label": "CustomerBehaviorTimeline.tsx",
+      "norm_label": "customerbehaviortimeline.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 453,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
       "norm_label": "useranalyticsname.tsx",
@@ -48436,7 +48610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 453,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -48445,7 +48619,7 @@
       "source_location": "L13"
     },
     {
-      "community": 451,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -48454,7 +48628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 454,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -48463,7 +48637,7 @@
       "source_location": "L7"
     },
     {
-      "community": 452,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -48472,7 +48646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 455,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -48481,7 +48655,7 @@
       "source_location": "L11"
     },
     {
-      "community": 453,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -48490,7 +48664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 456,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -48499,7 +48673,7 @@
       "source_location": "L7"
     },
     {
-      "community": 454,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -48508,7 +48682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 457,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -48517,7 +48691,7 @@
       "source_location": "L45"
     },
     {
-      "community": 455,
+      "community": 458,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -48526,7 +48700,7 @@
       "source_location": "L13"
     },
     {
-      "community": 455,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -48535,7 +48709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -48544,66 +48718,12 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 459,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
       "norm_label": "useimageupload()",
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 457,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
-      "label": "use-mobile.tsx",
-      "norm_label": "use-mobile.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 457,
-      "file_type": "code",
-      "id": "use_mobile_useismobile",
-      "label": "useIsMobile()",
-      "norm_label": "useismobile()",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
-      "label": "use-navigate-back.ts",
-      "norm_label": "use-navigate-back.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "use_navigate_back_usenavigateback",
-      "label": "useNavigateBack()",
-      "norm_label": "usenavigateback()",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
-      "label": "use-navigation-keyboard-shortcuts.ts",
-      "norm_label": "use-navigation-keyboard-shortcuts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
-      "label": "useNavigationKeyboardShortcuts()",
-      "norm_label": "usenavigationkeyboardshortcuts()",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L7"
     },
     {
@@ -48690,6 +48810,60 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
+      "label": "use-mobile.tsx",
+      "norm_label": "use-mobile.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "use_mobile_useismobile",
+      "label": "useIsMobile()",
+      "norm_label": "useismobile()",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
+      "label": "use-navigate-back.ts",
+      "norm_label": "use-navigate-back.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "use_navigate_back_usenavigateback",
+      "label": "useNavigateBack()",
+      "norm_label": "usenavigateback()",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
+      "label": "use-navigation-keyboard-shortcuts.ts",
+      "norm_label": "use-navigation-keyboard-shortcuts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
+      "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
+      "label": "useNavigationKeyboardShortcuts()",
+      "norm_label": "usenavigationkeyboardshortcuts()",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 463,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
       "norm_label": "use-pagination-persistence.ts",
@@ -48697,7 +48871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 463,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -48706,7 +48880,7 @@
       "source_location": "L9"
     },
     {
-      "community": 461,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -48715,7 +48889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 464,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -48724,7 +48898,7 @@
       "source_location": "L6"
     },
     {
-      "community": 462,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -48733,7 +48907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 465,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -48742,7 +48916,7 @@
       "source_location": "L168"
     },
     {
-      "community": 463,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecartoperations_ts",
       "label": "useCartOperations.ts",
@@ -48751,7 +48925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 466,
       "file_type": "code",
       "id": "usecartoperations_usecartoperations",
       "label": "useCartOperations()",
@@ -48760,7 +48934,7 @@
       "source_location": "L23"
     },
     {
-      "community": 464,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -48769,7 +48943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 467,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -48778,7 +48952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -48787,7 +48961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 468,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -48796,7 +48970,7 @@
       "source_location": "L6"
     },
     {
-      "community": 466,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecustomeroperations_ts",
       "label": "useCustomerOperations.ts",
@@ -48805,67 +48979,13 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 469,
       "file_type": "code",
       "id": "usecustomeroperations_usecustomeroperations",
       "label": "useCustomerOperations()",
       "norm_label": "usecustomeroperations()",
       "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
       "source_location": "L21"
-    },
-    {
-      "community": 467,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
-      "label": "useDebounce.ts",
-      "norm_label": "usedebounce.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 467,
-      "file_type": "code",
-      "id": "usedebounce_usedebounce",
-      "label": "useDebounce()",
-      "norm_label": "usedebounce()",
-      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
-      "label": "useExpenseOperations.ts",
-      "norm_label": "useexpenseoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "useexpenseoperations_useexpenseoperations",
-      "label": "useExpenseOperations()",
-      "norm_label": "useexpenseoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
-      "label": "useGetActiveProduct.ts",
-      "norm_label": "usegetactiveproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "usegetactiveproduct_usegetactiveproduct",
-      "label": "useGetActiveProduct()",
-      "norm_label": "usegetactiveproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L6"
     },
     {
       "community": 47,
@@ -48942,6 +49062,60 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
+      "label": "useDebounce.ts",
+      "norm_label": "usedebounce.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "usedebounce_usedebounce",
+      "label": "useDebounce()",
+      "norm_label": "usedebounce()",
+      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
+      "label": "useExpenseOperations.ts",
+      "norm_label": "useexpenseoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "useexpenseoperations_useexpenseoperations",
+      "label": "useExpenseOperations()",
+      "norm_label": "useexpenseoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
+      "label": "useGetActiveProduct.ts",
+      "norm_label": "usegetactiveproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
+      "id": "usegetactiveproduct_usegetactiveproduct",
+      "label": "useGetActiveProduct()",
+      "norm_label": "usegetactiveproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 473,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
       "norm_label": "usegetautheduser.ts",
@@ -48949,7 +49123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 473,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -48958,7 +49132,7 @@
       "source_location": "L4"
     },
     {
-      "community": 471,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -48967,7 +49141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 474,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -48976,7 +49150,7 @@
       "source_location": "L5"
     },
     {
-      "community": 472,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -48985,7 +49159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 475,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -48994,7 +49168,7 @@
       "source_location": "L5"
     },
     {
-      "community": 473,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -49003,7 +49177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 476,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -49012,7 +49186,7 @@
       "source_location": "L4"
     },
     {
-      "community": 474,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -49021,7 +49195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 477,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -49030,7 +49204,7 @@
       "source_location": "L5"
     },
     {
-      "community": 475,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -49039,7 +49213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 478,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -49048,7 +49222,7 @@
       "source_location": "L6"
     },
     {
-      "community": 476,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -49057,67 +49231,13 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 479,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
       "norm_label": "usenewordernotification()",
       "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
       "source_location": "L8"
-    },
-    {
-      "community": 477,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
-      "label": "usePermissions.ts",
-      "norm_label": "usepermissions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 477,
-      "file_type": "code",
-      "id": "usepermissions_usepermissions",
-      "label": "usePermissions()",
-      "norm_label": "usepermissions()",
-      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useprint_ts",
-      "label": "usePrint.ts",
-      "norm_label": "useprint.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "useprint_useprint",
-      "label": "usePrint()",
-      "norm_label": "useprint()",
-      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
-      "label": "useProductSearchResults.ts",
-      "norm_label": "useproductsearchresults.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "useproductsearchresults_useproductsearchresults",
-      "label": "useProductSearchResults()",
-      "norm_label": "useproductsearchresults()",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L26"
     },
     {
       "community": 48,
@@ -49194,6 +49314,60 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
+      "label": "usePermissions.ts",
+      "norm_label": "usepermissions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "usepermissions_usepermissions",
+      "label": "usePermissions()",
+      "norm_label": "usepermissions()",
+      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useprint_ts",
+      "label": "usePrint.ts",
+      "norm_label": "useprint.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "useprint_useprint",
+      "label": "usePrint()",
+      "norm_label": "useprint()",
+      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
+      "label": "useProductSearchResults.ts",
+      "norm_label": "useproductsearchresults.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
+      "id": "useproductsearchresults_useproductsearchresults",
+      "label": "useProductSearchResults()",
+      "norm_label": "useproductsearchresults()",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 483,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
       "norm_label": "useproductwithnoimagesnotification.tsx",
@@ -49201,7 +49375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 483,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -49210,7 +49384,7 @@
       "source_location": "L7"
     },
     {
-      "community": 481,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagement_ts",
       "label": "useSessionManagement.ts",
@@ -49219,7 +49393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 484,
       "file_type": "code",
       "id": "usesessionmanagement_usesessionmanagement",
       "label": "useSessionManagement()",
@@ -49228,7 +49402,7 @@
       "source_location": "L17"
     },
     {
-      "community": 482,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -49237,7 +49411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 485,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -49246,7 +49420,7 @@
       "source_location": "L17"
     },
     {
-      "community": 483,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanageroperations_ts",
       "label": "useSessionManagerOperations.ts",
@@ -49255,7 +49429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 486,
       "file_type": "code",
       "id": "usesessionmanageroperations_usesessionmanageroperations",
       "label": "useSessionManagerOperations()",
@@ -49264,7 +49438,7 @@
       "source_location": "L16"
     },
     {
-      "community": 484,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -49273,7 +49447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 487,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -49282,7 +49456,7 @@
       "source_location": "L12"
     },
     {
-      "community": 485,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -49291,7 +49465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 488,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -49300,7 +49474,7 @@
       "source_location": "L12"
     },
     {
-      "community": 486,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -49309,67 +49483,13 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 489,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
       "norm_label": "usetogglecomplimentaryproductactive()",
       "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 487,
-      "file_type": "code",
-      "id": "navigationutils_getorigin",
-      "label": "getOrigin()",
-      "norm_label": "getorigin()",
-      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 487,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_navigationutils_ts",
-      "label": "navigationUtils.ts",
-      "norm_label": "navigationutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "calculations_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
-      "label": "calculations.ts",
-      "norm_label": "calculations.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
-      "label": "pinHash.ts",
-      "norm_label": "pinhash.ts",
-      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "pinhash_hashpin",
-      "label": "hashPin()",
-      "norm_label": "hashpin()",
-      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
-      "source_location": "L12"
     },
     {
       "community": 49,
@@ -49446,6 +49566,60 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "navigationutils_getorigin",
+      "label": "getOrigin()",
+      "norm_label": "getorigin()",
+      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_navigationutils_ts",
+      "label": "navigationUtils.ts",
+      "norm_label": "navigationutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "calculations_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
+      "label": "calculations.ts",
+      "norm_label": "calculations.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
+      "label": "pinHash.ts",
+      "norm_label": "pinhash.ts",
+      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
+      "id": "pinhash_hashpin",
+      "label": "hashPin()",
+      "norm_label": "hashpin()",
+      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 493,
+      "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
       "norm_label": "storerootredirect()",
@@ -49453,7 +49627,7 @@
       "source_location": "L13"
     },
     {
-      "community": 490,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -49462,7 +49636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -49471,7 +49645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 494,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -49480,7 +49654,7 @@
       "source_location": "L9"
     },
     {
-      "community": 492,
+      "community": 495,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -49489,7 +49663,7 @@
       "source_location": "L13"
     },
     {
-      "community": 492,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -49498,7 +49672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 496,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -49507,7 +49681,7 @@
       "source_location": "L4"
     },
     {
-      "community": 493,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -49516,7 +49690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 497,
       "file_type": "code",
       "id": "layout_loginlayout",
       "label": "LoginLayout()",
@@ -49525,7 +49699,7 @@
       "source_location": "L36"
     },
     {
-      "community": 494,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -49534,7 +49708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 498,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -49543,7 +49717,7 @@
       "source_location": "L13"
     },
     {
-      "community": 495,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -49552,7 +49726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 499,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -49561,66 +49735,12 @@
       "source_location": "L5"
     },
     {
-      "community": 496,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
       "norm_label": "overview.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Patterns/Overview.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 497,
-      "file_type": "code",
-      "id": "controls_stories_controlsshowcase",
-      "label": "ControlsShowcase()",
-      "norm_label": "controlsshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 497,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
-      "label": "Controls.stories.tsx",
-      "norm_label": "controls.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "dialog_stories_dialogshowcase",
-      "label": "DialogShowcase()",
-      "norm_label": "dialogshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
-      "label": "Dialog.stories.tsx",
-      "norm_label": "dialog.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "feedback_stories_feedbackshowcase",
-      "label": "FeedbackShowcase()",
-      "norm_label": "feedbackshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
-      "label": "Feedback.stories.tsx",
-      "norm_label": "feedback.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -49950,6 +50070,60 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "controls_stories_controlsshowcase",
+      "label": "ControlsShowcase()",
+      "norm_label": "controlsshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
+      "label": "Controls.stories.tsx",
+      "norm_label": "controls.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "dialog_stories_dialogshowcase",
+      "label": "DialogShowcase()",
+      "norm_label": "dialogshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
+      "label": "Dialog.stories.tsx",
+      "norm_label": "dialog.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
+      "id": "feedback_stories_feedbackshowcase",
+      "label": "FeedbackShowcase()",
+      "norm_label": "feedbackshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
+      "label": "Feedback.stories.tsx",
+      "norm_label": "feedback.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 503,
+      "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
       "norm_label": "primitivesoverview()",
@@ -49957,7 +50131,7 @@
       "source_location": "L5"
     },
     {
-      "community": 500,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -49966,7 +50140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -49975,7 +50149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 504,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -49984,7 +50158,7 @@
       "source_location": "L13"
     },
     {
-      "community": 502,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -49993,7 +50167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 505,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -50002,7 +50176,7 @@
       "source_location": "L14"
     },
     {
-      "community": 503,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -50011,7 +50185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 506,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -50020,7 +50194,7 @@
       "source_location": "L13"
     },
     {
-      "community": 504,
+      "community": 507,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -50029,7 +50203,7 @@
       "source_location": "L5"
     },
     {
-      "community": 504,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -50038,7 +50212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -50047,7 +50221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 508,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -50056,7 +50230,7 @@
       "source_location": "L17"
     },
     {
-      "community": 506,
+      "community": 509,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -50065,66 +50239,12 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
       "norm_label": "formatnumber.ts",
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "bannermessage_getbannermessage",
-      "label": "getBannerMessage()",
-      "norm_label": "getbannermessage()",
-      "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "checkoutsession_test_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
-      "label": "checkoutSession.test.ts",
-      "norm_label": "checkoutsession.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "guest_updateguest",
-      "label": "updateGuest()",
-      "norm_label": "updateguest()",
-      "source_file": "packages/storefront-webapp/src/api/guest.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L1"
     },
     {
@@ -50202,6 +50322,60 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "bannermessage_getbannermessage",
+      "label": "getBannerMessage()",
+      "norm_label": "getbannermessage()",
+      "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "checkoutsession_test_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
+      "label": "checkoutSession.test.ts",
+      "norm_label": "checkoutsession.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
+      "id": "guest_updateguest",
+      "label": "updateGuest()",
+      "norm_label": "updateguest()",
+      "source_file": "packages/storefront-webapp/src/api/guest.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/storefront-webapp/src/api/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 513,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
       "norm_label": "storefront.ts",
@@ -50209,7 +50383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 513,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -50218,7 +50392,7 @@
       "source_location": "L5"
     },
     {
-      "community": 511,
+      "community": 514,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -50227,7 +50401,7 @@
       "source_location": "L10"
     },
     {
-      "community": 511,
+      "community": 514,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -50236,7 +50410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 515,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -50245,7 +50419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 515,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -50254,7 +50428,7 @@
       "source_location": "L10"
     },
     {
-      "community": 513,
+      "community": 516,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -50263,7 +50437,7 @@
       "source_location": "L4"
     },
     {
-      "community": 513,
+      "community": 516,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -50272,7 +50446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 517,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -50281,7 +50455,7 @@
       "source_location": "L39"
     },
     {
-      "community": 514,
+      "community": 517,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -50290,7 +50464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 518,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -50299,7 +50473,7 @@
       "source_location": "L18"
     },
     {
-      "community": 515,
+      "community": 518,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -50308,7 +50482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 519,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -50317,66 +50491,12 @@
       "source_location": "L71"
     },
     {
-      "community": 516,
+      "community": 519,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
       "norm_label": "checkoutprovider.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
-      "label": "PickupOptions.tsx",
-      "norm_label": "pickupoptions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "pickupoptions_iswithinrestrictiontime",
-      "label": "isWithinRestrictionTime()",
-      "norm_label": "iswithinrestrictiontime()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
-      "label": "EnteredBillingAddressDetails.tsx",
-      "norm_label": "enteredbillingaddressdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "ordersummary_ordersummary",
-      "label": "OrderSummary()",
-      "norm_label": "ordersummary()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L1"
     },
     {
@@ -50454,6 +50574,60 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
+      "label": "PickupOptions.tsx",
+      "norm_label": "pickupoptions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "pickupoptions_iswithinrestrictiontime",
+      "label": "isWithinRestrictionTime()",
+      "norm_label": "iswithinrestrictiontime()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
+      "label": "EnteredBillingAddressDetails.tsx",
+      "norm_label": "enteredbillingaddressdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
+      "id": "ordersummary_ordersummary",
+      "label": "OrderSummary()",
+      "norm_label": "ordersummary()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 523,
+      "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
       "norm_label": "pickupdetails()",
@@ -50461,7 +50635,7 @@
       "source_location": "L10"
     },
     {
-      "community": 520,
+      "community": 523,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -50470,7 +50644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 524,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -50479,7 +50653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 524,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -50488,7 +50662,7 @@
       "source_location": "L8"
     },
     {
-      "community": 522,
+      "community": 525,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -50497,7 +50671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 525,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -50506,7 +50680,7 @@
       "source_location": "L27"
     },
     {
-      "community": 523,
+      "community": 526,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -50515,7 +50689,7 @@
       "source_location": "L40"
     },
     {
-      "community": 523,
+      "community": 526,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -50524,7 +50698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 527,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -50533,7 +50707,7 @@
       "source_location": "L3"
     },
     {
-      "community": 524,
+      "community": 527,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -50542,7 +50716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 528,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -50551,7 +50725,7 @@
       "source_location": "L8"
     },
     {
-      "community": 525,
+      "community": 528,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -50560,7 +50734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 529,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -50569,67 +50743,13 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 529,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
       "norm_label": "getissuemap()",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 527,
-      "file_type": "code",
-      "id": "customerdetailsform_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 527,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
-      "label": "CustomerDetailsForm.tsx",
-      "norm_label": "customerdetailsform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "deliverydetailsform_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
-      "label": "DeliveryDetailsForm.tsx",
-      "norm_label": "deliverydetailsform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "hooks_usecountdown",
-      "label": "useCountdown()",
-      "norm_label": "usecountdown()",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
-      "source_location": "L1"
     },
     {
       "community": 53,
@@ -50706,6 +50826,60 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "customerdetailsform_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
+      "label": "CustomerDetailsForm.tsx",
+      "norm_label": "customerdetailsform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "deliverydetailsform_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
+      "label": "DeliveryDetailsForm.tsx",
+      "norm_label": "deliverydetailsform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
+      "id": "hooks_usecountdown",
+      "label": "useCountdown()",
+      "norm_label": "usecountdown()",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 533,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
       "norm_label": "trustsignals.tsx",
@@ -50713,7 +50887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 533,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -50722,7 +50896,7 @@
       "source_location": "L4"
     },
     {
-      "community": 531,
+      "community": 534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -50731,7 +50905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 534,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -50740,7 +50914,7 @@
       "source_location": "L14"
     },
     {
-      "community": 532,
+      "community": 535,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -50749,7 +50923,7 @@
       "source_location": "L27"
     },
     {
-      "community": 532,
+      "community": 535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -50758,7 +50932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 536,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -50767,7 +50941,7 @@
       "source_location": "L17"
     },
     {
-      "community": 533,
+      "community": 536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -50776,7 +50950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 537,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -50785,7 +50959,7 @@
       "source_location": "L13"
     },
     {
-      "community": 534,
+      "community": 537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -50794,7 +50968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 538,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -50803,7 +50977,7 @@
       "source_location": "L47"
     },
     {
-      "community": 535,
+      "community": 538,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -50812,7 +50986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 539,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -50821,66 +50995,12 @@
       "source_location": "L7"
     },
     {
-      "community": 536,
+      "community": 539,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
       "norm_label": "mobilebagmenu.tsx",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
-      "label": "SiteBanner.tsx",
-      "norm_label": "sitebanner.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "sitebanner_sitebanner",
-      "label": "SiteBanner()",
-      "norm_label": "sitebanner()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "notificationpill_notificationpill",
-      "label": "NotificationPill()",
-      "norm_label": "notificationpill()",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
-      "label": "NotificationPill.tsx",
-      "norm_label": "notificationpill.tsx",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "dimensionbar_mapvaluetolabelindex",
-      "label": "mapValueToLabelIndex()",
-      "norm_label": "mapvaluetolabelindex()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
-      "label": "DimensionBar.tsx",
-      "norm_label": "dimensionbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L1"
     },
     {
@@ -50958,6 +51078,60 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
+      "label": "SiteBanner.tsx",
+      "norm_label": "sitebanner.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "sitebanner_sitebanner",
+      "label": "SiteBanner()",
+      "norm_label": "sitebanner()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "notificationpill_notificationpill",
+      "label": "NotificationPill()",
+      "norm_label": "notificationpill()",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
+      "label": "NotificationPill.tsx",
+      "norm_label": "notificationpill.tsx",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
+      "id": "dimensionbar_mapvaluetolabelindex",
+      "label": "mapValueToLabelIndex()",
+      "norm_label": "mapvaluetolabelindex()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
+      "label": "DimensionBar.tsx",
+      "norm_label": "dimensionbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 543,
+      "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
       "norm_label": "discountbadge()",
@@ -50965,7 +51139,7 @@
       "source_location": "L7"
     },
     {
-      "community": 540,
+      "community": 543,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -50974,7 +51148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 544,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -50983,7 +51157,7 @@
       "source_location": "L45"
     },
     {
-      "community": 541,
+      "community": 544,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -50992,7 +51166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 545,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -51001,7 +51175,7 @@
       "source_location": "L5"
     },
     {
-      "community": 542,
+      "community": 545,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -51010,7 +51184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 546,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -51019,7 +51193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 546,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -51028,7 +51202,7 @@
       "source_location": "L17"
     },
     {
-      "community": 544,
+      "community": 547,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -51037,7 +51211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 547,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -51046,7 +51220,7 @@
       "source_location": "L3"
     },
     {
-      "community": 545,
+      "community": 548,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -51055,7 +51229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 548,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -51064,7 +51238,7 @@
       "source_location": "L78"
     },
     {
-      "community": 546,
+      "community": 549,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -51073,67 +51247,13 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 549,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
       "norm_label": "handlehelpful()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L87"
-    },
-    {
-      "community": 547,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
-      "label": "ReviewSummary.tsx",
-      "norm_label": "reviewsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 547,
-      "file_type": "code",
-      "id": "reviewsummary_reviewsummary",
-      "label": "ReviewSummary()",
-      "norm_label": "reviewsummary()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "orderitem_orderitem",
-      "label": "OrderItem()",
-      "norm_label": "orderitem()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
-      "label": "OrderItem.tsx",
-      "norm_label": "orderitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
-      "label": "RatingSelector.tsx",
-      "norm_label": "ratingselector.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "ratingselector_ratingselector",
-      "label": "RatingSelector()",
-      "norm_label": "ratingselector()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
-      "source_location": "L18"
     },
     {
       "community": 55,
@@ -51210,6 +51330,60 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
+      "label": "ReviewSummary.tsx",
+      "norm_label": "reviewsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "reviewsummary_reviewsummary",
+      "label": "ReviewSummary()",
+      "norm_label": "reviewsummary()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "orderitem_orderitem",
+      "label": "OrderItem()",
+      "norm_label": "orderitem()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
+      "label": "OrderItem.tsx",
+      "norm_label": "orderitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
+      "label": "RatingSelector.tsx",
+      "norm_label": "ratingselector.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
+      "id": "ratingselector_ratingselector",
+      "label": "RatingSelector()",
+      "norm_label": "ratingselector()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 553,
+      "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
       "norm_label": "guestrewardsprompt()",
@@ -51217,7 +51391,7 @@
       "source_location": "L10"
     },
     {
-      "community": 550,
+      "community": 553,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -51226,7 +51400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 554,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -51235,7 +51409,7 @@
       "source_location": "L11"
     },
     {
-      "community": 551,
+      "community": 554,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -51244,7 +51418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 555,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -51253,7 +51427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 555,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -51262,7 +51436,7 @@
       "source_location": "L59"
     },
     {
-      "community": 553,
+      "community": 556,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -51271,7 +51445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 556,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -51280,7 +51454,7 @@
       "source_location": "L33"
     },
     {
-      "community": 554,
+      "community": 557,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -51289,7 +51463,7 @@
       "source_location": "L19"
     },
     {
-      "community": 554,
+      "community": 557,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -51298,7 +51472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 558,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -51307,7 +51481,7 @@
       "source_location": "L4"
     },
     {
-      "community": 555,
+      "community": 558,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -51316,7 +51490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 559,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -51325,66 +51499,12 @@
       "source_location": "L22"
     },
     {
-      "community": 556,
+      "community": 559,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
       "norm_label": "errorboundary.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 557,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
-      "label": "ScrollDownButton.tsx",
-      "norm_label": "scrolldownbutton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 557,
-      "file_type": "code",
-      "id": "scrolldownbutton_scrolldownbutton",
-      "label": "ScrollDownButton()",
-      "norm_label": "scrolldownbutton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "country_select_countryselect",
-      "label": "CountrySelect()",
-      "norm_label": "countryselect()",
-      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
-      "label": "country-select.tsx",
-      "norm_label": "country-select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "ghana_region_select_ghanaregionselect",
-      "label": "GhanaRegionSelect()",
-      "norm_label": "ghanaregionselect()",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
-      "label": "ghana-region-select.tsx",
-      "norm_label": "ghana-region-select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
       "source_location": "L1"
     },
     {
@@ -51462,6 +51582,60 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
+      "label": "ScrollDownButton.tsx",
+      "norm_label": "scrolldownbutton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "scrolldownbutton_scrolldownbutton",
+      "label": "ScrollDownButton()",
+      "norm_label": "scrolldownbutton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "country_select_countryselect",
+      "label": "CountrySelect()",
+      "norm_label": "countryselect()",
+      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
+      "label": "country-select.tsx",
+      "norm_label": "country-select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
+      "id": "ghana_region_select_ghanaregionselect",
+      "label": "GhanaRegionSelect()",
+      "norm_label": "ghanaregionselect()",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
+      "label": "ghana-region-select.tsx",
+      "norm_label": "ghana-region-select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 563,
+      "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
       "norm_label": "ghostbutton()",
@@ -51469,7 +51643,7 @@
       "source_location": "L9"
     },
     {
-      "community": 560,
+      "community": 563,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -51478,7 +51652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 564,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -51487,7 +51661,7 @@
       "source_location": "L66"
     },
     {
-      "community": 561,
+      "community": 564,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -51496,7 +51670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 565,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -51505,7 +51679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 565,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -51514,7 +51688,7 @@
       "source_location": "L19"
     },
     {
-      "community": 563,
+      "community": 566,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -51523,7 +51697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 566,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -51532,7 +51706,7 @@
       "source_location": "L13"
     },
     {
-      "community": 564,
+      "community": 567,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -51541,7 +51715,7 @@
       "source_location": "L46"
     },
     {
-      "community": 564,
+      "community": 567,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -51550,7 +51724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 568,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -51559,7 +51733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 568,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -51568,7 +51742,7 @@
       "source_location": "L46"
     },
     {
-      "community": 566,
+      "community": 569,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -51577,67 +51751,13 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 569,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
       "norm_label": "webpimage()",
       "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "formsubmissionprovider_useformsubmission",
-      "label": "useFormSubmission()",
-      "norm_label": "useformsubmission()",
-      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
-      "label": "FormSubmissionProvider.tsx",
-      "norm_label": "formsubmissionprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
-      "label": "useCheckout.ts",
-      "norm_label": "usecheckout.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "usecheckout_usecheckout",
-      "label": "useCheckout()",
-      "norm_label": "usecheckout()",
-      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
-      "label": "useDiscountCodeAlert.tsx",
-      "norm_label": "usediscountcodealert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "usediscountcodealert_usediscountcodealert",
-      "label": "useDiscountCodeAlert()",
-      "norm_label": "usediscountcodealert()",
-      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
-      "source_location": "L14"
     },
     {
       "community": 57,
@@ -51705,6 +51825,60 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "formsubmissionprovider_useformsubmission",
+      "label": "useFormSubmission()",
+      "norm_label": "useformsubmission()",
+      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
+      "label": "FormSubmissionProvider.tsx",
+      "norm_label": "formsubmissionprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
+      "label": "useCheckout.ts",
+      "norm_label": "usecheckout.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "usecheckout_usecheckout",
+      "label": "useCheckout()",
+      "norm_label": "usecheckout()",
+      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
+      "label": "useDiscountCodeAlert.tsx",
+      "norm_label": "usediscountcodealert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
+      "id": "usediscountcodealert_usediscountcodealert",
+      "label": "useDiscountCodeAlert()",
+      "norm_label": "usediscountcodealert()",
+      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 573,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
       "norm_label": "useenhancedtracking.ts",
@@ -51712,7 +51886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 573,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -51721,7 +51895,7 @@
       "source_location": "L29"
     },
     {
-      "community": 571,
+      "community": 574,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -51730,7 +51904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 574,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -51739,7 +51913,7 @@
       "source_location": "L5"
     },
     {
-      "community": 572,
+      "community": 575,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -51748,7 +51922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 575,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -51757,7 +51931,7 @@
       "source_location": "L5"
     },
     {
-      "community": 573,
+      "community": 576,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -51766,7 +51940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 576,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -51775,7 +51949,7 @@
       "source_location": "L3"
     },
     {
-      "community": 574,
+      "community": 577,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -51784,7 +51958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 577,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -51793,7 +51967,7 @@
       "source_location": "L4"
     },
     {
-      "community": 575,
+      "community": 578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -51802,7 +51976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 578,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -51811,7 +51985,7 @@
       "source_location": "L4"
     },
     {
-      "community": 576,
+      "community": 579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -51820,67 +51994,13 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 579,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
       "norm_label": "useinventorystatus()",
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L9"
-    },
-    {
-      "community": 577,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
-      "label": "useLeaveAReviewModal.tsx",
-      "norm_label": "useleaveareviewmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 577,
-      "file_type": "code",
-      "id": "useleaveareviewmodal_useleaveareviewmodal",
-      "label": "useLeaveAReviewModal()",
-      "norm_label": "useleaveareviewmodal()",
-      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
-      "label": "useLogout.ts",
-      "norm_label": "uselogout.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "uselogout_uselogout",
-      "label": "useLogout()",
-      "norm_label": "uselogout()",
-      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
-      "label": "useModalState.tsx",
-      "norm_label": "usemodalstate.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "usemodalstate_usemodalstate",
-      "label": "useModalState()",
-      "norm_label": "usemodalstate()",
-      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
-      "source_location": "L15"
     },
     {
       "community": 58,
@@ -51948,6 +52068,60 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
+      "label": "useLeaveAReviewModal.tsx",
+      "norm_label": "useleaveareviewmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "useleaveareviewmodal_useleaveareviewmodal",
+      "label": "useLeaveAReviewModal()",
+      "norm_label": "useleaveareviewmodal()",
+      "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
+      "label": "useLogout.ts",
+      "norm_label": "uselogout.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "uselogout_uselogout",
+      "label": "useLogout()",
+      "norm_label": "uselogout()",
+      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
+      "label": "useModalState.tsx",
+      "norm_label": "usemodalstate.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "usemodalstate_usemodalstate",
+      "label": "useModalState()",
+      "norm_label": "usemodalstate()",
+      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 583,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
       "norm_label": "useproductpagelogic.ts",
@@ -51955,7 +52129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 583,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -51964,7 +52138,7 @@
       "source_location": "L18"
     },
     {
-      "community": 581,
+      "community": 584,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -51973,7 +52147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 584,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -51982,7 +52156,7 @@
       "source_location": "L9"
     },
     {
-      "community": 582,
+      "community": 585,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -51991,7 +52165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 585,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -52000,7 +52174,7 @@
       "source_location": "L16"
     },
     {
-      "community": 583,
+      "community": 586,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -52009,7 +52183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 586,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -52018,7 +52192,7 @@
       "source_location": "L4"
     },
     {
-      "community": 584,
+      "community": 587,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -52027,7 +52201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 587,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -52036,7 +52210,7 @@
       "source_location": "L11"
     },
     {
-      "community": 585,
+      "community": 588,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -52045,7 +52219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 588,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -52054,7 +52228,7 @@
       "source_location": "L3"
     },
     {
-      "community": 586,
+      "community": 589,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -52063,67 +52237,13 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 589,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
       "norm_label": "usetrackaction()",
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L7"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
-      "label": "useTrackEvent.ts",
-      "norm_label": "usetrackevent.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "usetrackevent_usetrackevent",
-      "label": "useTrackEvent()",
-      "norm_label": "usetrackevent()",
-      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
-      "label": "useUpsellModal.tsx",
-      "norm_label": "useupsellmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "useupsellmodal_useupsellmodal",
-      "label": "useUpsellModal()",
-      "norm_label": "useupsellmodal()",
-      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "analytics_usepostanalytics",
-      "label": "usePostAnalytics()",
-      "norm_label": "usepostanalytics()",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
-      "source_location": "L1"
     },
     {
       "community": 59,
@@ -52191,6 +52311,60 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
+      "label": "useTrackEvent.ts",
+      "norm_label": "usetrackevent.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "usetrackevent_usetrackevent",
+      "label": "useTrackEvent()",
+      "norm_label": "usetrackevent()",
+      "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
+      "label": "useUpsellModal.tsx",
+      "norm_label": "useupsellmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "useupsellmodal_useupsellmodal",
+      "label": "useUpsellModal()",
+      "norm_label": "useupsellmodal()",
+      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
+      "id": "analytics_usepostanalytics",
+      "label": "usePostAnalytics()",
+      "norm_label": "usepostanalytics()",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 593,
+      "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
       "norm_label": "usebagqueries()",
@@ -52198,7 +52372,7 @@
       "source_location": "L7"
     },
     {
-      "community": 590,
+      "community": 593,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -52207,7 +52381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 594,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -52216,7 +52390,7 @@
       "source_location": "L6"
     },
     {
-      "community": 591,
+      "community": 594,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -52225,7 +52399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 595,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -52234,7 +52408,7 @@
       "source_location": "L10"
     },
     {
-      "community": 592,
+      "community": 595,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -52243,7 +52417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 596,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -52252,7 +52426,7 @@
       "source_location": "L6"
     },
     {
-      "community": 593,
+      "community": 596,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -52261,7 +52435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 597,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -52270,7 +52444,7 @@
       "source_location": "L5"
     },
     {
-      "community": 594,
+      "community": 597,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -52279,7 +52453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 598,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -52288,7 +52462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 598,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -52297,7 +52471,7 @@
       "source_location": "L14"
     },
     {
-      "community": 596,
+      "community": 599,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -52306,67 +52480,13 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 599,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
       "norm_label": "usepromocodesqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
       "source_location": "L9"
-    },
-    {
-      "community": 597,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 597,
-      "file_type": "code",
-      "id": "reviews_usereviewqueries",
-      "label": "useReviewQueries()",
-      "norm_label": "usereviewqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "rewards_userewardsqueries",
-      "label": "useRewardsQueries()",
-      "norm_label": "userewardsqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "upsells_useupsellsqueries",
-      "label": "useUpsellsQueries()",
-      "norm_label": "useupsellsqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
-      "source_location": "L6"
     },
     {
       "community": 6,
@@ -52668,6 +52788,60 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "reviews_usereviewqueries",
+      "label": "useReviewQueries()",
+      "norm_label": "usereviewqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "rewards_userewardsqueries",
+      "label": "useRewardsQueries()",
+      "norm_label": "userewardsqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "upsells_useupsellsqueries",
+      "label": "useUpsellsQueries()",
+      "norm_label": "useupsellsqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 603,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
@@ -52675,7 +52849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 603,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -52684,7 +52858,7 @@
       "source_location": "L5"
     },
     {
-      "community": 601,
+      "community": 604,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -52693,7 +52867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 604,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -52702,7 +52876,7 @@
       "source_location": "L6"
     },
     {
-      "community": 602,
+      "community": 605,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -52711,7 +52885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 605,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -52720,7 +52894,7 @@
       "source_location": "L10"
     },
     {
-      "community": 603,
+      "community": 606,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -52729,7 +52903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 606,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -52738,7 +52912,7 @@
       "source_location": "L15"
     },
     {
-      "community": 604,
+      "community": 607,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -52747,7 +52921,7 @@
       "source_location": "L14"
     },
     {
-      "community": 604,
+      "community": 607,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -52756,7 +52930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 608,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -52765,7 +52939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 608,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -52774,7 +52948,7 @@
       "source_location": "L5"
     },
     {
-      "community": 606,
+      "community": 609,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -52783,66 +52957,12 @@
       "source_location": "L13"
     },
     {
-      "community": 606,
+      "community": 609,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
       "norm_label": "-homepageloader.ts",
       "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "orderslayout_layoutcomponent",
-      "label": "LayoutComponent()",
-      "norm_label": "layoutcomponent()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
-      "label": "_ordersLayout.tsx",
-      "norm_label": "_orderslayout.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "contact_us_contactus",
-      "label": "ContactUs()",
-      "norm_label": "contactus()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
-      "label": "contact-us.tsx",
-      "norm_label": "contact-us.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "delivery_returns_exchanges_index_onlineorderpolicy",
-      "label": "OnlineOrderPolicy()",
-      "norm_label": "onlineorderpolicy()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
-      "label": "delivery-returns-exchanges.index.tsx",
-      "norm_label": "delivery-returns-exchanges.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1"
     },
     {
@@ -52911,6 +53031,60 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "orderslayout_layoutcomponent",
+      "label": "LayoutComponent()",
+      "norm_label": "layoutcomponent()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
+      "label": "_ordersLayout.tsx",
+      "norm_label": "_orderslayout.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "contact_us_contactus",
+      "label": "ContactUs()",
+      "norm_label": "contactus()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
+      "label": "contact-us.tsx",
+      "norm_label": "contact-us.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "delivery_returns_exchanges_index_onlineorderpolicy",
+      "label": "OnlineOrderPolicy()",
+      "norm_label": "onlineorderpolicy()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
+      "label": "delivery-returns-exchanges.index.tsx",
+      "norm_label": "delivery-returns-exchanges.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 613,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
       "norm_label": "privacy.index.tsx",
@@ -52918,7 +53092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 613,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -52927,7 +53101,7 @@
       "source_location": "L9"
     },
     {
-      "community": 611,
+      "community": 614,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -52936,7 +53110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 614,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -52945,7 +53119,7 @@
       "source_location": "L15"
     },
     {
-      "community": 612,
+      "community": 615,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -52954,7 +53128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 615,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -52963,7 +53137,7 @@
       "source_location": "L16"
     },
     {
-      "community": 613,
+      "community": 616,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -52972,7 +53146,7 @@
       "source_location": "L6"
     },
     {
-      "community": 613,
+      "community": 616,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -52981,7 +53155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 617,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -52990,7 +53164,7 @@
       "source_location": "L10"
     },
     {
-      "community": 614,
+      "community": 617,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -52999,7 +53173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 618,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -53008,7 +53182,7 @@
       "source_location": "L21"
     },
     {
-      "community": 615,
+      "community": 618,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -53017,7 +53191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 619,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -53026,66 +53200,12 @@
       "source_location": "L33"
     },
     {
-      "community": 616,
+      "community": 619,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
       "norm_label": "complete.index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 617,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
-      "label": "pod-confirmation.tsx",
-      "norm_label": "pod-confirmation.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 617,
-      "file_type": "code",
-      "id": "pod_confirmation_completepodcheckoutsession",
-      "label": "completePODCheckoutSession()",
-      "norm_label": "completepodcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
-      "source_location": "L193"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_test_connection_js",
-      "label": "test-connection.js",
-      "norm_label": "test-connection.js",
-      "source_file": "packages/valkey-proxy-server/test-connection.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "test_connection_main",
-      "label": "main()",
-      "norm_label": "main()",
-      "source_file": "packages/valkey-proxy-server/test-connection.js",
-      "source_location": "L7"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "architecture_boundaries_test_createsnippetlinter",
-      "label": "createSnippetLinter()",
-      "norm_label": "createsnippetlinter()",
-      "source_file": "scripts/architecture-boundaries.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "scripts_architecture_boundaries_test_ts",
-      "label": "architecture-boundaries.test.ts",
-      "norm_label": "architecture-boundaries.test.ts",
-      "source_file": "scripts/architecture-boundaries.test.ts",
       "source_location": "L1"
     },
     {
@@ -53154,6 +53274,60 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
+      "label": "pod-confirmation.tsx",
+      "norm_label": "pod-confirmation.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "pod_confirmation_completepodcheckoutsession",
+      "label": "completePODCheckoutSession()",
+      "norm_label": "completepodcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
+      "source_location": "L193"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "packages_valkey_proxy_server_test_connection_js",
+      "label": "test-connection.js",
+      "norm_label": "test-connection.js",
+      "source_file": "packages/valkey-proxy-server/test-connection.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "test_connection_main",
+      "label": "main()",
+      "norm_label": "main()",
+      "source_file": "packages/valkey-proxy-server/test-connection.js",
+      "source_location": "L7"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
+      "id": "architecture_boundaries_test_createsnippetlinter",
+      "label": "createSnippetLinter()",
+      "norm_label": "createsnippetlinter()",
+      "source_file": "scripts/architecture-boundaries.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
+      "id": "scripts_architecture_boundaries_test_ts",
+      "label": "architecture-boundaries.test.ts",
+      "norm_label": "architecture-boundaries.test.ts",
+      "source_file": "scripts/architecture-boundaries.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 623,
+      "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
       "norm_label": "run()",
@@ -53161,7 +53335,7 @@
       "source_location": "L32"
     },
     {
-      "community": 620,
+      "community": 623,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -53170,7 +53344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 624,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -53179,7 +53353,7 @@
       "source_location": "L211"
     },
     {
-      "community": 621,
+      "community": 624,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -53188,7 +53362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 625,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -53197,7 +53371,7 @@
       "source_location": "L85"
     },
     {
-      "community": 622,
+      "community": 625,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -53206,7 +53380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 626,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -53215,7 +53389,7 @@
       "source_location": "L15"
     },
     {
-      "community": 623,
+      "community": 626,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -53224,7 +53398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -53233,7 +53407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -53242,39 +53416,12 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
       "norm_label": "datamodel.d.ts",
       "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 627,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_server_d_ts",
-      "label": "server.d.ts",
-      "norm_label": "server.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_server_js",
-      "label": "server.js",
-      "norm_label": "server.js",
-      "source_file": "packages/athena-webapp/convex/_generated/server.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_app_ts",
-      "label": "app.ts",
-      "norm_label": "app.ts",
-      "source_file": "packages/athena-webapp/convex/app.ts",
       "source_location": "L1"
     },
     {
@@ -53343,6 +53490,33 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_server_d_ts",
+      "label": "server.d.ts",
+      "norm_label": "server.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_server_js",
+      "label": "server.js",
+      "norm_label": "server.js",
+      "source_file": "packages/athena-webapp/convex/_generated/server.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_app_ts",
+      "label": "app.ts",
+      "norm_label": "app.ts",
+      "source_file": "packages/athena-webapp/convex/app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 633,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
       "norm_label": "auth.config.js",
@@ -53350,7 +53524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -53359,7 +53533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -53368,7 +53542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -53377,7 +53551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -53386,7 +53560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -53395,39 +53569,12 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
       "norm_label": "crons.ts",
       "source_file": "packages/athena-webapp/convex/crons.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 637,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
-      "label": "FeedbackRequest.tsx",
-      "norm_label": "feedbackrequest.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
-      "label": "NewOrderAdmin.tsx",
-      "norm_label": "neworderadmin.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
-      "label": "OrderEmail.tsx",
-      "norm_label": "orderemail.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
       "source_location": "L1"
     },
     {
@@ -53496,6 +53643,33 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
+      "label": "FeedbackRequest.tsx",
+      "norm_label": "feedbackrequest.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
+      "label": "NewOrderAdmin.tsx",
+      "norm_label": "neworderadmin.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
+      "label": "OrderEmail.tsx",
+      "norm_label": "orderemail.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 643,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
       "norm_label": "posreceiptemail.tsx",
@@ -53503,7 +53677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -53512,7 +53686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
       "label": "analytics.ts",
@@ -53521,7 +53695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
@@ -53530,7 +53704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -53539,7 +53713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -53548,39 +53722,12 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
       "norm_label": "colors.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/colors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 647,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
-      "label": "organizations.ts",
-      "norm_label": "organizations.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/organizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
-      "label": "products.ts",
-      "norm_label": "products.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/products.ts",
       "source_location": "L1"
     },
     {
@@ -53649,6 +53796,33 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
+      "label": "organizations.ts",
+      "norm_label": "organizations.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/organizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
+      "label": "products.ts",
+      "norm_label": "products.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/products.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 653,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
       "label": "stores.ts",
       "norm_label": "stores.ts",
@@ -53656,7 +53830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
       "label": "subcategories.ts",
@@ -53665,7 +53839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
@@ -53674,7 +53848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
       "label": "bag.ts",
@@ -53683,7 +53857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
@@ -53692,7 +53866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
@@ -53701,39 +53875,12 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
       "norm_label": "me.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/me.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/offers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
-      "label": "paystack.ts",
-      "norm_label": "paystack.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
       "source_location": "L1"
     },
     {
@@ -53802,6 +53949,33 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
+      "label": "paystack.ts",
+      "norm_label": "paystack.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 663,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
       "label": "reviews.ts",
       "norm_label": "reviews.ts",
@@ -53809,7 +53983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
@@ -53818,7 +53992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -53827,7 +54001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
       "label": "security.test.ts",
@@ -53836,7 +54010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
@@ -53845,7 +54019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
@@ -53854,39 +54028,12 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 667,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_health_test_ts",
-      "label": "health.test.ts",
-      "norm_label": "health.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/health.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_ts",
-      "label": "http.ts",
-      "norm_label": "http.ts",
-      "source_file": "packages/athena-webapp/convex/http.ts",
       "source_location": "L1"
     },
     {
@@ -53955,6 +54102,33 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/userOffers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_health_test_ts",
+      "label": "health.test.ts",
+      "norm_label": "health.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/health.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_ts",
+      "label": "http.ts",
+      "norm_label": "http.ts",
+      "source_file": "packages/athena-webapp/convex/http.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 673,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
       "norm_label": "athenauser.ts",
@@ -53962,7 +54136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -53971,7 +54145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -53980,7 +54154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -53989,7 +54163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -53998,7 +54172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -54007,39 +54181,12 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
       "norm_label": "complimentaryproduct.ts",
       "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 677,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
-      "label": "expenseSessionItems.ts",
-      "norm_label": "expensesessionitems.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
-      "label": "expenseTransactions.ts",
-      "norm_label": "expensetransactions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
-      "label": "featuredItem.ts",
-      "norm_label": "featureditem.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
       "source_location": "L1"
     },
     {
@@ -54108,6 +54255,33 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
+      "label": "expenseSessionItems.ts",
+      "norm_label": "expensesessionitems.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
+      "label": "expenseTransactions.ts",
+      "norm_label": "expensetransactions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
+      "label": "featuredItem.ts",
+      "norm_label": "featureditem.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 683,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
       "norm_label": "invitecode.ts",
@@ -54115,7 +54289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -54124,7 +54298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -54133,7 +54307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -54142,7 +54316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 687,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -54151,7 +54325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 688,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -54160,39 +54334,12 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 689,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
       "norm_label": "productsku.ts",
       "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 687,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_productutil_ts",
-      "label": "productUtil.ts",
-      "norm_label": "productutil.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_promocode_ts",
-      "label": "promoCode.ts",
-      "norm_label": "promocode.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
-      "label": "stockValidation.ts",
-      "norm_label": "stockvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
       "source_location": "L1"
     },
     {
@@ -54261,6 +54408,33 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_productutil_ts",
+      "label": "productUtil.ts",
+      "norm_label": "productutil.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_promocode_ts",
+      "label": "promoCode.ts",
+      "norm_label": "promocode.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
+      "label": "stockValidation.ts",
+      "norm_label": "stockvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 693,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
       "norm_label": "storeconfigv2.test.ts",
@@ -54268,7 +54442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 694,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -54277,7 +54451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -54286,7 +54460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -54295,7 +54469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -54304,7 +54478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -54313,39 +54487,12 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
       "norm_label": "client.test.ts",
       "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 697,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_test_ts",
-      "label": "config.test.ts",
-      "norm_label": "config.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
-      "label": "normalize.test.ts",
-      "norm_label": "normalize.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/types.ts",
       "source_location": "L1"
     },
     {
@@ -54639,6 +54786,33 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_test_ts",
+      "label": "config.test.ts",
+      "norm_label": "config.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
+      "label": "normalize.test.ts",
+      "norm_label": "normalize.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 703,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
       "norm_label": "approvalrequests.test.ts",
@@ -54646,7 +54820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -54655,7 +54829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -54664,7 +54838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -54673,7 +54847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -54682,7 +54856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_resendotp_ts",
       "label": "ResendOTP.ts",
@@ -54691,39 +54865,12 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
       "norm_label": "schema.ts",
       "source_file": "packages/athena-webapp/convex/schema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 707,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
-      "label": "appVerificationCode.ts",
-      "norm_label": "appverificationcode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/appVerificationCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
-      "label": "athenaUser.ts",
-      "norm_label": "athenauser.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/athenaUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/bannerMessage.ts",
       "source_location": "L1"
     },
     {
@@ -54783,6 +54930,33 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
+      "label": "appVerificationCode.ts",
+      "norm_label": "appverificationcode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/appVerificationCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
+      "label": "athenaUser.ts",
+      "norm_label": "athenauser.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/athenaUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 713,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
       "norm_label": "bestseller.ts",
@@ -54790,7 +54964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 714,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -54799,7 +54973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 715,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -54808,7 +54982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 716,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -54817,7 +54991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 717,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -54826,7 +55000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 718,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -54835,39 +55009,12 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 719,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 717,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
-      "label": "inviteCode.ts",
-      "norm_label": "invitecode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/organization.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
-      "label": "organizationMember.ts",
-      "norm_label": "organizationmember.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/organizationMember.ts",
       "source_location": "L1"
     },
     {
@@ -54927,6 +55074,33 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
+      "label": "inviteCode.ts",
+      "norm_label": "invitecode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/organization.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
+      "label": "organizationMember.ts",
+      "norm_label": "organizationmember.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/organizationMember.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 723,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
@@ -54934,7 +55108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 724,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -54943,7 +55117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 725,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -54952,7 +55126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -54961,7 +55135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -54970,7 +55144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -54979,39 +55153,12 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
       "norm_label": "customerprofile.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/customerProfile.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 727,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
-      "label": "inventoryMovement.ts",
-      "norm_label": "inventorymovement.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/inventoryMovement.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
-      "label": "operationalEvent.ts",
-      "norm_label": "operationalevent.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalEvent.ts",
       "source_location": "L1"
     },
     {
@@ -55071,6 +55218,33 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
+      "label": "inventoryMovement.ts",
+      "norm_label": "inventorymovement.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/inventoryMovement.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 732,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
+      "label": "operationalEvent.ts",
+      "norm_label": "operationalevent.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 733,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
       "norm_label": "operationalworkitem.ts",
@@ -55078,7 +55252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -55087,7 +55261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -55096,7 +55270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -55105,7 +55279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -55114,7 +55288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -55123,39 +55297,12 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
       "norm_label": "customer.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 737,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
-      "label": "expenseSession.ts",
-      "norm_label": "expensesession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
-      "label": "expenseSessionItem.ts",
-      "norm_label": "expensesessionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
-      "label": "expenseTransaction.ts",
-      "norm_label": "expensetransaction.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
       "source_location": "L1"
     },
     {
@@ -55215,6 +55362,33 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
+      "label": "expenseSession.ts",
+      "norm_label": "expensesession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
+      "label": "expenseSessionItem.ts",
+      "norm_label": "expensesessionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 742,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
+      "label": "expenseTransaction.ts",
+      "norm_label": "expensetransaction.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 743,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
       "norm_label": "expensetransactionitem.ts",
@@ -55222,7 +55396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -55231,7 +55405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -55240,7 +55414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -55249,7 +55423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -55258,7 +55432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -55267,39 +55441,12 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
       "norm_label": "postransactionitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 747,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 748,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
-      "label": "serviceAppointment.ts",
-      "norm_label": "serviceappointment.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceAppointment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
-      "label": "serviceCase.ts",
-      "norm_label": "servicecase.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCase.ts",
       "source_location": "L1"
     },
     {
@@ -55359,6 +55506,33 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
+      "label": "serviceAppointment.ts",
+      "norm_label": "serviceappointment.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceAppointment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 752,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
+      "label": "serviceCase.ts",
+      "norm_label": "servicecase.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCase.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 753,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
       "norm_label": "servicecaselineitem.ts",
@@ -55366,7 +55540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -55375,7 +55549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -55384,7 +55558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -55393,7 +55567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -55402,7 +55576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -55411,39 +55585,12 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
       "norm_label": "checkoutsession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 757,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
-      "label": "checkoutSessionItem.ts",
-      "norm_label": "checkoutsessionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 758,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
-      "label": "customer.ts",
-      "norm_label": "customer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
       "source_location": "L1"
     },
     {
@@ -55503,6 +55650,33 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
+      "label": "checkoutSessionItem.ts",
+      "norm_label": "checkoutsessionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
+      "label": "customer.ts",
+      "norm_label": "customer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/customer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 762,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 763,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -55510,7 +55684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -55519,7 +55693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -55528,7 +55702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -55537,7 +55711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -55546,7 +55720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -55555,39 +55729,12 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
       "norm_label": "savedbag.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 767,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
-      "label": "savedBagItem.ts",
-      "norm_label": "savedbagitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 768,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
-      "label": "storeFrontSession.ts",
-      "norm_label": "storefrontsession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
-      "label": "storeFrontUser.ts",
-      "norm_label": "storefrontuser.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
       "source_location": "L1"
     },
     {
@@ -55647,6 +55794,33 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
+      "label": "savedBagItem.ts",
+      "norm_label": "savedbagitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
+      "label": "storeFrontSession.ts",
+      "norm_label": "storefrontsession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 772,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
+      "label": "storeFrontUser.ts",
+      "norm_label": "storefrontuser.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 773,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
       "norm_label": "storefrontverificationcode.ts",
@@ -55654,7 +55828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -55663,7 +55837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -55672,7 +55846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -55681,7 +55855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -55690,7 +55864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -55699,39 +55873,12 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 777,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
-      "label": "onlineOrderUtilFns.ts",
-      "norm_label": "onlineorderutilfns.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 778,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
-      "label": "orderOperations.test.ts",
-      "norm_label": "orderoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/orderOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_payment_ts",
-      "label": "payment.ts",
-      "norm_label": "payment.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/payment.ts",
       "source_location": "L1"
     },
     {
@@ -55791,6 +55938,33 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
+      "label": "onlineOrderUtilFns.ts",
+      "norm_label": "onlineorderutilfns.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
+      "label": "orderOperations.test.ts",
+      "norm_label": "orderoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/orderOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 782,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_payment_ts",
+      "label": "payment.ts",
+      "norm_label": "payment.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/payment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 783,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
       "norm_label": "paystackactions.ts",
@@ -55798,16 +55972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 782,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -55816,7 +55981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -55825,7 +55990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -55834,7 +55999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -55843,7 +56008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -55852,30 +56017,12 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 788,
-      "file_type": "code",
-      "id": "packages_athena_webapp_postcss_config_js",
-      "label": "postcss.config.js",
-      "norm_label": "postcss.config.js",
-      "source_file": "packages/athena-webapp/postcss.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
-      "label": "GenericComboBox.tsx",
-      "norm_label": "genericcombobox.tsx",
-      "source_file": "packages/athena-webapp/src/components/GenericComboBox.tsx",
       "source_location": "L1"
     },
     {
@@ -55935,6 +56082,24 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "packages_athena_webapp_postcss_config_js",
+      "label": "postcss.config.js",
+      "norm_label": "postcss.config.js",
+      "source_file": "packages/athena-webapp/postcss.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
+      "label": "GenericComboBox.tsx",
+      "norm_label": "genericcombobox.tsx",
+      "source_file": "packages/athena-webapp/src/components/GenericComboBox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 792,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
       "norm_label": "storeaccordion.tsx",
@@ -55942,7 +56107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -55951,7 +56116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -55960,7 +56125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -55969,7 +56134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -55978,7 +56143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -55987,7 +56152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -55996,30 +56161,12 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/types.ts",
       "source_location": "L1"
     },
     {
@@ -56277,6 +56424,24 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 802,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
       "norm_label": "conversionfunnelchart.tsx",
@@ -56284,7 +56449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -56293,7 +56458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -56302,7 +56467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -56311,7 +56476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56320,7 +56485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56329,7 +56494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -56338,30 +56503,12 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 808,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -56421,6 +56568,24 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 812,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -56428,7 +56593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -56437,7 +56602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56446,7 +56611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -56455,7 +56620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56464,7 +56629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56473,7 +56638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -56482,30 +56647,12 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 818,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -56565,6 +56712,24 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 822,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -56572,7 +56737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -56581,7 +56746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56590,7 +56755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56599,7 +56764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56608,7 +56773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -56617,7 +56782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -56626,30 +56791,12 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 828,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -56709,6 +56856,24 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 832,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
       "norm_label": "data-table-column-header.tsx",
@@ -56716,7 +56881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56725,7 +56890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -56734,7 +56899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -56743,7 +56908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -56752,7 +56917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -56761,7 +56926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -56770,30 +56935,12 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 838,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -56853,6 +57000,24 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 842,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -56860,7 +57025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -56869,7 +57034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -56878,7 +57043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -56887,7 +57052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -56896,7 +57061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -56905,7 +57070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -56914,30 +57079,12 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 848,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -56997,6 +57144,24 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 852,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -57004,7 +57169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -57013,7 +57178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -57022,7 +57187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -57031,7 +57196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -57040,7 +57205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -57049,7 +57214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
       "label": "index.tsx",
@@ -57058,30 +57223,12 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 858,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -57141,6 +57288,24 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 862,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
       "norm_label": "metriccard.tsx",
@@ -57148,7 +57313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -57157,7 +57322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -57166,7 +57331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -57175,7 +57340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -57184,7 +57349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -57193,7 +57358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -57202,30 +57367,12 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
       "norm_label": "orders.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 868,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
-      "label": "ReturnExchangeView.test.tsx",
-      "norm_label": "returnexchangeview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
       "source_location": "L1"
     },
     {
@@ -57285,6 +57432,24 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
+      "label": "ReturnExchangeView.test.tsx",
+      "norm_label": "returnexchangeview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 872,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -57292,7 +57457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -57301,7 +57466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -57310,7 +57475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -57319,7 +57484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -57328,7 +57493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -57337,7 +57502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -57346,30 +57511,12 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 878,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -57429,6 +57576,24 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 882,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
@@ -57436,7 +57601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -57445,7 +57610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -57454,7 +57619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -57463,7 +57628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -57472,7 +57637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -57481,7 +57646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -57490,30 +57655,12 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 888,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
-      "label": "membersColumns.tsx",
-      "norm_label": "memberscolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
-      "label": "CartItems.tsx",
-      "norm_label": "cartitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
       "source_location": "L1"
     },
     {
@@ -57573,6 +57720,24 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
+      "label": "membersColumns.tsx",
+      "norm_label": "memberscolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
+      "label": "CartItems.tsx",
+      "norm_label": "cartitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 892,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
       "norm_label": "cashierauthdialog.tsx",
@@ -57580,7 +57745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -57589,7 +57754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -57598,7 +57763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -57607,7 +57772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -57616,7 +57781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -57625,7 +57790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -57634,30 +57799,12 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
       "norm_label": "transactionview.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
-      "label": "AnalyticsInsights.tsx",
-      "norm_label": "analyticsinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
       "source_location": "L1"
     },
     {
@@ -57906,6 +58053,24 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
+      "label": "AnalyticsInsights.tsx",
+      "norm_label": "analyticsinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 902,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
       "norm_label": "attributesview.tsx",
@@ -57913,7 +58078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -57922,7 +58087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -57931,7 +58096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -57940,7 +58105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -57949,7 +58114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -57958,7 +58123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -57967,30 +58132,12 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
       "norm_label": "storeproducts.tsx",
       "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 908,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
-      "label": "UnresolvedProducts.tsx",
-      "norm_label": "unresolvedproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
-      "label": "ComplimentaryProducts.tsx",
-      "norm_label": "complimentaryproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
       "source_location": "L1"
     },
     {
@@ -58050,6 +58197,24 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
+      "label": "UnresolvedProducts.tsx",
+      "norm_label": "unresolvedproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
+      "label": "ComplimentaryProducts.tsx",
+      "norm_label": "complimentaryproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 912,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
       "norm_label": "complimentaryproductscolumn.tsx",
@@ -58057,7 +58222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -58066,7 +58231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -58075,7 +58240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58084,7 +58249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -58093,7 +58258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -58102,7 +58267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -58111,30 +58276,12 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
       "norm_label": "productcolumns.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 918,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
-      "label": "PromoCodePreview.tsx",
-      "norm_label": "promocodepreview.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodePreview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
-      "label": "PromoCodes.tsx",
-      "norm_label": "promocodes.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodes.tsx",
       "source_location": "L1"
     },
     {
@@ -58194,6 +58341,24 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
+      "label": "PromoCodePreview.tsx",
+      "norm_label": "promocodepreview.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodePreview.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
+      "label": "PromoCodes.tsx",
+      "norm_label": "promocodes.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 922,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
       "norm_label": "promocodeanalytics.tsx",
@@ -58201,7 +58366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -58210,7 +58375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -58219,7 +58384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -58228,7 +58393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -58237,7 +58402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58246,7 +58411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -58255,30 +58420,12 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 928,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -58338,6 +58485,24 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 932,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -58345,7 +58510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58354,7 +58519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -58363,7 +58528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -58372,7 +58537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -58381,7 +58546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -58390,7 +58555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -58399,30 +58564,12 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
       "norm_label": "reviewcard.tsx",
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 938,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
-      "label": "ReviewMetadata.tsx",
-      "norm_label": "reviewmetadata.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
-      "label": "ServiceAppointmentsView.test.tsx",
-      "norm_label": "serviceappointmentsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -58482,6 +58629,24 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
+      "label": "ReviewMetadata.tsx",
+      "norm_label": "reviewmetadata.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
+      "label": "ServiceAppointmentsView.test.tsx",
+      "norm_label": "serviceappointmentsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 942,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
       "norm_label": "servicecasesview.test.tsx",
@@ -58489,7 +58654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -58498,7 +58663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -58507,7 +58672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -58516,7 +58681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -58525,7 +58690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -58534,7 +58699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -58543,30 +58708,12 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
       "norm_label": "button.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 948,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
-      "label": "calendar.test.tsx",
-      "norm_label": "calendar.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_card_tsx",
-      "label": "card.tsx",
-      "norm_label": "card.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
       "source_location": "L1"
     },
     {
@@ -58626,6 +58773,24 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
+      "label": "calendar.test.tsx",
+      "norm_label": "calendar.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_card_tsx",
+      "label": "card.tsx",
+      "norm_label": "card.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 952,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
       "norm_label": "checkbox.tsx",
@@ -58633,7 +58798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -58642,7 +58807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -58651,7 +58816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -58660,7 +58825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -58669,7 +58834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -58678,7 +58843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -58687,30 +58852,12 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
       "norm_label": "icons.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/icons.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 958,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
-      "label": "input-otp.tsx",
-      "norm_label": "input-otp.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
       "source_location": "L1"
     },
     {
@@ -58770,6 +58917,24 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
+      "label": "input-otp.tsx",
+      "norm_label": "input-otp.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 962,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
       "norm_label": "action-modal.tsx",
@@ -58777,7 +58942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -58786,7 +58951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -58795,7 +58960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -58804,7 +58969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -58813,7 +58978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -58822,7 +58987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -58831,30 +58996,12 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
       "norm_label": "sheet.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 968,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
-      "label": "switch.tsx",
-      "norm_label": "switch.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_table_tsx",
-      "label": "table.tsx",
-      "norm_label": "table.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
       "source_location": "L1"
     },
     {
@@ -58914,6 +59061,24 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
+      "label": "switch.tsx",
+      "norm_label": "switch.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_table_tsx",
+      "label": "table.tsx",
+      "norm_label": "table.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 972,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
       "norm_label": "tabs.tsx",
@@ -58921,7 +59086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -58930,7 +59095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -58939,7 +59104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -58948,7 +59113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -58957,7 +59122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -58966,7 +59131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -58975,30 +59140,12 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 978,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -59058,6 +59205,24 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 982,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -59065,7 +59230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -59074,7 +59239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -59083,7 +59248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -59092,7 +59257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -59101,7 +59266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -59110,7 +59275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -59119,30 +59284,12 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 988,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -59193,6 +59340,24 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 992,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -59200,7 +59365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -59209,7 +59374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -59218,7 +59383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -59227,7 +59392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -59236,7 +59401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -59245,7 +59410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -59254,30 +59419,12 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
       "norm_label": "config.ts",
       "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
-      "label": "ThemeContext.tsx",
-      "norm_label": "themecontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1312
-- Graph nodes: 3098
-- Graph edges: 2616
-- Communities: 1227
+- Code files discovered: 1314
+- Graph nodes: 3105
+- Graph edges: 2623
+- Communities: 1229
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 25) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 180) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 181) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 25) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 25) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 25) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -199,6 +199,7 @@ import type * as storeFront_customerBehaviorTimeline from "../storeFront/custome
 import type * as storeFront_customerObservabilityTimelineData from "../storeFront/customerObservabilityTimelineData.js";
 import type * as storeFront_guest from "../storeFront/guest.js";
 import type * as storeFront_helpers_bag from "../storeFront/helpers/bag.js";
+import type * as storeFront_helpers_customerEngagementEvents from "../storeFront/helpers/customerEngagementEvents.js";
 import type * as storeFront_helpers_onlineOrder from "../storeFront/helpers/onlineOrder.js";
 import type * as storeFront_helpers_orderOperations from "../storeFront/helpers/orderOperations.js";
 import type * as storeFront_helpers_orderUpdateEmails from "../storeFront/helpers/orderUpdateEmails.js";
@@ -420,6 +421,7 @@ declare const fullApi: ApiFromModules<{
   "storeFront/customerObservabilityTimelineData": typeof storeFront_customerObservabilityTimelineData;
   "storeFront/guest": typeof storeFront_guest;
   "storeFront/helpers/bag": typeof storeFront_helpers_bag;
+  "storeFront/helpers/customerEngagementEvents": typeof storeFront_helpers_customerEngagementEvents;
   "storeFront/helpers/onlineOrder": typeof storeFront_helpers_onlineOrder;
   "storeFront/helpers/orderOperations": typeof storeFront_helpers_orderOperations;
   "storeFront/helpers/orderUpdateEmails": typeof storeFront_helpers_orderUpdateEmails;

--- a/packages/athena-webapp/convex/operations/operationalEvents.ts
+++ b/packages/athena-webapp/convex/operations/operationalEvents.ts
@@ -108,6 +108,7 @@ export const recordOperationalEvent = internalMutation({
     eventType: v.string(),
     subjectType: v.string(),
     subjectId: v.string(),
+    subjectLabel: v.optional(v.string()),
     message: v.optional(v.string()),
     reason: v.optional(v.string()),
     metadata: v.optional(v.record(v.string(), v.any())),

--- a/packages/athena-webapp/convex/schemas/operations/operationalEvent.ts
+++ b/packages/athena-webapp/convex/schemas/operations/operationalEvent.ts
@@ -6,6 +6,7 @@ export const operationalEventSchema = v.object({
   eventType: v.string(),
   subjectType: v.string(),
   subjectId: v.string(),
+  subjectLabel: v.optional(v.string()),
   message: v.string(),
   reason: v.optional(v.string()),
   metadata: v.optional(v.record(v.string(), v.any())),

--- a/packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts
+++ b/packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts
@@ -1,15 +1,24 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveCustomerProfileIdForTimeline } from "./customerBehaviorTimeline";
+import {
+  getCustomerOperationalTimelineEvents,
+  resolveCustomerProfileIdForTimeline,
+} from "./customerBehaviorTimeline";
 
 function createQueryCtx({
   guest,
   guestProfile,
+  loyaltyEvents,
+  onlineOrder,
+  onlineOrderEvents,
   storeFrontProfile,
   storeFrontUser,
 }: {
   guest?: { _id: string } | null;
   guestProfile?: { _id: string } | null;
+  loyaltyEvents?: Array<Record<string, unknown>>;
+  onlineOrder?: { _id: string; orderNumber?: string } | null;
+  onlineOrderEvents?: Array<Record<string, unknown>>;
   storeFrontProfile?: { _id: string } | null;
   storeFrontUser?: { _id: string } | null;
 }) {
@@ -24,28 +33,55 @@ function createQueryCtx({
           return guest;
         }
 
+        if (table === "onlineOrder" && onlineOrder?._id === id) {
+          return onlineOrder;
+        }
+
         return null;
       },
       query(table: string) {
-        expect(table).toBe("customerProfile");
+        if (table === "customerProfile") {
+          return {
+            withIndex(index: string) {
+              return {
+                async first() {
+                  if (index === "by_storeFrontUserId") {
+                    return storeFrontProfile ?? null;
+                  }
 
-        return {
-          withIndex(index: string) {
-            return {
-              async first() {
-                if (index === "by_storeFrontUserId") {
-                  return storeFrontProfile ?? null;
-                }
+                  if (index === "by_guestId") {
+                    return guestProfile ?? null;
+                  }
 
-                if (index === "by_guestId") {
-                  return guestProfile ?? null;
-                }
+                  return null;
+                },
+              };
+            },
+          };
+        }
 
-                return null;
-              },
-            };
-          },
-        };
+        if (table === "operationalEvent") {
+          return {
+            withIndex(index: string) {
+              expect(index).toBe("by_customerProfileId");
+
+              return {
+                order() {
+                  return {
+                    async take() {
+                      return [
+                        ...(onlineOrderEvents ?? []),
+                        ...(loyaltyEvents ?? []),
+                      ];
+                    },
+                  };
+                },
+              };
+            },
+          };
+        }
+
+        throw new Error(`Unexpected table query: ${table}`);
       },
     },
   } as any;
@@ -74,5 +110,78 @@ describe("resolveCustomerProfileIdForTimeline", () => {
     );
 
     expect(customerProfileId).toBe("customer_guest_1");
+  });
+});
+
+describe("getCustomerOperationalTimelineEvents", () => {
+  it("keeps loyalty and follow-up milestones in the Athena customer timeline", async () => {
+    const events = await getCustomerOperationalTimelineEvents(
+      createQueryCtx({
+        loyaltyEvents: [
+          {
+            _id: "loyalty_event_1",
+            createdAt: 250,
+            customerProfileId: "customer_storefront_1",
+            eventType: "loyalty_points_awarded",
+            message: "Awarded 120 loyalty points after checkout.",
+            metadata: { points: 120 },
+            storeId: "store_1",
+            subjectId: "reward_txn_1",
+            subjectLabel: "120 points",
+            subjectType: "loyalty",
+          },
+          {
+            _id: "follow_up_event_1",
+            createdAt: 225,
+            customerProfileId: "customer_storefront_1",
+            eventType: "follow_up_offer_sent",
+            message: "Sent WELCOME25 follow-up offer email.",
+            metadata: { promoCode: "WELCOME25" },
+            storeId: "store_1",
+            subjectId: "offer_1",
+            subjectLabel: "WELCOME25",
+            subjectType: "follow_up",
+          },
+        ],
+        onlineOrder: { _id: "order_1", orderNumber: "ORD-1001" },
+        onlineOrderEvents: [
+          {
+            _id: "order_event_1",
+            createdAt: 300,
+            customerProfileId: "customer_storefront_1",
+            eventType: "online_order_ready_for_pickup",
+            onlineOrderId: "order_1",
+            storeId: "store_1",
+            subjectId: "order_1",
+            subjectType: "online_order",
+          },
+        ],
+        storeFrontProfile: { _id: "customer_storefront_1" },
+        storeFrontUser: { _id: "storefront_1" },
+      }),
+      "storefront_1" as any,
+      20,
+    );
+
+    expect(events).toMatchObject([
+      {
+        _id: "order_event_1",
+        eventType: "online_order_ready_for_pickup",
+        subjectLabel: "ORD-1001",
+        subjectType: "online_order",
+      },
+      {
+        _id: "loyalty_event_1",
+        eventType: "loyalty_points_awarded",
+        subjectLabel: "120 points",
+        subjectType: "loyalty",
+      },
+      {
+        _id: "follow_up_event_1",
+        eventType: "follow_up_offer_sent",
+        subjectLabel: "WELCOME25",
+        subjectType: "follow_up",
+      },
+    ]);
   });
 });

--- a/packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts
+++ b/packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts
@@ -150,7 +150,7 @@ export async function resolveCustomerProfileIdForTimeline(
   return null;
 }
 
-async function getCustomerOperationalTimelineEvents(
+export async function getCustomerOperationalTimelineEvents(
   ctx: QueryCtx,
   userId: Id<"storeFrontUser"> | Id<"guest">,
   limit: number,
@@ -168,13 +168,13 @@ async function getCustomerOperationalTimelineEvents(
     .order("desc")
     .take(Math.max(limit * 5, 500));
 
-  const onlineOrderEvents = events.filter(
-    (event) => event.subjectType === "online_order" || Boolean(event.onlineOrderId),
+  const customerEvents = events.filter(
+    (event) => event.customerProfileId === customerProfileId,
   );
 
   const onlineOrderIds = [
     ...new Set(
-      onlineOrderEvents
+      customerEvents
         .map((event) => event.onlineOrderId)
         .filter((onlineOrderId): onlineOrderId is Id<"onlineOrder"> =>
           Boolean(onlineOrderId),
@@ -193,12 +193,13 @@ async function getCustomerOperationalTimelineEvents(
     }
   }
 
-  return onlineOrderEvents.map((event) => ({
+  return customerEvents.map((event) => ({
     ...event,
     _creationTime: event.createdAt,
-    subjectLabel: event.onlineOrderId
-      ? onlineOrderMap.get(event.onlineOrderId)?.orderNumber
-      : undefined,
+    subjectLabel:
+      (event.onlineOrderId
+        ? onlineOrderMap.get(event.onlineOrderId)?.orderNumber
+        : undefined) ?? event.subjectLabel,
   }));
 }
 

--- a/packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts
+++ b/packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import { recordStoreFrontCustomerMilestone } from "./customerEngagementEvents";
+
+function createMutationCtx({
+  guest,
+  guestProfile,
+  store,
+  storeFrontProfile,
+  storeFrontUser,
+}: {
+  guest?: { _id: string } | null;
+  guestProfile?: { _id: string } | null;
+  store?: { _id: string; organizationId?: string } | null;
+  storeFrontProfile?: { _id: string } | null;
+  storeFrontUser?: { _id: string } | null;
+}) {
+  const insertedEvents: Array<Record<string, unknown>> = [];
+
+  return {
+    ctx: {
+      db: {
+        async get(table: string, id: string) {
+          if (table === "store" && store?._id === id) {
+            return store;
+          }
+
+          if (table === "storeFrontUser" && storeFrontUser?._id === id) {
+            return storeFrontUser;
+          }
+
+          if (table === "guest" && guest?._id === id) {
+            return guest;
+          }
+
+          if (table === "operationalEvent" && id === "operational_event_1") {
+            return {
+              _id: "operational_event_1",
+              ...insertedEvents.at(-1),
+            };
+          }
+
+          return null;
+        },
+        async insert(table: string, value: Record<string, unknown>) {
+          expect(table).toBe("operationalEvent");
+          insertedEvents.push(value);
+          return "operational_event_1";
+        },
+        query(table: string) {
+          if (table === "customerProfile") {
+            return {
+              withIndex(index: string) {
+                return {
+                  async first() {
+                    if (index === "by_storeFrontUserId") {
+                      return storeFrontProfile ?? null;
+                    }
+
+                    if (index === "by_guestId") {
+                      return guestProfile ?? null;
+                    }
+
+                    return null;
+                  },
+                };
+              },
+            };
+          }
+
+          if (table === "operationalEvent") {
+            return {
+              withIndex(index: string) {
+                expect(index).toBe("by_storeId_subject");
+
+                return {
+                  collect: async () => [],
+                };
+              },
+            };
+          }
+
+          throw new Error(`Unexpected table query: ${table}`);
+        },
+      },
+    } as any,
+    insertedEvents,
+  };
+}
+
+describe("recordStoreFrontCustomerMilestone", () => {
+  it("records loyalty milestones against the shared customer profile for registered users", async () => {
+    const { ctx, insertedEvents } = createMutationCtx({
+      store: { _id: "store_1", organizationId: "org_1" },
+      storeFrontProfile: { _id: "customer_storefront_1" },
+      storeFrontUser: { _id: "storefront_1" },
+    });
+
+    await recordStoreFrontCustomerMilestone(ctx, {
+      eventType: "loyalty_points_awarded",
+      metadata: { points: 120 },
+      storeFrontUserId: "storefront_1" as any,
+      storeId: "store_1" as any,
+      subjectId: "reward_txn_1",
+      subjectLabel: "120 points",
+      subjectType: "loyalty",
+    });
+
+    expect(insertedEvents[0]).toMatchObject({
+      customerProfileId: "customer_storefront_1",
+      eventType: "loyalty_points_awarded",
+      metadata: { points: 120 },
+      organizationId: "org_1",
+      storeId: "store_1",
+      subjectId: "reward_txn_1",
+      subjectLabel: "120 points",
+      subjectType: "loyalty",
+    });
+  });
+
+  it("records follow-up milestones against guest-linked customer profiles", async () => {
+    const { ctx, insertedEvents } = createMutationCtx({
+      guest: { _id: "guest_1" },
+      guestProfile: { _id: "customer_guest_1" },
+      store: { _id: "store_1", organizationId: "org_1" },
+    });
+
+    await recordStoreFrontCustomerMilestone(ctx, {
+      eventType: "follow_up_offer_sent",
+      metadata: { promoCode: "WELCOME25" },
+      storeFrontUserId: "guest_1" as any,
+      storeId: "store_1" as any,
+      subjectId: "offer_1",
+      subjectLabel: "WELCOME25",
+      subjectType: "follow_up",
+    });
+
+    expect(insertedEvents[0]).toMatchObject({
+      customerProfileId: "customer_guest_1",
+      eventType: "follow_up_offer_sent",
+      metadata: { promoCode: "WELCOME25" },
+      organizationId: "org_1",
+      storeId: "store_1",
+      subjectId: "offer_1",
+      subjectLabel: "WELCOME25",
+      subjectType: "follow_up",
+    });
+  });
+});

--- a/packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts
+++ b/packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts
@@ -1,0 +1,104 @@
+import { Id } from "../../_generated/dataModel";
+import { MutationCtx } from "../../_generated/server";
+import { recordOperationalEventWithCtx } from "../../operations/operationalEvents";
+import { resolveCustomerProfileForStoreFrontActor } from "./orderOperations";
+
+type StoreFrontActorId = Id<"storeFrontUser"> | Id<"guest">;
+
+export type RecordStoreFrontCustomerMilestoneArgs = {
+  actorUserId?: Id<"athenaUser">;
+  eventType: string;
+  message?: string;
+  metadata?: Record<string, unknown>;
+  reason?: string;
+  storeFrontUserId: StoreFrontActorId;
+  storeId: Id<"store">;
+  subjectId: string;
+  subjectLabel?: string;
+  subjectType: string;
+};
+
+async function findExistingCustomerProfileId(
+  ctx: MutationCtx,
+  storeFrontUserId: StoreFrontActorId,
+) {
+  try {
+    const storeFrontUser = await ctx.db.get(
+      "storeFrontUser",
+      storeFrontUserId as Id<"storeFrontUser">,
+    );
+
+    if (storeFrontUser) {
+      const profile = await ctx.db
+        .query("customerProfile")
+        .withIndex("by_storeFrontUserId", (q) =>
+          q.eq("storeFrontUserId", storeFrontUser._id),
+        )
+        .first();
+
+      if (profile?._id) {
+        return profile._id;
+      }
+    }
+  } catch {}
+
+  try {
+    const guest = await ctx.db.get("guest", storeFrontUserId as Id<"guest">);
+
+    if (guest) {
+      const profile = await ctx.db
+        .query("customerProfile")
+        .withIndex("by_guestId", (q) => q.eq("guestId", guest._id))
+        .first();
+
+      if (profile?._id) {
+        return profile._id;
+      }
+    }
+  } catch {}
+
+  return null;
+}
+
+async function getStoreOrganizationId(
+  ctx: MutationCtx,
+  storeId: Id<"store">,
+) {
+  const store = await ctx.db.get("store", storeId);
+  return store?.organizationId;
+}
+
+export async function recordStoreFrontCustomerMilestone(
+  ctx: MutationCtx,
+  args: RecordStoreFrontCustomerMilestoneArgs,
+) {
+  const organizationId = (await getStoreOrganizationId(ctx, args.storeId)) ?? undefined;
+  const customerProfileId =
+    (await findExistingCustomerProfileId(ctx, args.storeFrontUserId)) ??
+    (
+      await resolveCustomerProfileForStoreFrontActor(ctx, {
+        organizationId,
+        storeFrontUserId: args.storeFrontUserId,
+        storeId: args.storeId,
+      })
+    )?._id ??
+    undefined;
+
+  if (!customerProfileId) {
+    return null;
+  }
+
+  return recordOperationalEventWithCtx(ctx, {
+    actorUserId: args.actorUserId,
+    customerProfileId,
+    eventType: args.eventType,
+    message: args.message,
+    metadata: args.metadata,
+    organizationId,
+    reason: args.reason,
+    storeId: args.storeId,
+    subjectId: args.subjectId,
+    subjectLabel: args.subjectLabel,
+    subjectType: args.subjectType,
+  });
+}

--- a/packages/athena-webapp/convex/storeFront/offers.ts
+++ b/packages/athena-webapp/convex/storeFront/offers.ts
@@ -19,6 +19,7 @@ import {
 } from "../mailersend";
 import { currencyFormatter, getProductName } from "../utils";
 import { getProductDiscountValue } from "../inventory/utils";
+import { recordStoreFrontCustomerMilestone } from "./helpers/customerEngagementEvents";
 
 const entity = "offer" as const;
 const MAX_OFFERS = 500;
@@ -132,6 +133,24 @@ const createOffer = async (
   });
 
   await updateStoreFrontActorEmail(ctx, args.storeFrontUserId, args.email);
+
+  const promoCode = await ctx.db.get("promoCode", args.promoCodeId);
+  const subjectLabel = promoCode?.code ?? args.email;
+
+  await recordStoreFrontCustomerMilestone(ctx, {
+    eventType: "follow_up_offer_requested",
+    message: `Requested ${subjectLabel} follow-up offer.`,
+    metadata: {
+      email: args.email,
+      promoCodeId: args.promoCodeId,
+      promoCode: promoCode?.code ?? null,
+    },
+    storeFrontUserId: args.storeFrontUserId,
+    storeId: args.storeId,
+    subjectId: offerId,
+    subjectLabel,
+    subjectType: "follow_up",
+  });
 
   return {
     success: true,
@@ -486,6 +505,11 @@ export const updateStatus = internalMutation({
     ),
   },
   handler: async (ctx, args) => {
+    const existingOffer = await ctx.db.get("offer", args.id);
+    if (!existingOffer) {
+      return;
+    }
+
     let update: any = {};
 
     if (args.status) {
@@ -501,13 +525,69 @@ export const updateStatus = internalMutation({
     }
 
     if (args.activity) {
-      const offer = await ctx.db.get("offer", args.id);
-      if (offer) {
-        update.activity = [...(offer.activity || []), args.activity];
-      }
+      update.activity = [...(existingOffer.activity || []), args.activity];
     }
 
     await ctx.db.patch("offer", args.id, update);
+
+    const promoCode = await ctx.db.get("promoCode", existingOffer.promoCodeId);
+    const subjectLabel = promoCode?.code ?? existingOffer.email;
+
+    if (args.status === "sent") {
+      await recordStoreFrontCustomerMilestone(ctx, {
+        eventType: "follow_up_offer_sent",
+        message: `Sent ${subjectLabel} follow-up offer email.`,
+        metadata: {
+          email: existingOffer.email,
+          promoCode: promoCode?.code ?? null,
+          promoCodeId: existingOffer.promoCodeId,
+          sentAt: args.sentAt ?? null,
+          status: args.status,
+        },
+        storeFrontUserId: existingOffer.storeFrontUserId,
+        storeId: existingOffer.storeId,
+        subjectId: existingOffer._id,
+        subjectLabel,
+        subjectType: "follow_up",
+      });
+    }
+
+    if (args.status === "reminded") {
+      await recordStoreFrontCustomerMilestone(ctx, {
+        eventType: "follow_up_offer_reminded",
+        message: `Sent ${subjectLabel} follow-up reminder email.`,
+        metadata: {
+          activity: args.activity?.action ?? null,
+          email: existingOffer.email,
+          promoCode: promoCode?.code ?? null,
+          promoCodeId: existingOffer.promoCodeId,
+          status: args.status,
+        },
+        storeFrontUserId: existingOffer.storeFrontUserId,
+        storeId: existingOffer.storeId,
+        subjectId: existingOffer._id,
+        subjectLabel,
+        subjectType: "follow_up",
+      });
+    }
+
+    if (args.status === "redeemed") {
+      await recordStoreFrontCustomerMilestone(ctx, {
+        eventType: "follow_up_offer_redeemed",
+        message: `Redeemed ${subjectLabel} follow-up offer.`,
+        metadata: {
+          email: existingOffer.email,
+          promoCode: promoCode?.code ?? null,
+          promoCodeId: existingOffer.promoCodeId,
+          status: args.status,
+        },
+        storeFrontUserId: existingOffer.storeFrontUserId,
+        storeId: existingOffer.storeId,
+        subjectId: existingOffer._id,
+        subjectLabel,
+        subjectType: "follow_up",
+      });
+    }
   },
 });
 

--- a/packages/athena-webapp/convex/storeFront/rewards.ts
+++ b/packages/athena-webapp/convex/storeFront/rewards.ts
@@ -2,6 +2,11 @@ import { v } from "convex/values";
 import { internalMutation, mutation, query } from "../_generated/server";
 import { Id } from "../_generated/dataModel";
 import { api } from "../_generated/api";
+import { recordStoreFrontCustomerMilestone } from "./helpers/customerEngagementEvents";
+
+function formatPointsLabel(points: number) {
+  return `${points} points`;
+}
 
 // Get user's current points
 export const getUserPoints = query({
@@ -88,7 +93,7 @@ export const awardOrderPoints = internalMutation({
     }
 
     // Record the transaction
-    await ctx.db.insert("rewardTransactions", {
+    const rewardTransactionId = await ctx.db.insert("rewardTransactions", {
       storeFrontUserId: order.storeFrontUserId as Id<"storeFrontUser">,
       storeId: order.storeId,
       points: args.points,
@@ -123,6 +128,22 @@ export const awardOrderPoints = internalMutation({
         updatedAt: Date.now(),
       });
     }
+
+    await recordStoreFrontCustomerMilestone(ctx, {
+      eventType: "loyalty_points_awarded",
+      message: `Awarded ${formatPointsLabel(args.points)} after order ${order.orderNumber}.`,
+      metadata: {
+        orderId: args.orderId,
+        orderNumber: order.orderNumber,
+        points: args.points,
+        reason: "order_placed",
+      },
+      storeFrontUserId: order.storeFrontUserId as Id<"storeFrontUser">,
+      storeId: order.storeId,
+      subjectId: rewardTransactionId,
+      subjectLabel: formatPointsLabel(args.points),
+      subjectType: "loyalty",
+    });
 
     return { success: true };
   },
@@ -162,7 +183,7 @@ export const redeemPoints = mutation({
     }
 
     // Record the redemption transaction
-    await ctx.db.insert("rewardTransactions", {
+    const rewardTransactionId = await ctx.db.insert("rewardTransactions", {
       storeFrontUserId: args.storeFrontUserId,
       storeId: args.storeId,
       points: -tier.pointsRequired, // Negative points for redemption
@@ -173,6 +194,23 @@ export const redeemPoints = mutation({
     await ctx.db.patch(pointsRecord._id, {
       points: pointsRecord.points - tier.pointsRequired,
       updatedAt: Date.now(),
+    });
+
+    await recordStoreFrontCustomerMilestone(ctx, {
+      eventType: "reward_redeemed",
+      message: `Redeemed ${tier.pointsRequired} points for ${tier.name}.`,
+      metadata: {
+        discountType: tier.discountType,
+        discountValue: tier.discountValue,
+        points: tier.pointsRequired,
+        rewardTierId: args.rewardTierId,
+        rewardTierName: tier.name,
+      },
+      storeFrontUserId: args.storeFrontUserId,
+      storeId: args.storeId,
+      subjectId: rewardTransactionId,
+      subjectLabel: tier.name,
+      subjectType: "reward",
     });
 
     // Return the discount information for application
@@ -284,7 +322,7 @@ export const awardPointsForPastOrder = mutation({
     const pointsToAward = Math.floor(order.amount / 1000);
 
     // Record the transaction
-    await ctx.db.insert("rewardTransactions", {
+    const rewardTransactionId = await ctx.db.insert("rewardTransactions", {
       storeFrontUserId: args.storeFrontUserId,
       storeId: order.storeId,
       points: pointsToAward,
@@ -316,6 +354,22 @@ export const awardPointsForPastOrder = mutation({
         updatedAt: Date.now(),
       });
     }
+
+    await recordStoreFrontCustomerMilestone(ctx, {
+      eventType: "loyalty_points_awarded",
+      message: `Awarded ${formatPointsLabel(pointsToAward)} after order ${order.orderNumber}.`,
+      metadata: {
+        orderId: args.orderId,
+        orderNumber: order.orderNumber,
+        points: pointsToAward,
+        reason: "past_order_points",
+      },
+      storeFrontUserId: args.storeFrontUserId,
+      storeId: order.storeId,
+      subjectId: rewardTransactionId,
+      subjectLabel: formatPointsLabel(pointsToAward),
+      subjectType: "loyalty",
+    });
 
     return {
       success: true,
@@ -439,9 +493,28 @@ export const awardPointsForGuestOrders = mutation({
     // Batch insert all new transactions
     if (transactions.length > 0) {
       await Promise.all(
-        transactions.map((transaction) =>
-          ctx.db.insert("rewardTransactions", transaction)
-        )
+        transactions.map(async (transaction) => {
+          const rewardTransactionId = await ctx.db.insert(
+            "rewardTransactions",
+            transaction,
+          );
+
+          await recordStoreFrontCustomerMilestone(ctx, {
+            eventType: "loyalty_points_awarded",
+            message: `Awarded ${formatPointsLabel(transaction.points)} after order ${transaction.orderNumber}.`,
+            metadata: {
+              orderId: transaction.orderId,
+              orderNumber: transaction.orderNumber,
+              points: transaction.points,
+              reason: transaction.reason,
+            },
+            storeFrontUserId: transaction.storeFrontUserId,
+            storeId: transaction.storeId,
+            subjectId: rewardTransactionId,
+            subjectLabel: formatPointsLabel(transaction.points),
+            subjectType: "loyalty",
+          });
+        }),
       );
     }
 

--- a/packages/athena-webapp/convex/storeFront/rewards.ts
+++ b/packages/athena-webapp/convex/storeFront/rewards.ts
@@ -34,6 +34,7 @@ export const getTiers = query({
     storeId: v.id("store"),
   },
   handler: async (ctx, args) => {
+    // eslint-disable-next-line @convex-dev/no-collect-in-query -- Reward tiers are store-scoped and intentionally returned as the active set for checkout and loyalty surfaces.
     return await ctx.db
       .query("rewardTiers")
       .withIndex("by_store", (q) => q.eq("storeId", args.storeId))
@@ -48,6 +49,7 @@ export const getPointHistory = query({
     storeFrontUserId: v.id("storeFrontUser"),
   },
   handler: async (ctx, args) => {
+    // eslint-disable-next-line @convex-dev/no-collect-in-query -- Point history is intentionally returned as the full user-visible ledger for one storefront account.
     return await ctx.db
       .query("rewardTransactions")
       .withIndex("by_user", (q) =>
@@ -65,7 +67,7 @@ export const awardOrderPoints = internalMutation({
     points: v.number(),
   },
   handler: async (ctx, args) => {
-    const order = await ctx.db.get(args.orderId);
+    const order = await ctx.db.get("onlineOrder", args.orderId);
     if (!order) return { success: false, error: "Order not found" };
 
     // We can only award points to registered users, not guests
@@ -116,7 +118,7 @@ export const awardOrderPoints = internalMutation({
       .first();
 
     if (existing) {
-      await ctx.db.patch(existing._id, {
+      await ctx.db.patch("rewardPoints", existing._id, {
         points: existing.points + args.points,
         updatedAt: Date.now(),
       });
@@ -172,7 +174,7 @@ export const redeemPoints = mutation({
     }
 
     // Get the reward tier
-    const tier = await ctx.db.get(args.rewardTierId);
+    const tier = await ctx.db.get("rewardTiers", args.rewardTierId);
     if (!tier) {
       return { success: false, error: "Reward tier not found" };
     }
@@ -191,7 +193,7 @@ export const redeemPoints = mutation({
     });
 
     // Update the user's point balance
-    await ctx.db.patch(pointsRecord._id, {
+    await ctx.db.patch("rewardPoints", pointsRecord._id, {
       points: pointsRecord.points - tier.pointsRequired,
       updatedAt: Date.now(),
     });
@@ -256,6 +258,7 @@ export const getPastEligibleOrders = query({
   },
   handler: async (ctx, args) => {
     // Get all past orders for this email that were made as a guest
+    // eslint-disable-next-line @convex-dev/no-collect-in-query -- This guest-order recovery flow needs the full matching paid-order set before it can filter already-awarded transactions.
     const guestOrders = await ctx.db
       .query("onlineOrder")
       .filter((q) =>
@@ -305,7 +308,7 @@ export const awardPointsForPastOrder = mutation({
   },
   handler: async (ctx, args) => {
     // Get the order
-    const order = await ctx.db.get(args.orderId);
+    const order = await ctx.db.get("onlineOrder", args.orderId);
     if (!order) return { success: false, error: "Order not found" };
 
     // Check if this order has already had points awarded
@@ -342,7 +345,7 @@ export const awardPointsForPastOrder = mutation({
       .first();
 
     if (existing) {
-      await ctx.db.patch(existing._id, {
+      await ctx.db.patch("rewardPoints", existing._id, {
         points: existing.points + pointsToAward,
         updatedAt: Date.now(),
       });
@@ -398,7 +401,7 @@ export const getOrderPoints = query({
     }
 
     // If no transaction found, get the order to calculate potential points
-    const order = await ctx.db.get(args.orderId);
+    const order = await ctx.db.get("onlineOrder", args.orderId);
     if (!order) {
       return { points: 0 };
     }
@@ -419,7 +422,7 @@ export const awardPointsForGuestOrders = mutation({
   },
   handler: async (ctx, args) => {
     // Get guest information first
-    const guest = await ctx.db.get(args.guestId);
+    const guest = await ctx.db.get("guest", args.guestId);
     if (!guest || !guest.email) {
       return { success: false, error: "Guest not found or has no email" };
     }
@@ -464,7 +467,7 @@ export const awardPointsForGuestOrders = mutation({
         .first();
 
       if (existingTransaction) {
-        await ctx.db.patch(existingTransaction._id, {
+        await ctx.db.patch("rewardTransactions", existingTransaction._id, {
           points: existingTransaction.points + order.potentialPoints,
         });
       } else {
@@ -532,7 +535,7 @@ export const awardPointsForGuestOrders = mutation({
           .first();
 
         if (existingPointsRecord) {
-          return ctx.db.patch(existingPointsRecord._id, {
+          return ctx.db.patch("rewardPoints", existingPointsRecord._id, {
             points: existingPointsRecord.points + points,
             updatedAt: Date.now(),
           });

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -16,7 +16,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Backend and test surfaces
 
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 256 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 258 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 6 file(s); key children: README.md, SUMMARY.md, pos.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -41,6 +41,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/storeFront/customerBehaviorTimeline.test.ts`](../../convex/storeFront/customerBehaviorTimeline.test.ts)
 - [`convex/storeFront/customerObservabilityTimeline.test.ts`](../../convex/storeFront/customerObservabilityTimeline.test.ts)
 - [`convex/storeFront/helperOrchestration.test.ts`](../../convex/storeFront/helperOrchestration.test.ts)
+- [`convex/storeFront/helpers/customerEngagementEvents.test.ts`](../../convex/storeFront/helpers/customerEngagementEvents.test.ts)
 - [`convex/storeFront/orderOperations.test.ts`](../../convex/storeFront/orderOperations.test.ts)
 - [`convex/storeFront/returnExchangeOperations.test.ts`](../../convex/storeFront/returnExchangeOperations.test.ts)
 - [`convex/storeFront/storefrontObservabilityReport.test.ts`](../../convex/storeFront/storefrontObservabilityReport.test.ts)


### PR DESCRIPTION
## Summary
- add shared customer-profile milestone recording for loyalty and follow-up behavior
- surface loyalty, reward, and offer milestones in Athena customer history
- fix the operational event schema so subject labels are typed and preserved in timelines

## Testing
- bun run --filter @athena/webapp test convex/storeFront/customerObservabilityTimeline.test.ts src/components/users/TimelineEventCard.test.tsx convex/storeFront/helpers/customerEngagementEvents.test.ts convex/storeFront/customerBehaviorTimeline.test.ts
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run --filter @athena/webapp audit:convex
- bun run pr:athena