### PR TITLE
[V26-292]: Cash Controls: attribute service and retail cash through payment allocations

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1330 files · ~0 words
+- 1332 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3177 nodes · 2698 edges · 1246 communities detected
+- 3185 nodes · 2707 edges · 1248 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1256,6 +1256,8 @@
 - [[_COMMUNITY_Community 1243|Community 1243]]
 - [[_COMMUNITY_Community 1244|Community 1244]]
 - [[_COMMUNITY_Community 1245|Community 1245]]
+- [[_COMMUNITY_Community 1246|Community 1246]]
+- [[_COMMUNITY_Community 1247|Community 1247]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1324,12 +1326,12 @@ Cohesion: 0.17
 Nodes (15): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix() (+7 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.15
-Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
-
-### Community 11 - "Community 11"
 Cohesion: 0.11
 Nodes (2): isSkuReserved(), shouldDisable()
+
+### Community 11 - "Community 11"
+Cohesion: 0.15
+Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.16
@@ -1392,20 +1394,20 @@ Cohesion: 0.24
 Nodes (6): createApp(), createHandlers(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern()
 
 ### Community 27 - "Community 27"
-Cohesion: 0.33
-Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 28 - "Community 28"
 Cohesion: 0.33
-Nodes (9): usePOSActiveSession(), usePOSSessionComplete(), usePOSSessionCreate(), usePOSSessionHold(), usePOSSessionManager(), usePOSSessionResume(), usePOSSessionUpdate(), usePOSSessionVoid() (+1 more)
+Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
 ### Community 29 - "Community 29"
-Cohesion: 0.18
-Nodes (0):
+Cohesion: 0.33
+Nodes (9): usePOSActiveSession(), usePOSSessionComplete(), usePOSSessionCreate(), usePOSSessionHold(), usePOSSessionManager(), usePOSSessionResume(), usePOSSessionUpdate(), usePOSSessionVoid() (+1 more)
 
 ### Community 30 - "Community 30"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+Cohesion: 0.18
+Nodes (0):
 
 ### Community 31 - "Community 31"
 Cohesion: 0.18
@@ -1560,16 +1562,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 69 - "Community 69"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 70 - "Community 70"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 71 - "Community 71"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 72 - "Community 72"
 Cohesion: 0.52
@@ -1588,40 +1590,40 @@ Cohesion: 0.33
 Nodes (1): ValkeyClient
 
 ### Community 76 - "Community 76"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.53
+Nodes (5): buildInStorePaymentAllocations(), isActiveRegisterSessionStatus(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 77 - "Community 77"
-Cohesion: 0.73
-Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
-
-### Community 78 - "Community 78"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 78 - "Community 78"
+Cohesion: 0.73
+Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 79 - "Community 79"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 80 - "Community 80"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 81 - "Community 81"
 Cohesion: 0.4
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.4
 Nodes (2): buildUsername(), normalizeNameSegment()
-
-### Community 84 - "Community 84"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 85 - "Community 85"
 Cohesion: 0.33
@@ -1636,12 +1638,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 88 - "Community 88"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
-
-### Community 89 - "Community 89"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 89 - "Community 89"
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 90 - "Community 90"
 Cohesion: 0.33
@@ -1656,51 +1658,51 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 93 - "Community 93"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 94 - "Community 94"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 95 - "Community 95"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 96 - "Community 96"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
-
-### Community 97 - "Community 97"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 97 - "Community 97"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 98 - "Community 98"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 99 - "Community 99"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 100 - "Community 100"
-Cohesion: 0.53
-Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
-
-### Community 101 - "Community 101"
-Cohesion: 0.47
-Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
-
-### Community 102 - "Community 102"
-Cohesion: 0.67
-Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
-
-### Community 103 - "Community 103"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 100 - "Community 100"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+
+### Community 101 - "Community 101"
+Cohesion: 0.53
+Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
+
+### Community 102 - "Community 102"
+Cohesion: 0.47
+Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+
+### Community 103 - "Community 103"
+Cohesion: 0.67
+Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
+
 ### Community 104 - "Community 104"
-Cohesion: 0.4
+Cohesion: 0.33
 Nodes (0):
 
 ### Community 105 - "Community 105"
@@ -1716,40 +1718,40 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 108 - "Community 108"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 109 - "Community 109"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.5
 Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.5
 Nodes (2): buildPaymentAllocation(), recordPaymentAllocationWithCtx()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.6
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.6
 Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 116 - "Community 116"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 117 - "Community 117"
 Cohesion: 0.4
@@ -1757,7 +1759,7 @@ Nodes (0):
 
 ### Community 118 - "Community 118"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 119 - "Community 119"
 Cohesion: 0.4
@@ -1785,7 +1787,7 @@ Nodes (0):
 
 ### Community 125 - "Community 125"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 126 - "Community 126"
 Cohesion: 0.4
@@ -1812,16 +1814,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 132 - "Community 132"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 133 - "Community 133"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 133 - "Community 133"
-Cohesion: 0.4
-Nodes (1): MockImage
-
 ### Community 134 - "Community 134"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 135 - "Community 135"
 Cohesion: 0.4
@@ -1836,32 +1838,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 138 - "Community 138"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 139 - "Community 139"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 140 - "Community 140"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 141 - "Community 141"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 142 - "Community 142"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 143 - "Community 143"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 144 - "Community 144"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 145 - "Community 145"
 Cohesion: 0.5
@@ -1876,40 +1878,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 148 - "Community 148"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 149 - "Community 149"
 Cohesion: 0.67
 Nodes (2): toDisplayAmount(), toPesewas()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 152 - "Community 152"
-Cohesion: 0.67
-Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
-
 ### Community 153 - "Community 153"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
 ### Community 154 - "Community 154"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 155 - "Community 155"
-Cohesion: 0.83
-Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 156 - "Community 156"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 157 - "Community 157"
 Cohesion: 0.5
@@ -1932,24 +1934,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 162 - "Community 162"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 163 - "Community 163"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 163 - "Community 163"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 164 - "Community 164"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 165 - "Community 165"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 166 - "Community 166"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 166 - "Community 166"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 167 - "Community 167"
 Cohesion: 0.5
@@ -1964,40 +1966,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 170 - "Community 170"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 171 - "Community 171"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), parseDateTimeLocal()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 172 - "Community 172"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 173 - "Community 173"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 174 - "Community 174"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 175 - "Community 175"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 176 - "Community 176"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 177 - "Community 177"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 178 - "Community 178"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 179 - "Community 179"
 Cohesion: 0.5
@@ -2020,51 +2022,51 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 184 - "Community 184"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 185 - "Community 185"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 190 - "Community 190"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 191 - "Community 191"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 192 - "Community 192"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 193 - "Community 193"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 194 - "Community 194"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 195 - "Community 195"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 196 - "Community 196"
@@ -2092,28 +2094,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 202 - "Community 202"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 203 - "Community 203"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 203 - "Community 203"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 204 - "Community 204"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 205 - "Community 205"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 206 - "Community 206"
 Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
-### Community 206 - "Community 206"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 207 - "Community 207"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.67
@@ -2128,16 +2130,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 211 - "Community 211"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 212 - "Community 212"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 213 - "Community 213"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 214 - "Community 214"
 Cohesion: 0.67
@@ -2145,11 +2147,11 @@ Nodes (0):
 
 ### Community 215 - "Community 215"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 216 - "Community 216"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 217 - "Community 217"
 Cohesion: 0.67
@@ -2157,11 +2159,11 @@ Nodes (0):
 
 ### Community 218 - "Community 218"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 219 - "Community 219"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 220 - "Community 220"
 Cohesion: 0.67
@@ -2209,75 +2211,75 @@ Nodes (0):
 
 ### Community 231 - "Community 231"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 232 - "Community 232"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 233 - "Community 233"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 234 - "Community 234"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 235 - "Community 235"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 236 - "Community 236"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 237 - "Community 237"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 238 - "Community 238"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 239 - "Community 239"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (0):
 
 ### Community 240 - "Community 240"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): AppContextMenu()
 
 ### Community 241 - "Community 241"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): Badge()
 
 ### Community 242 - "Community 242"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 243 - "Community 243"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 244 - "Community 244"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 245 - "Community 245"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 246 - "Community 246"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 248 - "Community 248"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 249 - "Community 249"
 Cohesion: 0.67
@@ -2305,11 +2307,11 @@ Nodes (0):
 
 ### Community 255 - "Community 255"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 256 - "Community 256"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 257 - "Community 257"
 Cohesion: 0.67
@@ -2325,63 +2327,63 @@ Nodes (0):
 
 ### Community 260 - "Community 260"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 261 - "Community 261"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 263 - "Community 263"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): App()
 
 ### Community 264 - "Community 264"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 265 - "Community 265"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 266 - "Community 266"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.67
 Nodes (1): manualChunks()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 272 - "Community 272"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 273 - "Community 273"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 274 - "Community 274"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 275 - "Community 275"
 Cohesion: 0.67
@@ -2392,12 +2394,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 277 - "Community 277"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 278 - "Community 278"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 278 - "Community 278"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 279 - "Community 279"
 Cohesion: 0.67
@@ -2408,12 +2410,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 281 - "Community 281"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 282 - "Community 282"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 282 - "Community 282"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 283 - "Community 283"
 Cohesion: 0.67
@@ -2492,16 +2494,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 302 - "Community 302"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 303 - "Community 303"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 304 - "Community 304"
+### Community 303 - "Community 303"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 304 - "Community 304"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 305 - "Community 305"
 Cohesion: 1.0
@@ -2516,20 +2518,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 308 - "Community 308"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 309 - "Community 309"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 310 - "Community 310"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 311 - "Community 311"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 312 - "Community 312"
 Cohesion: 1.0
@@ -6267,1876 +6269,1886 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1246 - "Community 1246"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1247 - "Community 1247"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 311`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 312`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 313`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 314`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 315`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 316`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (2 nodes): `authenticateHandler()`, `cashier.ts`
+- **Thin community `Community 317`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 318`** (2 nodes): `authenticateHandler()`, `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 319`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 320`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 321`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 322`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 323`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 324`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 325`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 326`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (2 nodes): `decideApprovalRequestWithCtx()`, `approvalRequests.ts`
+- **Thin community `Community 327`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 328`** (2 nodes): `decideApprovalRequestWithCtx()`, `approvalRequests.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
+- **Thin community `Community 329`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 329`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
+- **Thin community `Community 330`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 331`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 331`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 332`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 332`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 333`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (2 nodes): `receiving.test.ts`, `getSource()`
+- **Thin community `Community 334`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 334`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 335`** (2 nodes): `receiving.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 335`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 336`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 336`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 337`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 337`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 338`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 338`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 339`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 339`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 340`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 340`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 341`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 341`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 342`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 342`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 343`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 343`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 344`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 344`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 345`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 345`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 346`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 346`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 347`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 347`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 348`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 348`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 349`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 349`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 350`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 350`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 351`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 351`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 352`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 352`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 353`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 354`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 355`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 356`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 357`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 358`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 359`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 360`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 361`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 362`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 363`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 364`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 365`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 366`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 367`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 368`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 369`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 370`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 371`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 372`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 373`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 374`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 375`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 376`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 377`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 378`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 379`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 380`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 381`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 382`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 383`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 384`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 385`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 386`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 387`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 388`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 389`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 390`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 391`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 392`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 393`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 394`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 395`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 396`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
+- **Thin community `Community 397`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 398`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 399`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 400`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 401`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 402`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
+- **Thin community `Community 403`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 404`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 405`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 406`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 407`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 408`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 409`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 410`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
+- **Thin community `Community 411`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 412`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 413`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 414`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `usePOSCashier()`, `hooks.ts`
+- **Thin community `Community 415`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
+- **Thin community `Community 416`** (2 nodes): `usePOSCashier()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
+- **Thin community `Community 417`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 418`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 419`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 420`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 421`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 422`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 423`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 424`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 425`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 426`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 427`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 428`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 429`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 430`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 431`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 432`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 433`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 434`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 435`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
+- **Thin community `Community 436`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 437`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 438`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 439`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 440`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 441`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 442`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 443`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 444`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 445`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 446`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 447`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 448`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 449`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 450`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 451`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
+- **Thin community `Community 452`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 453`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 454`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 455`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 456`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 457`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 458`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 459`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 460`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 461`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 462`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 463`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 464`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 465`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 466`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 467`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 468`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 469`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 470`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 471`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 472`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 473`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 474`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 475`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 476`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 477`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 478`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
+- **Thin community `Community 479`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 480`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 481`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
+- **Thin community `Community 482`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 483`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 484`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 485`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 486`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 487`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 488`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 489`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 490`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 491`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 492`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 493`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 494`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 495`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 496`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
+- **Thin community `Community 497`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 498`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
+- **Thin community `Community 499`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 500`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 501`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 502`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 503`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 504`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 505`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 506`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 507`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 508`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 509`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `LoginLayout()`, `_layout.tsx`
+- **Thin community `Community 510`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 511`** (2 nodes): `LoginLayout()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 512`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 513`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 514`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 515`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 516`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 517`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 518`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 519`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 520`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 521`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 522`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 523`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 524`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 525`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 526`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 527`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 528`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 529`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 530`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 531`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 532`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 533`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 534`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 535`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 536`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 537`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 538`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 539`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 540`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 541`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 542`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 543`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 544`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 545`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 546`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 547`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 548`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 549`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 550`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 551`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 552`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 553`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 554`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 555`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 556`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 557`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 558`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 559`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 560`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 561`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 562`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 563`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 564`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 565`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 566`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 567`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 568`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 569`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 570`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 571`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 572`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 573`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 574`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 575`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 576`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 577`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 578`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 579`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 580`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 581`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 582`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 583`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 584`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 585`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 586`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 587`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 588`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 589`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 590`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 591`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 592`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 593`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 594`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 595`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 596`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 597`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 598`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 599`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 600`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 601`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 602`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 603`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 604`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 605`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 606`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 607`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 608`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 609`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 610`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 611`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 612`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 613`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 614`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 615`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 616`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 617`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 618`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 619`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 620`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 621`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 622`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 623`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 624`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 625`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 626`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 627`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 628`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 629`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 630`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 631`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 632`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 633`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 634`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 635`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 636`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 637`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 638`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 639`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (1 nodes): `api.d.ts`
+- **Thin community `Community 640`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (1 nodes): `api.js`
+- **Thin community `Community 641`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 642`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (1 nodes): `server.d.ts`
+- **Thin community `Community 643`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (1 nodes): `server.js`
+- **Thin community `Community 644`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (1 nodes): `app.ts`
+- **Thin community `Community 645`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (1 nodes): `auth.config.js`
+- **Thin community `Community 646`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (1 nodes): `auth.ts`
+- **Thin community `Community 647`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 648`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (1 nodes): `countries.ts`
+- **Thin community `Community 649`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (1 nodes): `email.ts`
+- **Thin community `Community 650`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (1 nodes): `ghana.ts`
+- **Thin community `Community 651`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (1 nodes): `payment.ts`
+- **Thin community `Community 652`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (1 nodes): `crons.ts`
+- **Thin community `Community 653`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 654`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 655`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 656`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 657`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (1 nodes): `env.ts`
+- **Thin community `Community 658`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (1 nodes): `analytics.ts`
+- **Thin community `Community 659`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (1 nodes): `auth.ts`
+- **Thin community `Community 660`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 661`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (1 nodes): `categories.ts`
+- **Thin community `Community 662`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (1 nodes): `colors.ts`
+- **Thin community `Community 663`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (1 nodes): `index.ts`
+- **Thin community `Community 664`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (1 nodes): `organizations.ts`
+- **Thin community `Community 665`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (1 nodes): `products.ts`
+- **Thin community `Community 666`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (1 nodes): `stores.ts`
+- **Thin community `Community 667`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 668`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (1 nodes): `index.ts`
+- **Thin community `Community 669`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (1 nodes): `bag.ts`
+- **Thin community `Community 670`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `guest.ts`
+- **Thin community `Community 671`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `index.ts`
+- **Thin community `Community 672`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `me.ts`
+- **Thin community `Community 673`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `offers.ts`
+- **Thin community `Community 674`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 675`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `paystack.ts`
+- **Thin community `Community 676`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `reviews.ts`
+- **Thin community `Community 677`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `rewards.ts`
+- **Thin community `Community 678`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 679`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `security.test.ts`
+- **Thin community `Community 680`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `storefront.ts`
+- **Thin community `Community 681`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `upsells.ts`
+- **Thin community `Community 682`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `user.ts`
+- **Thin community `Community 683`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 684`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `health.test.ts`
+- **Thin community `Community 685`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `http.ts`
+- **Thin community `Community 686`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 687`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `auth.ts`
+- **Thin community `Community 688`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 689`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 690`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `categories.ts`
+- **Thin community `Community 691`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `colors.ts`
+- **Thin community `Community 692`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 693`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 694`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 695`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 696`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 697`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 698`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `organizations.ts`
+- **Thin community `Community 699`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 700`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 701`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 702`** (1 nodes): `posSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `productSku.ts`
+- **Thin community `Community 703`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 704`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 705`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 706`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 707`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 708`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 709`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 710`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 711`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 712`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `client.test.ts`
+- **Thin community `Community 713`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `config.test.ts`
+- **Thin community `Community 714`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 715`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `types.ts`
+- **Thin community `Community 716`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 717`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 718`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 719`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `staffProfiles.test.ts`
+- **Thin community `Community 720`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `ResendOTP.ts`
+- **Thin community `Community 721`** (1 nodes): `staffProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `schema.ts`
+- **Thin community `Community 722`** (1 nodes): `ResendOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 723`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 724`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 725`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 726`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `cashier.ts`
+- **Thin community `Community 727`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `category.ts`
+- **Thin community `Community 728`** (1 nodes): `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `color.ts`
+- **Thin community `Community 729`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 730`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 731`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `index.ts`
+- **Thin community `Community 732`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 733`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `organization.ts`
+- **Thin community `Community 734`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 735`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `product.ts`
+- **Thin community `Community 736`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 737`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 738`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `store.ts`
+- **Thin community `Community 739`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 740`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 741`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 742`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `index.ts`
+- **Thin community `Community 743`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 744`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 745`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 746`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 747`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 748`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 749`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 750`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 751`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `customer.ts`
+- **Thin community `Community 752`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 753`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 754`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 755`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 756`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `index.ts`
+- **Thin community `Community 757`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `posSession.ts`
+- **Thin community `Community 758`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 759`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 760`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 761`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 762`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `index.ts`
+- **Thin community `Community 763`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 764`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 765`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 766`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 767`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 768`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `index.ts`
+- **Thin community `Community 769`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 770`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 771`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 772`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 773`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `vendor.ts`
+- **Thin community `Community 774`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `analytics.ts`
+- **Thin community `Community 775`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `bag.ts`
+- **Thin community `Community 776`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 777`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 778`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 779`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `customer.ts`
+- **Thin community `Community 780`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `guest.ts`
+- **Thin community `Community 781`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `index.ts`
+- **Thin community `Community 782`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `offer.ts`
+- **Thin community `Community 783`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 784`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 785`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `review.ts`
+- **Thin community `Community 786`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `rewards.ts`
+- **Thin community `Community 787`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 788`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 789`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 790`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 791`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 792`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 793`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 794`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `bag.ts`
+- **Thin community `Community 795`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 796`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `customer.ts`
+- **Thin community `Community 797`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `guest.ts`
+- **Thin community `Community 798`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 799`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 800`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `payment.ts`
+- **Thin community `Community 801`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 802`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 803`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 804`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `users.ts`
+- **Thin community `Community 805`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `payment.ts`
+- **Thin community `Community 806`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 807`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `index.ts`
+- **Thin community `Community 808`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 809`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 810`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 811`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 812`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 813`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 814`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 815`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `constants.ts`
+- **Thin community `Community 816`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 817`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 818`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 819`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `types.ts`
+- **Thin community `Community 820`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 821`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 822`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 823`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 824`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 825`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 826`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 827`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 828`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `columns.tsx`
+- **Thin community `Community 829`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 830`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 831`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 832`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 833`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `columns.tsx`
+- **Thin community `Community 834`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 835`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 836`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `chart.tsx`
+- **Thin community `Community 837`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `columns.tsx`
+- **Thin community `Community 838`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 839`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 840`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `columns.tsx`
+- **Thin community `Community 841`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `constants.ts`
+- **Thin community `Community 842`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 843`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 844`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 845`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `data.ts`
+- **Thin community `Community 846`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `columns.tsx`
+- **Thin community `Community 847`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 848`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 849`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `columns.tsx`
+- **Thin community `Community 850`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 851`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 852`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 853`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 854`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 855`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 856`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 857`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `constants.ts`
+- **Thin community `Community 858`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 859`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 860`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 861`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `data.ts`
+- **Thin community `Community 862`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 863`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 864`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `columns.tsx`
+- **Thin community `Community 865`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 866`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 867`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 868`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 869`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 870`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `columns.tsx`
+- **Thin community `Community 871`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `constants.ts`
+- **Thin community `Community 872`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 873`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 874`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 875`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 876`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `index.tsx`
+- **Thin community `Community 877`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `columns.tsx`
+- **Thin community `Community 878`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 879`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 880`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 881`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 882`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 883`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 884`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 885`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 886`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 887`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 888`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 889`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `constants.ts`
+- **Thin community `Community 890`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 891`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 892`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 893`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `data.ts`
+- **Thin community `Community 894`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 895`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `constants.ts`
+- **Thin community `Community 896`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 897`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 898`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 899`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 900`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `data.ts`
+- **Thin community `Community 901`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 902`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `constants.ts`
+- **Thin community `Community 903`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 904`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 905`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 906`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 907`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `data.ts`
+- **Thin community `Community 908`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 909`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 910`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 911`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 912`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 913`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 914`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 915`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 916`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 917`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 918`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `types.ts`
+- **Thin community `Community 919`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 920`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 921`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 922`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 923`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 924`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 925`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 926`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 927`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `Products.tsx`
+- **Thin community `Community 928`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 929`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 930`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 931`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 932`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 933`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 934`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 935`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 936`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 937`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `data.ts`
+- **Thin community `Community 938`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 939`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `PromoCodePreview.tsx`
+- **Thin community `Community 940`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 941`** (1 nodes): `PromoCodePreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 942`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 943`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `columns.tsx`
+- **Thin community `Community 944`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 945`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 946`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 947`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 948`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 949`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `columns.tsx`
+- **Thin community `Community 950`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `constants.ts`
+- **Thin community `Community 951`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 952`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 953`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 954`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `data.ts`
+- **Thin community `Community 955`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `types.ts`
+- **Thin community `Community 956`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 957`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 958`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 959`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 960`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `ServiceAppointmentsView.test.tsx`
+- **Thin community `Community 961`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `ServiceCasesView.test.tsx`
+- **Thin community `Community 962`** (1 nodes): `ServiceAppointmentsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `ServiceCatalogView.test.tsx`
+- **Thin community `Community 963`** (1 nodes): `ServiceCasesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `ServiceIntakeView.test.tsx`
+- **Thin community `Community 964`** (1 nodes): `ServiceCatalogView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 965`** (1 nodes): `ServiceIntakeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `index.tsx`
+- **Thin community `Community 966`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 967`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 968`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `button.tsx`
+- **Thin community `Community 969`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 970`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `card.tsx`
+- **Thin community `Community 971`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 972`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 973`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `command.tsx`
+- **Thin community `Community 974`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 975`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 976`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 977`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `form.tsx`
+- **Thin community `Community 978`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `icons.tsx`
+- **Thin community `Community 979`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 980`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `input.tsx`
+- **Thin community `Community 981`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 982`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `popover.tsx`
+- **Thin community `Community 983`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 984`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 985`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 986`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `select.tsx`
+- **Thin community `Community 987`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `separator.tsx`
+- **Thin community `Community 988`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 989`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `switch.tsx`
+- **Thin community `Community 990`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `table.tsx`
+- **Thin community `Community 991`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 992`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 993`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 994`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 995`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 996`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 997`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 998`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `columns.tsx`
+- **Thin community `Community 999`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `constants.ts`
+- **Thin community `Community 1000`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1001`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1002`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1003`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `data.ts`
+- **Thin community `Community 1004`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1005`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1006`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1007`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1008`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1009`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1010`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1011`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1012`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1013`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1014`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1015`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1016`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1017`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `index.ts`
+- **Thin community `Community 1018`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `config.ts`
+- **Thin community `Community 1019`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1020`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1021`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1022`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `aws.ts`
+- **Thin community `Community 1023`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `constants.ts`
+- **Thin community `Community 1024`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `countries.ts`
+- **Thin community `Community 1025`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1026`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1027`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `constants.ts`
+- **Thin community `Community 1028`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1029`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1030`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `category.ts`
+- **Thin community `Community 1031`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `product.ts`
+- **Thin community `Community 1032`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `store.ts`
+- **Thin community `Community 1033`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1034`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `user.ts`
+- **Thin community `Community 1035`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1036`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1037`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1038`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1039`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `index.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `index.tsx`
+- **Thin community `Community 1040`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1041`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1042`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1043`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1044`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1045`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1046`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `index.tsx`
+- **Thin community `Community 1047`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1048`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1049`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1050`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `home.tsx`
+- **Thin community `Community 1051`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1052`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1053`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1054`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `index.tsx`
+- **Thin community `Community 1055`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `index.tsx`
+- **Thin community `Community 1056`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1057`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1058`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1059`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `index.tsx`
+- **Thin community `Community 1060`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1061`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1062`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1063`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1064`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1065`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1066`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1067`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `index.tsx`
+- **Thin community `Community 1068`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1069`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1070`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1071`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1072`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1073`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `index.tsx`
+- **Thin community `Community 1074`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `index.tsx`
+- **Thin community `Community 1075`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `new.tsx`
+- **Thin community `Community 1076`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1077`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1078`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1079`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1080`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `index.tsx`
+- **Thin community `Community 1081`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `new.tsx`
+- **Thin community `Community 1082`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1083`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1084`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1085`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1086`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1087`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1088`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1089`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `index.tsx`
+- **Thin community `Community 1090`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1091`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1092`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1093`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1094`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `posStore.ts`
+- **Thin community `Community 1095`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1096`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1097`** (1 nodes): `posStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1098`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1099`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1100`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1101`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1102`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1103`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1104`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1105`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1106`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1107`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `setup.ts`
+- **Thin community `Community 1108`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1109`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1110`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `types.ts`
+- **Thin community `Community 1111`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1112`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1113`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1114`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1115`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1116`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1117`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `types.ts`
+- **Thin community `Community 1118`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1119`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1120`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1121`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1122`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1123`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1124`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1125`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1126`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1127`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `schema.ts`
+- **Thin community `Community 1128`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1129`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1130`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1131`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1132`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1133`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1134`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1135`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1136`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1137`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `types.ts`
+- **Thin community `Community 1138`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1139`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1140`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1141`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1142`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1143`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1144`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1145`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `constants.ts`
+- **Thin community `Community 1146`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1147`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `About.tsx`
+- **Thin community `Community 1148`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1149`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1150`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1151`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1152`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1153`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1154`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1155`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1156`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1157`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `types.ts`
+- **Thin community `Community 1158`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1159`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1160`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1161`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1162`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1163`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1164`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1165`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1166`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1167`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1168`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `button.tsx`
+- **Thin community `Community 1169`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `card.tsx`
+- **Thin community `Community 1170`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1171`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `command.tsx`
+- **Thin community `Community 1172`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1173`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1174`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1175`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `form.tsx`
+- **Thin community `Community 1176`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1177`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1178`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1179`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1180`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `input.tsx`
+- **Thin community `Community 1181`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `label.tsx`
+- **Thin community `Community 1182`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1183`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1184`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1185`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `index.ts`
+- **Thin community `Community 1186`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `types.ts`
+- **Thin community `Community 1187`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1188`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1189`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1190`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1191`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `select.tsx`
+- **Thin community `Community 1192`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1193`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1194`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `table.tsx`
+- **Thin community `Community 1195`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1196`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1197`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1198`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1199`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1200`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `config.ts`
+- **Thin community `Community 1201`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1202`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1203`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1204`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `constants.ts`
+- **Thin community `Community 1205`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `countries.ts`
+- **Thin community `Community 1206`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1207`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1208`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1209`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1210`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `index.ts`
+- **Thin community `Community 1211`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `store.ts`
+- **Thin community `Community 1212`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `bag.ts`
+- **Thin community `Community 1213`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1214`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `category.ts`
+- **Thin community `Community 1215`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `organization.ts`
+- **Thin community `Community 1216`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `product.ts`
+- **Thin community `Community 1217`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `store.ts`
+- **Thin community `Community 1218`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1219`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `user.ts`
+- **Thin community `Community 1220`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `states.ts`
+- **Thin community `Community 1221`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1222`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1223`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1224`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1225`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1226`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1227`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1228`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `index.tsx`
+- **Thin community `Community 1229`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1230`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1231`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1232`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1233`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1234`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1235`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1236`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `index.tsx`
+- **Thin community `Community 1237`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1238`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1239`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1240`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1241`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `index.js`
+- **Thin community `Community 1242`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1243`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1244`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1245`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1246`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1247`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -8148,7 +8160,7 @@ _Questions this graph is uniquely positioned to answer:_
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
 - **Should `Community 6` be split into smaller, more focused modules?**
   _Cohesion score 0.13 - nodes in this community are weakly interconnected._
-- **Should `Community 11` be split into smaller, more focused modules?**
+- **Should `Community 10` be split into smaller, more focused modules?**
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
 - **Should `Community 14` be split into smaller, more focused modules?**
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -5531,7 +5531,7 @@
       "relation": "calls",
       "source": "onlineorder_appendtransition",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L118",
+      "source_location": "L119",
       "target": "onlineorder_applyonlineorderupdate",
       "weight": 1
     },
@@ -5711,7 +5711,7 @@
       "relation": "calls",
       "source": "orderoperations_ispaymentondeliveryorder",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L75",
+      "source_location": "L76",
       "target": "orderoperations_assertvalidonlineorderstatustransition",
       "weight": 1
     },
@@ -5723,7 +5723,7 @@
       "relation": "calls",
       "source": "orderoperations_getonlineorderpaymentamount",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L188",
+      "source_location": "L189",
       "target": "orderoperations_recordonlineordercreatedevent",
       "weight": 1
     },
@@ -5735,7 +5735,7 @@
       "relation": "calls",
       "source": "orderoperations_resolveonlineordercontext",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L177",
+      "source_location": "L178",
       "target": "orderoperations_recordonlineordercreatedevent",
       "weight": 1
     },
@@ -5747,7 +5747,7 @@
       "relation": "calls",
       "source": "orderoperations_resolveonlineordercontext",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L376",
+      "source_location": "L388",
       "target": "orderoperations_recordonlineorderfulfillmentmovement",
       "weight": 1
     },
@@ -5759,7 +5759,7 @@
       "relation": "calls",
       "source": "orderoperations_getonlineorderpaymentamount",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L294",
+      "source_location": "L296",
       "target": "orderoperations_recordonlineorderpaymentcollected",
       "weight": 1
     },
@@ -5771,7 +5771,7 @@
       "relation": "calls",
       "source": "orderoperations_getonlineorderpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L312",
+      "source_location": "L322",
       "target": "orderoperations_recordonlineorderpaymentcollected",
       "weight": 1
     },
@@ -5783,7 +5783,7 @@
       "relation": "calls",
       "source": "orderoperations_resolveonlineordercontext",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L299",
+      "source_location": "L301",
       "target": "orderoperations_recordonlineorderpaymentcollected",
       "weight": 1
     },
@@ -5795,7 +5795,7 @@
       "relation": "calls",
       "source": "orderoperations_getonlineorderpaymentamount",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L247",
+      "source_location": "L248",
       "target": "orderoperations_recordonlineorderpaymentverified",
       "weight": 1
     },
@@ -5807,7 +5807,7 @@
       "relation": "calls",
       "source": "orderoperations_getonlineorderpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L264",
+      "source_location": "L265",
       "target": "orderoperations_recordonlineorderpaymentverified",
       "weight": 1
     },
@@ -5819,7 +5819,7 @@
       "relation": "calls",
       "source": "orderoperations_resolveonlineordercontext",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L252",
+      "source_location": "L253",
       "target": "orderoperations_recordonlineorderpaymentverified",
       "weight": 1
     },
@@ -5831,7 +5831,7 @@
       "relation": "calls",
       "source": "orderoperations_getonlineorderpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L360",
+      "source_location": "L372",
       "target": "orderoperations_recordonlineorderrefundallocation",
       "weight": 1
     },
@@ -5843,7 +5843,7 @@
       "relation": "calls",
       "source": "orderoperations_resolveonlineordercontext",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L348",
+      "source_location": "L360",
       "target": "orderoperations_recordonlineorderrefundallocation",
       "weight": 1
     },
@@ -5855,7 +5855,7 @@
       "relation": "calls",
       "source": "orderoperations_resolveonlineordercontext",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L405",
+      "source_location": "L417",
       "target": "orderoperations_recordonlineorderrestockmovement",
       "weight": 1
     },
@@ -5867,7 +5867,7 @@
       "relation": "calls",
       "source": "orderoperations_getonlineorderstatuseventtype",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L221",
+      "source_location": "L222",
       "target": "orderoperations_recordonlineorderstatusevent",
       "weight": 1
     },
@@ -5879,7 +5879,7 @@
       "relation": "calls",
       "source": "orderoperations_resolveonlineordercontext",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L213",
+      "source_location": "L214",
       "target": "orderoperations_recordonlineorderstatusevent",
       "weight": 1
     },
@@ -5891,7 +5891,7 @@
       "relation": "calls",
       "source": "orderoperations_getstoreorganizationid",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L151",
+      "source_location": "L152",
       "target": "orderoperations_resolveonlineordercontext",
       "weight": 1
     },
@@ -5903,7 +5903,7 @@
       "relation": "calls",
       "source": "orderoperations_resolvecustomerprofileforstorefrontactor",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L155",
+      "source_location": "L156",
       "target": "orderoperations_resolveonlineordercontext",
       "weight": 1
     },
@@ -6001,6 +6001,78 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L4",
       "target": "index_valkeyclient",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
+      "_tgt": "paymentallocationattribution_test_readprojectfile",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
+      "source_location": "L12",
+      "target": "paymentallocationattribution_test_readprojectfile",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "_tgt": "paymentallocationattribution_buildinstorepaymentallocations",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L48",
+      "target": "paymentallocationattribution_buildinstorepaymentallocations",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "_tgt": "paymentallocationattribution_isactiveregistersessionstatus",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L20",
+      "target": "paymentallocationattribution_isactiveregistersessionstatus",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "_tgt": "paymentallocationattribution_normalizeinstorepayments",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L24",
+      "target": "paymentallocationattribution_normalizeinstorepayments",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "_tgt": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L120",
+      "target": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "_tgt": "paymentallocationattribution_selectregistersessionforattribution",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L83",
+      "target": "paymentallocationattribution_selectregistersessionforattribution",
       "weight": 1
     },
     {
@@ -6743,7 +6815,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L943",
+      "source_location": "L978",
       "target": "pos_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -6755,7 +6827,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L11",
+      "source_location": "L13",
       "target": "pos_isconvexproductid",
       "weight": 1
     },
@@ -6767,7 +6839,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L102",
+      "source_location": "L104",
       "target": "pos_listcompletedtransactionsforday",
       "weight": 1
     },
@@ -6779,7 +6851,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L36",
+      "source_location": "L38",
       "target": "pos_listmatchingstoreskus",
       "weight": 1
     },
@@ -6791,7 +6863,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L25",
+      "source_location": "L27",
       "target": "pos_listproductskusbyproductid",
       "weight": 1
     },
@@ -6803,7 +6875,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L94",
+      "source_location": "L96",
       "target": "pos_listsessionitems",
       "weight": 1
     },
@@ -6815,7 +6887,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L83",
+      "source_location": "L85",
       "target": "pos_listtransactionitems",
       "weight": 1
     },
@@ -6827,7 +6899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L15",
+      "source_location": "L17",
       "target": "pos_readallqueryresults",
       "weight": 1
     },
@@ -8255,7 +8327,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L67",
+      "source_location": "L68",
       "target": "serviceintake_resolveserviceintakecustomerprofile",
       "weight": 1
     },
@@ -8267,7 +8339,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L19",
+      "source_location": "L20",
       "target": "serviceintake_splitfullname",
       "weight": 1
     },
@@ -8279,7 +8351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L14",
+      "source_location": "L15",
       "target": "serviceintake_trimoptional",
       "weight": 1
     },
@@ -8291,7 +8363,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L32",
+      "source_location": "L33",
       "target": "serviceintake_validateserviceintakeinput",
       "weight": 1
     },
@@ -8507,7 +8579,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L215",
+      "source_location": "L216",
       "target": "servicecases_assertvalidservicecasestatustransition",
       "weight": 1
     },
@@ -8519,7 +8591,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L224",
+      "source_location": "L225",
       "target": "servicecases_buildservicecase",
       "weight": 1
     },
@@ -8531,7 +8603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L252",
+      "source_location": "L253",
       "target": "servicecases_buildservicecaselineitem",
       "weight": 1
     },
@@ -8543,7 +8615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L274",
+      "source_location": "L275",
       "target": "servicecases_createservicecasewithctx",
       "weight": 1
     },
@@ -8555,7 +8627,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L85",
+      "source_location": "L86",
       "target": "servicecases_deriveservicecasepaymentstatus",
       "weight": 1
     },
@@ -8567,7 +8639,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L189",
+      "source_location": "L190",
       "target": "servicecases_getservicecasecontext",
       "weight": 1
     },
@@ -8579,7 +8651,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L142",
+      "source_location": "L143",
       "target": "servicecases_listpendingapprovalrequestswithctx",
       "weight": 1
     },
@@ -8591,7 +8663,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L129",
+      "source_location": "L130",
       "target": "servicecases_listservicecaseallocationswithctx",
       "weight": 1
     },
@@ -8603,7 +8675,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L109",
+      "source_location": "L110",
       "target": "servicecases_listservicecaselineitemswithctx",
       "weight": 1
     },
@@ -8615,7 +8687,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L119",
+      "source_location": "L120",
       "target": "servicecases_listserviceinventoryusagewithctx",
       "weight": 1
     },
@@ -8627,7 +8699,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L69",
+      "source_location": "L70",
       "target": "servicecases_mapservicecasestatustoworkitemstatus",
       "weight": 1
     },
@@ -8639,7 +8711,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L154",
+      "source_location": "L155",
       "target": "servicecases_syncservicecasefinancialswithctx",
       "weight": 1
     },
@@ -9839,7 +9911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L40",
+      "source_location": "L41",
       "target": "orderoperations_assertvalidonlineorderstatustransition",
       "weight": 1
     },
@@ -9851,7 +9923,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L94",
+      "source_location": "L95",
       "target": "orderoperations_getonlineorderpaymentamount",
       "weight": 1
     },
@@ -9863,7 +9935,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L84",
+      "source_location": "L85",
       "target": "orderoperations_getonlineorderpaymentmethodlabel",
       "weight": 1
     },
@@ -9875,7 +9947,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L28",
+      "source_location": "L29",
       "target": "orderoperations_getonlineorderstatuseventtype",
       "weight": 1
     },
@@ -9887,7 +9959,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L100",
+      "source_location": "L101",
       "target": "orderoperations_getstoreorganizationid",
       "weight": 1
     },
@@ -9899,7 +9971,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L32",
+      "source_location": "L33",
       "target": "orderoperations_ispaymentondeliveryorder",
       "weight": 1
     },
@@ -9911,7 +9983,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L173",
+      "source_location": "L174",
       "target": "orderoperations_recordonlineordercreatedevent",
       "weight": 1
     },
@@ -9923,7 +9995,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L369",
+      "source_location": "L381",
       "target": "orderoperations_recordonlineorderfulfillmentmovement",
       "weight": 1
     },
@@ -9935,7 +10007,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L287",
+      "source_location": "L288",
       "target": "orderoperations_recordonlineorderpaymentcollected",
       "weight": 1
     },
@@ -9947,7 +10019,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L239",
+      "source_location": "L240",
       "target": "orderoperations_recordonlineorderpaymentverified",
       "weight": 1
     },
@@ -9959,7 +10031,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L335",
+      "source_location": "L347",
       "target": "orderoperations_recordonlineorderrefundallocation",
       "weight": 1
     },
@@ -9971,7 +10043,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L397",
+      "source_location": "L409",
       "target": "orderoperations_recordonlineorderrestockmovement",
       "weight": 1
     },
@@ -9983,7 +10055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L200",
+      "source_location": "L201",
       "target": "orderoperations_recordonlineorderstatusevent",
       "weight": 1
     },
@@ -9995,7 +10067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L108",
+      "source_location": "L109",
       "target": "orderoperations_resolvecustomerprofileforstorefrontactor",
       "weight": 1
     },
@@ -10007,7 +10079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L146",
+      "source_location": "L147",
       "target": "orderoperations_resolveonlineordercontext",
       "weight": 1
     },
@@ -10283,7 +10355,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_onlineorder_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L202",
+      "source_location": "L204",
       "target": "onlineorder_buildreturnexchangereplacementsourceid",
       "weight": 1
     },
@@ -10295,7 +10367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_onlineorder_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L210",
+      "source_location": "L212",
       "target": "onlineorder_buildreturnexchangereturnsourceid",
       "weight": 1
     },
@@ -25168,6 +25240,42 @@
       "weight": 1
     },
     {
+      "_src": "paymentallocationattribution_buildinstorepaymentallocations",
+      "_tgt": "paymentallocationattribution_normalizeinstorepayments",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "paymentallocationattribution_normalizeinstorepayments",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L67",
+      "target": "paymentallocationattribution_buildinstorepaymentallocations",
+      "weight": 1
+    },
+    {
+      "_src": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "_tgt": "paymentallocationattribution_isactiveregistersessionstatus",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "paymentallocationattribution_isactiveregistersessionstatus",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L136",
+      "target": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "_tgt": "paymentallocationattribution_selectregistersessionforattribution",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "paymentallocationattribution_selectregistersessionforattribution",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L157",
+      "target": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "weight": 1
+    },
+    {
       "_src": "paymentallocations_recordpaymentallocationwithctx",
       "_tgt": "paymentallocations_buildpaymentallocation",
       "confidence": "EXTRACTED",
@@ -25223,7 +25331,7 @@
       "relation": "calls",
       "source": "pos_listsessionitems",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L958",
+      "source_location": "L993",
       "target": "pos_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -25235,7 +25343,7 @@
       "relation": "calls",
       "source": "pos_readallqueryresults",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L108",
+      "source_location": "L110",
       "target": "pos_listcompletedtransactionsforday",
       "weight": 1
     },
@@ -25247,7 +25355,7 @@
       "relation": "calls",
       "source": "pos_readallqueryresults",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L29",
+      "source_location": "L31",
       "target": "pos_listproductskusbyproductid",
       "weight": 1
     },
@@ -25259,7 +25367,7 @@
       "relation": "calls",
       "source": "pos_readallqueryresults",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L95",
+      "source_location": "L97",
       "target": "pos_listsessionitems",
       "weight": 1
     },
@@ -25271,7 +25379,7 @@
       "relation": "calls",
       "source": "pos_readallqueryresults",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L87",
+      "source_location": "L89",
       "target": "pos_listtransactionitems",
       "weight": 1
     },
@@ -30323,7 +30431,7 @@
       "relation": "calls",
       "source": "servicecases_buildservicecase",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L289",
+      "source_location": "L290",
       "target": "servicecases_createservicecasewithctx",
       "weight": 1
     },
@@ -30335,7 +30443,7 @@
       "relation": "calls",
       "source": "servicecases_deriveservicecasepaymentstatus",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L173",
+      "source_location": "L174",
       "target": "servicecases_syncservicecasefinancialswithctx",
       "weight": 1
     },
@@ -30347,7 +30455,7 @@
       "relation": "calls",
       "source": "servicecases_listservicecaseallocationswithctx",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L164",
+      "source_location": "L165",
       "target": "servicecases_syncservicecasefinancialswithctx",
       "weight": 1
     },
@@ -30359,7 +30467,7 @@
       "relation": "calls",
       "source": "servicecases_listservicecaselineitemswithctx",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L163",
+      "source_location": "L164",
       "target": "servicecases_syncservicecasefinancialswithctx",
       "weight": 1
     },
@@ -30431,7 +30539,7 @@
       "relation": "calls",
       "source": "serviceintake_splitfullname",
       "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L130",
+      "source_location": "L131",
       "target": "serviceintake_resolveserviceintakecustomerprofile",
       "weight": 1
     },
@@ -30443,7 +30551,7 @@
       "relation": "calls",
       "source": "serviceintake_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L118",
+      "source_location": "L119",
       "target": "serviceintake_resolveserviceintakecustomerprofile",
       "weight": 1
     },
@@ -33222,1572 +33330,6 @@
     {
       "community": 10,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_capitalizefirstletter",
-      "label": "capitalizeFirstLetter()",
-      "norm_label": "capitalizefirstletter()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_capitalizewords",
-      "label": "capitalizeWords()",
-      "norm_label": "capitalizewords()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_currencyformatter",
-      "label": "currencyFormatter()",
-      "norm_label": "currencyformatter()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_enablequery",
-      "label": "enableQuery()",
-      "norm_label": "enablequery()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_formatdate",
-      "label": "formatDate()",
-      "norm_label": "formatdate()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_formatuserid",
-      "label": "formatUserId()",
-      "norm_label": "formatuserid()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_getaddressstring",
-      "label": "getAddressString()",
-      "norm_label": "getaddressstring()",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_geterrorforfield",
-      "label": "getErrorForField()",
-      "norm_label": "geterrorforfield()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_getrelativetime",
-      "label": "getRelativeTime()",
-      "norm_label": "getrelativetime()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_getstoredetails",
-      "label": "getStoreDetails()",
-      "norm_label": "getstoredetails()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_gettimeremaining",
-      "label": "getTimeRemaining()",
-      "norm_label": "gettimeremaining()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_slugtowords",
-      "label": "slugToWords()",
-      "norm_label": "slugtowords()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_snakecasetowords",
-      "label": "snakeCaseToWords()",
-      "norm_label": "snakecasetowords()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "utils_toslug",
-      "label": "toSlug()",
-      "norm_label": "toslug()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "feeutils_getremainingforfreedelivery",
-      "label": "getRemainingForFreeDelivery()",
-      "norm_label": "getremainingforfreedelivery()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "feeutils_haswaiverconfigured",
-      "label": "hasWaiverConfigured()",
-      "norm_label": "haswaiverconfigured()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "feeutils_isanyfeewaived",
-      "label": "isAnyFeeWaived()",
-      "norm_label": "isanyfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "feeutils_isfeewaived",
-      "label": "isFeeWaived()",
-      "norm_label": "isfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "feeutils_meetsthreshold",
-      "label": "meetsThreshold()",
-      "norm_label": "meetsthreshold()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
-      "label": "feeUtils.ts",
-      "norm_label": "feeutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1000,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1001,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1002,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1003,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1004,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
-      "label": "bag-columns.tsx",
-      "norm_label": "bag-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1005,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
-      "label": "bags-table.tsx",
-      "norm_label": "bags-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1006,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1007,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1008,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "auth_verify_formattime",
-      "label": "formatTime()",
-      "norm_label": "formattime()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L149"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "auth_verify_handlecodechange",
-      "label": "handleCodeChange()",
-      "norm_label": "handlecodechange()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "auth_verify_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "auth_verify_reportauthfailure",
-      "label": "reportAuthFailure()",
-      "norm_label": "reportauthfailure()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "auth_verify_resendverificationcode",
-      "label": "resendVerificationCode()",
-      "norm_label": "resendverificationcode()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L282"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
-      "label": "auth.verify.tsx",
-      "norm_label": "auth.verify.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1010,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1011,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1012,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
-      "label": "LinkedAccounts.tsx",
-      "norm_label": "linkedaccounts.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1013,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
-      "label": "TimelineEventCard.test.tsx",
-      "norm_label": "timelineeventcard.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1014,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
-      "label": "UserCheckoutSession.tsx",
-      "norm_label": "usercheckoutsession.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1015,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
-      "label": "UserInsightsSection.tsx",
-      "norm_label": "userinsightssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1016,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
-      "label": "UserBehaviorInsights.tsx",
-      "norm_label": "userbehaviorinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1017,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1018,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
-      "label": "ThemeContext.tsx",
-      "norm_label": "themecontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "graphify_check_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "graphify_check_collectstalegraphifyartifacts",
-      "label": "collectStaleGraphifyArtifacts()",
-      "norm_label": "collectstalegraphifyartifacts()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "graphify_check_copygraphifycheckinputs",
-      "label": "copyGraphifyCheckInputs()",
-      "norm_label": "copygraphifycheckinputs()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "graphify_check_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "graphify_check_rungraphifycheck",
-      "label": "runGraphifyCheck()",
-      "norm_label": "rungraphifycheck()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "scripts_graphify_check_ts",
-      "label": "graphify-check.ts",
-      "norm_label": "graphify-check.ts",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1020,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1021,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1022,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_aws_ts",
-      "label": "aws.ts",
-      "norm_label": "aws.ts",
-      "source_file": "packages/athena-webapp/src/lib/aws.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1023,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1024,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/src/lib/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1025,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1026,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
-      "label": "ghanaRegions.ts",
-      "norm_label": "ghanaregions.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1027,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1028,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
-      "label": "displayAmounts.test.ts",
-      "norm_label": "displayamounts.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
-      "label": "productUtils.test.ts",
-      "norm_label": "productutils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
-      "label": "buildAthenaRuntimeUrl()",
-      "norm_label": "buildathenaruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
-      "label": "buildValkeyRuntimeUrl()",
-      "norm_label": "buildvalkeyruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
-      "label": "createAthenaRuntimeProcess()",
-      "norm_label": "createathenaruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
-      "label": "createStorefrontRuntimeProcesses()",
-      "norm_label": "createstorefrontruntimeprocesses()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
-      "label": "createValkeyRuntimeProcess()",
-      "norm_label": "createvalkeyruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_scenarios_ts",
-      "label": "harness-behavior-scenarios.ts",
-      "norm_label": "harness-behavior-scenarios.ts",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1030,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1031,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1032,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1033,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1034,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1035,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
-      "label": "storeConfig.test.ts",
-      "norm_label": "storeconfig.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1036,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1037,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routetree_gen_ts",
-      "label": "routeTree.gen.ts",
-      "norm_label": "routetree.gen.ts",
-      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1038,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_root_tsx",
-      "label": "__root.tsx",
-      "norm_label": "__root.tsx",
-      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "label": "r2.ts",
-      "norm_label": "r2.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "r2_deletedirectoryinr2",
-      "label": "deleteDirectoryInR2()",
-      "norm_label": "deletedirectoryinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "r2_deletefileinr2",
-      "label": "deleteFileInR2()",
-      "norm_label": "deletefileinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "r2_listitemsinr2directory",
-      "label": "listItemsInR2Directory()",
-      "norm_label": "listitemsinr2directory()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "r2_uploadfiletor2",
-      "label": "uploadFileToR2()",
-      "norm_label": "uploadfiletor2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 1040,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1041,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1042,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
-      "label": "$storeUrlSlug.tsx",
-      "norm_label": "$storeurlslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1043,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
-      "label": "analytics.tsx",
-      "norm_label": "analytics.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1044,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
-      "label": "assets.index.tsx",
-      "norm_label": "assets.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1045,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
-      "label": "bags.$bagId.tsx",
-      "norm_label": "bags.$bagid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1046,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
-      "label": "bags.index.tsx",
-      "norm_label": "bags.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1047,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1048,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
-      "label": "checkout-sessions.index.tsx",
-      "norm_label": "checkout-sessions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
-      "label": "configuration.index.tsx",
-      "norm_label": "configuration.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
-      "label": "validateExpenseItemBelongsToSession()",
-      "norm_label": "validateexpenseitembelongstosession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionactive",
-      "label": "validateExpenseSessionActive()",
-      "norm_label": "validateexpensesessionactive()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionexists",
-      "label": "validateExpenseSessionExists()",
-      "norm_label": "validateexpensesessionexists()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
-      "label": "validateExpenseSessionModifiable()",
-      "norm_label": "validateexpensesessionmodifiable()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
-      "label": "expenseSessionValidation.ts",
-      "norm_label": "expensesessionvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1050,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
-      "label": "dashboard.index.tsx",
-      "norm_label": "dashboard.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1051,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
-      "label": "home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1052,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
-      "label": "logs.$logId.tsx",
-      "norm_label": "logs.$logid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1053,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
-      "label": "logs.index.tsx",
-      "norm_label": "logs.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1054,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
-      "label": "members.index.tsx",
-      "norm_label": "members.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1055,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1056,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1057,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
-      "label": "all.index.tsx",
-      "norm_label": "all.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1058,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
-      "label": "cancelled.index.tsx",
-      "norm_label": "cancelled.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
-      "label": "completed.index.tsx",
-      "norm_label": "completed.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "label": "posSessions.ts",
-      "norm_label": "possessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "possessions_buildnextsessionnumber",
-      "label": "buildNextSessionNumber()",
-      "norm_label": "buildnextsessionnumber()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "possessions_listpossessionsbystatusbefore",
-      "label": "listPosSessionsByStatusBefore()",
-      "norm_label": "listpossessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "possessions_listpossessionsforstorestatus",
-      "label": "listPosSessionsForStoreStatus()",
-      "norm_label": "listpossessionsforstorestatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "possessions_loadpossessionitems",
-      "label": "loadPosSessionItems()",
-      "norm_label": "loadpossessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 1060,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1061,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
-      "label": "open.index.tsx",
-      "norm_label": "open.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1062,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
-      "label": "out-for-delivery.index.tsx",
-      "norm_label": "out-for-delivery.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1063,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
-      "label": "ready.index.tsx",
-      "norm_label": "ready.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1064,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
-      "label": "refunded.index.tsx",
-      "norm_label": "refunded.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1065,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
-      "label": "$reportId.tsx",
-      "norm_label": "$reportid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1066,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
-      "label": "expense-reports.index.tsx",
-      "norm_label": "expense-reports.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1067,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
-      "label": "expense.index.tsx",
-      "norm_label": "expense.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1068,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
-      "label": "register.index.tsx",
-      "norm_label": "register.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_products_ts",
-      "label": "products.ts",
-      "norm_label": "products.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "products_calculatetotalavailablecount",
-      "label": "calculateTotalAvailableCount()",
-      "norm_label": "calculatetotalavailablecount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "products_calculatetotalinventorycount",
-      "label": "calculateTotalInventoryCount()",
-      "norm_label": "calculatetotalinventorycount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "products_generatebarcode",
-      "label": "generateBarcode()",
-      "norm_label": "generatebarcode()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "products_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 1070,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
-      "label": "settings.index.tsx",
-      "norm_label": "settings.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1071,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
-      "label": "$transactionId.tsx",
-      "norm_label": "$transactionid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1072,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
-      "label": "transactions.index.tsx",
-      "norm_label": "transactions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1073,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
-      "label": "edit.tsx",
-      "norm_label": "edit.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1074,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1075,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1076,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1077,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1078,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
-      "label": "unresolved.tsx",
-      "norm_label": "unresolved.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "customerprofiles_compactrecord",
-      "label": "compactRecord()",
-      "norm_label": "compactrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
-      "label": "ensureCustomerProfileFromSourcesWithCtx()",
-      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "customerprofiles_findexistingprofile",
-      "label": "findExistingProfile()",
-      "norm_label": "findexistingprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "customerprofiles_loadcustomersources",
-      "label": "loadCustomerSources()",
-      "norm_label": "loadcustomersources()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
-      "label": "customerProfiles.ts",
-      "norm_label": "customerprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1080,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
-      "label": "$promoCodeSlug.tsx",
-      "norm_label": "$promocodeslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1081,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1082,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1083,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1084,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
-      "label": "new.index.tsx",
-      "norm_label": "new.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1085,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
-      "label": "active-cases.index.tsx",
-      "norm_label": "active-cases.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/active-cases.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1086,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
-      "label": "appointments.index.tsx",
-      "norm_label": "appointments.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/appointments.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1087,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
-      "label": "catalog-management.index.tsx",
-      "norm_label": "catalog-management.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1088,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
-      "label": "intake.index.tsx",
-      "norm_label": "intake.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
-      "label": "users.$userId.tsx",
-      "norm_label": "users.$userid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1090,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1091,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
-      "label": "join-team.index.tsx",
-      "norm_label": "join-team.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1092,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
-      "label": "_layout.index.test.tsx",
-      "norm_label": "_layout.index.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1093,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
-      "label": "StoresSettingsAccordion.tsx",
-      "norm_label": "storessettingsaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1094,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stores_expensestore_ts",
-      "label": "expenseStore.ts",
-      "norm_label": "expensestore.ts",
-      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1095,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stores_posstore_ts",
-      "label": "posStore.ts",
-      "norm_label": "posstore.ts",
-      "source_file": "packages/athena-webapp/src/stores/posStore.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1096,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1097,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
-      "label": "foundations-content.test.tsx",
-      "norm_label": "foundations-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1098,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
-      "label": "Introduction.stories.tsx",
-      "norm_label": "introduction.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
-      "label": "introduction-content.test.tsx",
-      "norm_label": "introduction-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 11,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productstock_tsx",
       "label": "ProductStock.tsx",
       "norm_label": "productstock.tsx",
@@ -34795,7 +33337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_addrow",
       "label": "addRow()",
@@ -34804,7 +33346,7 @@
       "source_location": "L430"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_getreservationtype",
       "label": "getReservationType()",
@@ -34813,7 +33355,7 @@
       "source_location": "L178"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_handlechange",
       "label": "handleChange()",
@@ -34822,7 +33364,7 @@
       "source_location": "L384"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_handleclearbarcodecancel",
       "label": "handleClearBarcodeCancel()",
@@ -34831,7 +33373,7 @@
       "source_location": "L379"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_handleclearbarcodeclick",
       "label": "handleClearBarcodeClick()",
@@ -34840,7 +33382,7 @@
       "source_location": "L308"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_handleclearbarcodeconfirm",
       "label": "handleClearBarcodeConfirm()",
@@ -34849,7 +33391,7 @@
       "source_location": "L313"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_handledeleteaction",
       "label": "handleDeleteAction()",
@@ -34858,7 +33400,7 @@
       "source_location": "L445"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_handlegeneratebarcode",
       "label": "handleGenerateBarcode()",
@@ -34867,7 +33409,7 @@
       "source_location": "L239"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_handlesavebarcode",
       "label": "handleSaveBarcode()",
@@ -34876,7 +33418,7 @@
       "source_location": "L285"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_handleviewbarcode",
       "label": "handleViewBarcode()",
@@ -34885,7 +33427,7 @@
       "source_location": "L300"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_haspriceerror",
       "label": "hasPriceError()",
@@ -34894,7 +33436,7 @@
       "source_location": "L514"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_hasquantityerror",
       "label": "hasQuantityError()",
@@ -34903,7 +33445,7 @@
       "source_location": "L506"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_islastactivevariant",
       "label": "isLastActiveVariant()",
@@ -34912,7 +33454,7 @@
       "source_location": "L486"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_islastvisiblevariant",
       "label": "isLastVisibleVariant()",
@@ -34921,7 +33463,7 @@
       "source_location": "L492"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_isskureserved",
       "label": "isSkuReserved()",
@@ -34930,7 +33472,7 @@
       "source_location": "L174"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_restock",
       "label": "restock()",
@@ -34939,7 +33481,7 @@
       "source_location": "L107"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_setoutofstock",
       "label": "setOutOfStock()",
@@ -34948,7 +33490,7 @@
       "source_location": "L462"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_setvisibility",
       "label": "setVisibility()",
@@ -34957,7 +33499,7 @@
       "source_location": "L472"
     },
     {
-      "community": 11,
+      "community": 10,
       "file_type": "code",
       "id": "productstock_shoulddisable",
       "label": "shouldDisable()",
@@ -34966,52 +33508,1645 @@
       "source_location": "L498"
     },
     {
-      "community": 110,
+      "community": 100,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
-      "community": 110,
+      "community": 100,
       "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1000,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1003,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1004,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1005,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1006,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
+      "label": "bag-columns.tsx",
+      "norm_label": "bag-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1007,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
+      "label": "bags-table.tsx",
+      "norm_label": "bags-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1008,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1009,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "feeutils_getremainingforfreedelivery",
+      "label": "getRemainingForFreeDelivery()",
+      "norm_label": "getremainingforfreedelivery()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "feeutils_haswaiverconfigured",
+      "label": "hasWaiverConfigured()",
+      "norm_label": "haswaiverconfigured()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "feeutils_isanyfeewaived",
+      "label": "isAnyFeeWaived()",
+      "norm_label": "isanyfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "feeutils_isfeewaived",
+      "label": "isFeeWaived()",
+      "norm_label": "isfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "feeutils_meetsthreshold",
+      "label": "meetsThreshold()",
+      "norm_label": "meetsthreshold()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
+      "label": "feeUtils.ts",
+      "norm_label": "feeutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1010,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1012,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1013,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1014,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
+      "label": "LinkedAccounts.tsx",
+      "norm_label": "linkedaccounts.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1015,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
+      "label": "TimelineEventCard.test.tsx",
+      "norm_label": "timelineeventcard.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1016,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
+      "label": "UserCheckoutSession.tsx",
+      "norm_label": "usercheckoutsession.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1017,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
+      "label": "UserInsightsSection.tsx",
+      "norm_label": "userinsightssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1018,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
+      "label": "UserBehaviorInsights.tsx",
+      "norm_label": "userbehaviorinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1019,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "auth_verify_formattime",
+      "label": "formatTime()",
+      "norm_label": "formattime()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L149"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "auth_verify_handlecodechange",
+      "label": "handleCodeChange()",
+      "norm_label": "handlecodechange()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "auth_verify_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "auth_verify_reportauthfailure",
+      "label": "reportAuthFailure()",
+      "norm_label": "reportauthfailure()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L93"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "auth_verify_resendverificationcode",
+      "label": "resendVerificationCode()",
+      "norm_label": "resendverificationcode()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L282"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
+      "label": "auth.verify.tsx",
+      "norm_label": "auth.verify.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1020,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
+      "label": "ThemeContext.tsx",
+      "norm_label": "themecontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1022,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1023,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1024,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_aws_ts",
+      "label": "aws.ts",
+      "norm_label": "aws.ts",
+      "source_file": "packages/athena-webapp/src/lib/aws.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1025,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1026,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/src/lib/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1027,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1028,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
+      "label": "ghanaRegions.ts",
+      "norm_label": "ghanaregions.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1029,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "graphify_check_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "graphify_check_collectstalegraphifyartifacts",
+      "label": "collectStaleGraphifyArtifacts()",
+      "norm_label": "collectstalegraphifyartifacts()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "graphify_check_copygraphifycheckinputs",
+      "label": "copyGraphifyCheckInputs()",
+      "norm_label": "copygraphifycheckinputs()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "graphify_check_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "graphify_check_rungraphifycheck",
+      "label": "runGraphifyCheck()",
+      "norm_label": "rungraphifycheck()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "scripts_graphify_check_ts",
+      "label": "graphify-check.ts",
+      "norm_label": "graphify-check.ts",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1030,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
+      "label": "displayAmounts.test.ts",
+      "norm_label": "displayamounts.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
+      "label": "productUtils.test.ts",
+      "norm_label": "productutils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1032,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1033,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1034,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1035,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1036,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1037,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
+      "label": "storeConfig.test.ts",
+      "norm_label": "storeconfig.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1038,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1039,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routetree_gen_ts",
+      "label": "routeTree.gen.ts",
+      "norm_label": "routetree.gen.ts",
+      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
+      "label": "buildAthenaRuntimeUrl()",
+      "norm_label": "buildathenaruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
+      "label": "buildValkeyRuntimeUrl()",
+      "norm_label": "buildvalkeyruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
+      "label": "createAthenaRuntimeProcess()",
+      "norm_label": "createathenaruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
+      "label": "createStorefrontRuntimeProcesses()",
+      "norm_label": "createstorefrontruntimeprocesses()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
+      "label": "createValkeyRuntimeProcess()",
+      "norm_label": "createvalkeyruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_scenarios_ts",
+      "label": "harness-behavior-scenarios.ts",
+      "norm_label": "harness-behavior-scenarios.ts",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1040,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_root_tsx",
+      "label": "__root.tsx",
+      "norm_label": "__root.tsx",
+      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1042,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1043,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1044,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
+      "label": "$storeUrlSlug.tsx",
+      "norm_label": "$storeurlslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1045,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
+      "label": "analytics.tsx",
+      "norm_label": "analytics.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1046,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
+      "label": "assets.index.tsx",
+      "norm_label": "assets.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1047,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
+      "label": "bags.$bagId.tsx",
+      "norm_label": "bags.$bagid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1048,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
+      "label": "bags.index.tsx",
+      "norm_label": "bags.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1049,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
+      "label": "r2.ts",
+      "norm_label": "r2.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "r2_deletedirectoryinr2",
+      "label": "deleteDirectoryInR2()",
+      "norm_label": "deletedirectoryinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "r2_deletefileinr2",
+      "label": "deleteFileInR2()",
+      "norm_label": "deletefileinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "r2_listitemsinr2directory",
+      "label": "listItemsInR2Directory()",
+      "norm_label": "listitemsinr2directory()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "r2_uploadfiletor2",
+      "label": "uploadFileToR2()",
+      "norm_label": "uploadfiletor2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 1050,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
+      "label": "checkout-sessions.index.tsx",
+      "norm_label": "checkout-sessions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
+      "label": "configuration.index.tsx",
+      "norm_label": "configuration.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1052,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
+      "label": "dashboard.index.tsx",
+      "norm_label": "dashboard.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1053,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
+      "label": "home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1054,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
+      "label": "logs.$logId.tsx",
+      "norm_label": "logs.$logid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1055,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
+      "label": "logs.index.tsx",
+      "norm_label": "logs.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1056,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
+      "label": "members.index.tsx",
+      "norm_label": "members.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1057,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1058,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1059,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
+      "label": "all.index.tsx",
+      "norm_label": "all.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
+      "label": "validateExpenseItemBelongsToSession()",
+      "norm_label": "validateexpenseitembelongstosession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionactive",
+      "label": "validateExpenseSessionActive()",
+      "norm_label": "validateexpensesessionactive()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionexists",
+      "label": "validateExpenseSessionExists()",
+      "norm_label": "validateexpensesessionexists()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
+      "label": "validateExpenseSessionModifiable()",
+      "norm_label": "validateexpensesessionmodifiable()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
+      "label": "expenseSessionValidation.ts",
+      "norm_label": "expensesessionvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1060,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
+      "label": "cancelled.index.tsx",
+      "norm_label": "cancelled.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
+      "label": "completed.index.tsx",
+      "norm_label": "completed.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1062,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1063,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
+      "label": "open.index.tsx",
+      "norm_label": "open.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1064,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
+      "label": "out-for-delivery.index.tsx",
+      "norm_label": "out-for-delivery.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1065,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
+      "label": "ready.index.tsx",
+      "norm_label": "ready.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1066,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
+      "label": "refunded.index.tsx",
+      "norm_label": "refunded.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1067,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
+      "label": "$reportId.tsx",
+      "norm_label": "$reportid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1068,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
+      "label": "expense-reports.index.tsx",
+      "norm_label": "expense-reports.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1069,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
+      "label": "expense.index.tsx",
+      "norm_label": "expense.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "label": "posSessions.ts",
+      "norm_label": "possessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "possessions_buildnextsessionnumber",
+      "label": "buildNextSessionNumber()",
+      "norm_label": "buildnextsessionnumber()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "possessions_listpossessionsbystatusbefore",
+      "label": "listPosSessionsByStatusBefore()",
+      "norm_label": "listpossessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "possessions_listpossessionsforstorestatus",
+      "label": "listPosSessionsForStoreStatus()",
+      "norm_label": "listpossessionsforstorestatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "possessions_loadpossessionitems",
+      "label": "loadPosSessionItems()",
+      "norm_label": "loadpossessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 1070,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
+      "label": "register.index.tsx",
+      "norm_label": "register.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1072,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
+      "label": "settings.index.tsx",
+      "norm_label": "settings.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1073,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
+      "label": "$transactionId.tsx",
+      "norm_label": "$transactionid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1074,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
+      "label": "transactions.index.tsx",
+      "norm_label": "transactions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1075,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
+      "label": "edit.tsx",
+      "norm_label": "edit.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1076,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1077,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1078,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1079,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_products_ts",
+      "label": "products.ts",
+      "norm_label": "products.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "products_calculatetotalavailablecount",
+      "label": "calculateTotalAvailableCount()",
+      "norm_label": "calculatetotalavailablecount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "products_calculatetotalinventorycount",
+      "label": "calculateTotalInventoryCount()",
+      "norm_label": "calculatetotalinventorycount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "products_generatebarcode",
+      "label": "generateBarcode()",
+      "norm_label": "generatebarcode()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "products_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 1080,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
+      "label": "unresolved.tsx",
+      "norm_label": "unresolved.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1082,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
+      "label": "$promoCodeSlug.tsx",
+      "norm_label": "$promocodeslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1083,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1084,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1085,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1086,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
+      "label": "new.index.tsx",
+      "norm_label": "new.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1087,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
+      "label": "active-cases.index.tsx",
+      "norm_label": "active-cases.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/active-cases.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1088,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
+      "label": "appointments.index.tsx",
+      "norm_label": "appointments.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/appointments.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1089,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
+      "label": "catalog-management.index.tsx",
+      "norm_label": "catalog-management.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "customerprofiles_compactrecord",
+      "label": "compactRecord()",
+      "norm_label": "compactrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
+      "label": "ensureCustomerProfileFromSourcesWithCtx()",
+      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "customerprofiles_findexistingprofile",
+      "label": "findExistingProfile()",
+      "norm_label": "findexistingprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "customerprofiles_loadcustomersources",
+      "label": "loadCustomerSources()",
+      "norm_label": "loadcustomersources()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
+      "label": "customerProfiles.ts",
+      "norm_label": "customerprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1090,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
+      "label": "intake.index.tsx",
+      "norm_label": "intake.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
+      "label": "users.$userId.tsx",
+      "norm_label": "users.$userid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1092,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1093,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
+      "label": "join-team.index.tsx",
+      "norm_label": "join-team.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1094,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
+      "label": "_layout.index.test.tsx",
+      "norm_label": "_layout.index.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1095,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
+      "label": "StoresSettingsAccordion.tsx",
+      "norm_label": "storessettingsaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1096,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stores_expensestore_ts",
+      "label": "expenseStore.ts",
+      "norm_label": "expensestore.ts",
+      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1097,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stores_posstore_ts",
+      "label": "posStore.ts",
+      "norm_label": "posstore.ts",
+      "source_file": "packages/athena-webapp/src/stores/posStore.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1098,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1099,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
+      "label": "foundations-content.test.tsx",
+      "norm_label": "foundations-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_capitalizefirstletter",
+      "label": "capitalizeFirstLetter()",
+      "norm_label": "capitalizefirstletter()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_capitalizewords",
+      "label": "capitalizeWords()",
+      "norm_label": "capitalizewords()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_currencyformatter",
+      "label": "currencyFormatter()",
+      "norm_label": "currencyformatter()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_enablequery",
+      "label": "enableQuery()",
+      "norm_label": "enablequery()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_formatdate",
+      "label": "formatDate()",
+      "norm_label": "formatdate()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_formatuserid",
+      "label": "formatUserId()",
+      "norm_label": "formatuserid()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_getaddressstring",
+      "label": "getAddressString()",
+      "norm_label": "getaddressstring()",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_geterrorforfield",
+      "label": "getErrorForField()",
+      "norm_label": "geterrorforfield()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_getrelativetime",
+      "label": "getRelativeTime()",
+      "norm_label": "getrelativetime()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_getstoredetails",
+      "label": "getStoreDetails()",
+      "norm_label": "getstoredetails()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_gettimeremaining",
+      "label": "getTimeRemaining()",
+      "norm_label": "gettimeremaining()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_slugtowords",
+      "label": "slugToWords()",
+      "norm_label": "slugtowords()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_snakecasetowords",
+      "label": "snakeCaseToWords()",
+      "norm_label": "snakecasetowords()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 11,
+      "file_type": "code",
+      "id": "utils_toslug",
+      "label": "toSlug()",
+      "norm_label": "toslug()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L37"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L25"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L78"
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L51"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L1"
     },
     {
       "community": 1100,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
+      "label": "Introduction.stories.tsx",
+      "norm_label": "introduction.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
+      "label": "introduction-content.test.tsx",
+      "norm_label": "introduction-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -35020,7 +35155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -35029,7 +35164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -35038,7 +35173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -35047,7 +35182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -35056,7 +35191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -35065,7 +35200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -35074,7 +35209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -35083,7 +35218,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 111,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 1110,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -35092,7 +35272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1109,
+      "community": 1111,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -35101,52 +35281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 111,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
-      "label": "serviceIntake.ts",
-      "norm_label": "serviceintake.ts",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "serviceintake_resolveserviceintakecustomerprofile",
-      "label": "resolveServiceIntakeCustomerProfile()",
-      "norm_label": "resolveserviceintakecustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "serviceintake_splitfullname",
-      "label": "splitFullName()",
-      "norm_label": "splitfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "serviceintake_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "serviceintake_validateserviceintakeinput",
-      "label": "validateServiceIntakeInput()",
-      "norm_label": "validateserviceintakeinput()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 1110,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -35155,7 +35290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -35164,7 +35299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -35173,7 +35308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -35182,7 +35317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -35191,7 +35326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -35200,7 +35335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -35209,7 +35344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -35218,7 +35353,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 112,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
+      "label": "serviceIntake.ts",
+      "norm_label": "serviceintake.ts",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "serviceintake_resolveserviceintakecustomerprofile",
+      "label": "resolveServiceIntakeCustomerProfile()",
+      "norm_label": "resolveserviceintakecustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "serviceintake_splitfullname",
+      "label": "splitFullName()",
+      "norm_label": "splitfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "serviceintake_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "serviceintake_validateserviceintakeinput",
+      "label": "validateServiceIntakeInput()",
+      "norm_label": "validateserviceintakeinput()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 1120,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -35227,7 +35407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1119,
+      "community": 1121,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -35236,52 +35416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 112,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_paystackservice_ts",
-      "label": "paystackService.ts",
-      "norm_label": "paystackservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "paystackservice_getpaystackheaders",
-      "label": "getPaystackHeaders()",
-      "norm_label": "getpaystackheaders()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "paystackservice_initializetransaction",
-      "label": "initializeTransaction()",
-      "norm_label": "initializetransaction()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "paystackservice_initiaterefund",
-      "label": "initiateRefund()",
-      "norm_label": "initiaterefund()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "paystackservice_verifytransaction",
-      "label": "verifyTransaction()",
-      "norm_label": "verifytransaction()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 1120,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -35290,7 +35425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -35299,7 +35434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -35308,7 +35443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -35317,7 +35452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -35326,7 +35461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -35335,7 +35470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -35344,7 +35479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -35353,7 +35488,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 113,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_paystackservice_ts",
+      "label": "paystackService.ts",
+      "norm_label": "paystackservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "paystackservice_getpaystackheaders",
+      "label": "getPaystackHeaders()",
+      "norm_label": "getpaystackheaders()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "paystackservice_initializetransaction",
+      "label": "initializeTransaction()",
+      "norm_label": "initializetransaction()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "paystackservice_initiaterefund",
+      "label": "initiateRefund()",
+      "norm_label": "initiaterefund()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "paystackservice_verifytransaction",
+      "label": "verifyTransaction()",
+      "norm_label": "verifytransaction()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 1130,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -35362,7 +35542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1129,
+      "community": 1131,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -35371,52 +35551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 113,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
-      "label": "returnExchangeOperations.ts",
-      "norm_label": "returnexchangeoperations.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
-      "label": "buildOnlineOrderReturnExchangePlan()",
-      "norm_label": "buildonlineorderreturnexchangeplan()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "returnexchangeoperations_getapprovalreason",
-      "label": "getApprovalReason()",
-      "norm_label": "getapprovalreason()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "returnexchangeoperations_getkind",
-      "label": "getKind()",
-      "norm_label": "getkind()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "returnexchangeoperations_getlinerefundamount",
-      "label": "getLineRefundAmount()",
-      "norm_label": "getlinerefundamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 1130,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -35425,7 +35560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -35434,7 +35569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -35443,7 +35578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -35452,7 +35587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -35461,7 +35596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -35470,7 +35605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -35479,7 +35614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -35488,7 +35623,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 114,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
+      "label": "returnExchangeOperations.ts",
+      "norm_label": "returnexchangeoperations.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
+      "label": "buildOnlineOrderReturnExchangePlan()",
+      "norm_label": "buildonlineorderreturnexchangeplan()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getapprovalreason",
+      "label": "getApprovalReason()",
+      "norm_label": "getapprovalreason()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getkind",
+      "label": "getKind()",
+      "norm_label": "getkind()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getlinerefundamount",
+      "label": "getLineRefundAmount()",
+      "norm_label": "getlinerefundamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 1140,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -35497,7 +35677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1139,
+      "community": 1141,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -35506,52 +35686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 114,
-      "file_type": "code",
-      "id": "offers_createoffer",
-      "label": "createOffer()",
-      "norm_label": "createoffer()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "offers_getupsellproducts",
-      "label": "getUpsellProducts()",
-      "norm_label": "getupsellproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L765"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "offers_isduplicate",
-      "label": "isDuplicate()",
-      "norm_label": "isduplicate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "offers_updatestorefrontactoremail",
-      "label": "updateStoreFrontActorEmail()",
-      "norm_label": "updatestorefrontactoremail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1140,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -35560,7 +35695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -35569,7 +35704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -35578,7 +35713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -35587,7 +35722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -35596,7 +35731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -35605,7 +35740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -35614,7 +35749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -35623,7 +35758,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 115,
+      "file_type": "code",
+      "id": "offers_createoffer",
+      "label": "createOffer()",
+      "norm_label": "createoffer()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L89"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "offers_getupsellproducts",
+      "label": "getUpsellProducts()",
+      "norm_label": "getupsellproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L765"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "offers_isduplicate",
+      "label": "isDuplicate()",
+      "norm_label": "isduplicate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "offers_updatestorefrontactoremail",
+      "label": "updateStoreFrontActorEmail()",
+      "norm_label": "updatestorefrontactoremail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1150,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -35632,7 +35812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1149,
+      "community": 1151,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -35641,52 +35821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 115,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
-      "label": "storefrontObservabilityReport.ts",
-      "norm_label": "storefrontobservabilityreport.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
-      "label": "buildStorefrontObservabilityReport()",
-      "norm_label": "buildstorefrontobservabilityreport()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_getnonemptystring",
-      "label": "getNonEmptyString()",
-      "norm_label": "getnonemptystring()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_gettrafficsource",
-      "label": "getTrafficSource()",
-      "norm_label": "gettrafficsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
-      "label": "normalizeStorefrontObservabilityEvent()",
-      "norm_label": "normalizestorefrontobservabilityevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 1150,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -35695,7 +35830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -35704,7 +35839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -35713,7 +35848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -35722,7 +35857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -35731,7 +35866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -35740,7 +35875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -35749,7 +35884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -35758,7 +35893,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 116,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
+      "label": "storefrontObservabilityReport.ts",
+      "norm_label": "storefrontobservabilityreport.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
+      "label": "buildStorefrontObservabilityReport()",
+      "norm_label": "buildstorefrontobservabilityreport()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_getnonemptystring",
+      "label": "getNonEmptyString()",
+      "norm_label": "getnonemptystring()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_gettrafficsource",
+      "label": "getTrafficSource()",
+      "norm_label": "gettrafficsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
+      "label": "normalizeStorefrontObservabilityEvent()",
+      "norm_label": "normalizestorefrontobservabilityevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 1160,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -35767,7 +35947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1159,
+      "community": 1161,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -35776,52 +35956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 116,
-      "file_type": "code",
-      "id": "navbar_appheader",
-      "label": "AppHeader()",
-      "norm_label": "appheader()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "navbar_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "navbar_navbar",
-      "label": "Navbar()",
-      "norm_label": "navbar()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "navbar_settingsheader",
-      "label": "SettingsHeader()",
-      "norm_label": "settingsheader()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_navbar_tsx",
-      "label": "Navbar.tsx",
-      "norm_label": "navbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1160,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -35830,7 +35965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -35839,7 +35974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -35848,7 +35983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -35857,7 +35992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -35866,7 +36001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -35875,7 +36010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -35884,7 +36019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -35893,7 +36028,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 117,
+      "file_type": "code",
+      "id": "navbar_appheader",
+      "label": "AppHeader()",
+      "norm_label": "appheader()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "navbar_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "navbar_navbar",
+      "label": "Navbar()",
+      "norm_label": "navbar()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "navbar_settingsheader",
+      "label": "SettingsHeader()",
+      "norm_label": "settingsheader()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_navbar_tsx",
+      "label": "Navbar.tsx",
+      "norm_label": "navbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1170,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -35902,7 +36082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1169,
+      "community": 1171,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -35911,52 +36091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 117,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
-      "label": "ProductCategorization.tsx",
-      "norm_label": "productcategorization.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "productcategorization_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L286"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "productcategorization_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L203"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "productcategorization_handleproductvisibility",
-      "label": "handleProductVisibility()",
-      "norm_label": "handleproductvisibility()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L243"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "productcategorization_setinitialselectedoption",
-      "label": "setInitialSelectedOption()",
-      "norm_label": "setinitialselectedoption()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L230"
-    },
-    {
-      "community": 1170,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -35965,7 +36100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -35974,7 +36109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -35983,7 +36118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -35992,7 +36127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -36001,7 +36136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -36010,7 +36145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -36019,7 +36154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -36028,7 +36163,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 118,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
+      "label": "ProductCategorization.tsx",
+      "norm_label": "productcategorization.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "productcategorization_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L286"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "productcategorization_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L203"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "productcategorization_handleproductvisibility",
+      "label": "handleProductVisibility()",
+      "norm_label": "handleproductvisibility()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L243"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "productcategorization_setinitialselectedoption",
+      "label": "setInitialSelectedOption()",
+      "norm_label": "setinitialselectedoption()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L230"
+    },
+    {
+      "community": 1180,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -36037,7 +36217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1179,
+      "community": 1181,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -36046,52 +36226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 118,
-      "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1180,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -36100,7 +36235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -36109,7 +36244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -36118,7 +36253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -36127,7 +36262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -36136,7 +36271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -36145,7 +36280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -36154,30 +36289,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1188,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
-      "label": "navigation-menu.tsx",
-      "norm_label": "navigation-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
-      "label": "popover.tsx",
-      "norm_label": "popover.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
       "source_location": "L1"
     },
     {
@@ -36228,6 +36345,24 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
+      "label": "navigation-menu.tsx",
+      "norm_label": "navigation-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
+      "label": "popover.tsx",
+      "norm_label": "popover.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1192,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
@@ -36235,7 +36370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -36244,7 +36379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -36253,7 +36388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -36262,7 +36397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -36271,7 +36406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -36280,7 +36415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -36289,30 +36424,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
       "norm_label": "textarea.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1198,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
-      "label": "toggle.tsx",
-      "norm_label": "toggle.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1"
     },
     {
@@ -36525,6 +36642,24 @@
     {
       "community": 1200,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
+      "label": "toggle.tsx",
+      "norm_label": "toggle.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1202,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
       "norm_label": "tooltip.tsx",
@@ -36532,7 +36667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -36541,7 +36676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -36550,7 +36685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -36559,7 +36694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -36568,7 +36703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -36577,7 +36712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -36586,30 +36721,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
       "norm_label": "feeutils.test.ts",
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1208,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/storefront-webapp/src/lib/ghana.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
-      "label": "ghanaRegions.ts",
-      "norm_label": "ghanaregions.ts",
-      "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1"
     },
     {
@@ -36660,6 +36777,24 @@
     {
       "community": 1210,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/storefront-webapp/src/lib/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1211,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
+      "label": "ghanaRegions.ts",
+      "norm_label": "ghanaregions.ts",
+      "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1212,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
       "norm_label": "maintenanceutils.test.ts",
@@ -36667,7 +36802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -36676,7 +36811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -36685,7 +36820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -36694,7 +36829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -36703,7 +36838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -36712,7 +36847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -36721,30 +36856,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1218,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
       "source_location": "L1"
     },
     {
@@ -36795,6 +36912,24 @@
     {
       "community": 1220,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1222,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
@@ -36802,7 +36937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -36811,7 +36946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -36820,7 +36955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -36829,7 +36964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -36838,7 +36973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -36847,7 +36982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -36856,30 +36991,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
       "norm_label": "__root.tsx",
       "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1228,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
-      "label": "$orderItemId.review.tsx",
-      "norm_label": "$orderitemid.review.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
       "source_location": "L1"
     },
     {
@@ -36930,6 +37047,24 @@
     {
       "community": 1230,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
+      "label": "$orderItemId.review.tsx",
+      "norm_label": "$orderitemid.review.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1231,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1232,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
       "norm_label": "$subcategoryslug.tsx",
@@ -36937,7 +37072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -36946,7 +37081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -36955,7 +37090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -36964,7 +37099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -36973,7 +37108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -36982,7 +37117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -36991,30 +37126,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1238,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
-      "label": "pending.tsx",
-      "norm_label": "pending.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tailwind_config_js",
-      "label": "tailwind.config.js",
-      "norm_label": "tailwind.config.js",
-      "source_file": "packages/storefront-webapp/tailwind.config.js",
       "source_location": "L1"
     },
     {
@@ -37065,6 +37182,24 @@
     {
       "community": 1240,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
+      "label": "pending.tsx",
+      "norm_label": "pending.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1241,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_tailwind_config_js",
+      "label": "tailwind.config.js",
+      "norm_label": "tailwind.config.js",
+      "source_file": "packages/storefront-webapp/tailwind.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1242,
+      "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
       "norm_label": "vitest.config.ts",
@@ -37072,7 +37207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -37081,7 +37216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -37090,7 +37225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1245,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -37099,7 +37234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1246,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -37108,7 +37243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1247,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -37119,6 +37254,51 @@
     {
       "community": 125,
       "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
       "id": "ordersummary_formatstoredamount",
       "label": "formatStoredAmount()",
       "norm_label": "formatstoredamount()",
@@ -37126,7 +37306,7 @@
       "source_location": "L320"
     },
     {
-      "community": 125,
+      "community": 126,
       "file_type": "code",
       "id": "ordersummary_handlecompletetransaction",
       "label": "handleCompleteTransaction()",
@@ -37135,7 +37315,7 @@
       "source_location": "L130"
     },
     {
-      "community": 125,
+      "community": 126,
       "file_type": "code",
       "id": "ordersummary_handlenewtransaction",
       "label": "handleNewTransaction()",
@@ -37144,7 +37324,7 @@
       "source_location": "L164"
     },
     {
-      "community": 125,
+      "community": 126,
       "file_type": "code",
       "id": "ordersummary_handleselectedpaymentmethod",
       "label": "handleSelectedPaymentMethod()",
@@ -37153,7 +37333,7 @@
       "source_location": "L152"
     },
     {
-      "community": 125,
+      "community": 126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -37162,7 +37342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 126,
+      "community": 127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
       "label": "PaymentView.tsx",
@@ -37171,7 +37351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 126,
+      "community": 127,
       "file_type": "code",
       "id": "paymentview_handleaddpayment",
       "label": "handleAddPayment()",
@@ -37180,7 +37360,7 @@
       "source_location": "L182"
     },
     {
-      "community": 126,
+      "community": 127,
       "file_type": "code",
       "id": "paymentview_handleamountblur",
       "label": "handleAmountBlur()",
@@ -37189,7 +37369,7 @@
       "source_location": "L246"
     },
     {
-      "community": 126,
+      "community": 127,
       "file_type": "code",
       "id": "paymentview_handleamountchange",
       "label": "handleAmountChange()",
@@ -37198,7 +37378,7 @@
       "source_location": "L228"
     },
     {
-      "community": 126,
+      "community": 127,
       "file_type": "code",
       "id": "paymentview_handleclearall",
       "label": "handleClearAll()",
@@ -37207,7 +37387,7 @@
       "source_location": "L223"
     },
     {
-      "community": 127,
+      "community": 128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -37216,7 +37396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 127,
+      "community": 128,
       "file_type": "code",
       "id": "sessionmanager_onholdconfirm",
       "label": "onHoldConfirm()",
@@ -37225,7 +37405,7 @@
       "source_location": "L72"
     },
     {
-      "community": 127,
+      "community": 128,
       "file_type": "code",
       "id": "sessionmanager_onnewsessionclick",
       "label": "onNewSessionClick()",
@@ -37234,7 +37414,7 @@
       "source_location": "L96"
     },
     {
-      "community": 127,
+      "community": 128,
       "file_type": "code",
       "id": "sessionmanager_onresumesession",
       "label": "onResumeSession()",
@@ -37243,7 +37423,7 @@
       "source_location": "L77"
     },
     {
-      "community": 127,
+      "community": 128,
       "file_type": "code",
       "id": "sessionmanager_onvoidconfirm",
       "label": "onVoidConfirm()",
@@ -37252,7 +37432,7 @@
       "source_location": "L90"
     },
     {
-      "community": 128,
+      "community": 129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
       "label": "ReceivingView.tsx",
@@ -37261,7 +37441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 128,
+      "community": 129,
       "file_type": "code",
       "id": "receivingview_builddefaultreceivedquantities",
       "label": "buildDefaultReceivedQuantities()",
@@ -37270,7 +37450,7 @@
       "source_location": "L35"
     },
     {
-      "community": 128,
+      "community": 129,
       "file_type": "code",
       "id": "receivingview_buildreceivedquantitiesaftersubmission",
       "label": "buildReceivedQuantitiesAfterSubmission()",
@@ -37279,7 +37459,7 @@
       "source_location": "L44"
     },
     {
-      "community": 128,
+      "community": 129,
       "file_type": "code",
       "id": "receivingview_buildsubmissionkey",
       "label": "buildSubmissionKey()",
@@ -37288,58 +37468,13 @@
       "source_location": "L31"
     },
     {
-      "community": 128,
+      "community": 129,
       "file_type": "code",
       "id": "receivingview_receivingview",
       "label": "ReceivingView()",
       "norm_label": "receivingview()",
       "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
       "source_location": "L70"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
-      "label": "PromoCodeView.tsx",
-      "norm_label": "promocodeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "promocodeview_handleaddpromocode",
-      "label": "handleAddPromoCode()",
-      "norm_label": "handleaddpromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L146"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "promocodeview_handleupdatepromocode",
-      "label": "handleUpdatePromoCode()",
-      "norm_label": "handleupdatepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "promocodeview_updatehomepagediscountcode",
-      "label": "updateHomepageDiscountCode()",
-      "norm_label": "updatehomepagediscountcode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L299"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "promocodeview_updateleaveareviewdiscountcode",
-      "label": "updateLeaveAReviewDiscountCode()",
-      "norm_label": "updateleaveareviewdiscountcode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L351"
     },
     {
       "community": 13,
@@ -37506,6 +37641,51 @@
     {
       "community": 130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
+      "label": "PromoCodeView.tsx",
+      "norm_label": "promocodeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "promocodeview_handleaddpromocode",
+      "label": "handleAddPromoCode()",
+      "norm_label": "handleaddpromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L146"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "promocodeview_handleupdatepromocode",
+      "label": "handleUpdatePromoCode()",
+      "norm_label": "handleupdatepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L213"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "promocodeview_updatehomepagediscountcode",
+      "label": "updateHomepageDiscountCode()",
+      "norm_label": "updatehomepagediscountcode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L299"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "promocodeview_updateleaveareviewdiscountcode",
+      "label": "updateLeaveAReviewDiscountCode()",
+      "norm_label": "updateleaveareviewdiscountcode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L351"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
       "norm_label": "basicmodalexample()",
@@ -37513,7 +37693,7 @@
       "source_location": "L7"
     },
     {
-      "community": 130,
+      "community": 131,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -37522,7 +37702,7 @@
       "source_location": "L69"
     },
     {
-      "community": 130,
+      "community": 131,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -37531,7 +37711,7 @@
       "source_location": "L44"
     },
     {
-      "community": 130,
+      "community": 131,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -37540,7 +37720,7 @@
       "source_location": "L103"
     },
     {
-      "community": 130,
+      "community": 131,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -37549,7 +37729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 131,
+      "community": 132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
@@ -37558,7 +37738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 131,
+      "community": 132,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -37567,7 +37747,7 @@
       "source_location": "L30"
     },
     {
-      "community": 131,
+      "community": 132,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -37576,7 +37756,7 @@
       "source_location": "L41"
     },
     {
-      "community": 131,
+      "community": 132,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -37585,7 +37765,7 @@
       "source_location": "L10"
     },
     {
-      "community": 131,
+      "community": 132,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -37594,7 +37774,7 @@
       "source_location": "L100"
     },
     {
-      "community": 132,
+      "community": 133,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -37603,7 +37783,7 @@
       "source_location": "L18"
     },
     {
-      "community": 132,
+      "community": 133,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -37612,7 +37792,7 @@
       "source_location": "L23"
     },
     {
-      "community": 132,
+      "community": 133,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -37621,7 +37801,7 @@
       "source_location": "L65"
     },
     {
-      "community": 132,
+      "community": 133,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -37630,7 +37810,7 @@
       "source_location": "L45"
     },
     {
-      "community": 132,
+      "community": 133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -37639,7 +37819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 133,
+      "community": 134,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -37648,7 +37828,7 @@
       "source_location": "L78"
     },
     {
-      "community": 133,
+      "community": 134,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -37657,7 +37837,7 @@
       "source_location": "L74"
     },
     {
-      "community": 133,
+      "community": 134,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -37666,7 +37846,7 @@
       "source_location": "L103"
     },
     {
-      "community": 133,
+      "community": 134,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -37675,7 +37855,7 @@
       "source_location": "L109"
     },
     {
-      "community": 133,
+      "community": 134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -37684,7 +37864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 134,
+      "community": 135,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -37693,7 +37873,7 @@
       "source_location": "L75"
     },
     {
-      "community": 134,
+      "community": 135,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -37702,7 +37882,7 @@
       "source_location": "L26"
     },
     {
-      "community": 134,
+      "community": 135,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -37711,7 +37891,7 @@
       "source_location": "L38"
     },
     {
-      "community": 134,
+      "community": 135,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -37720,7 +37900,7 @@
       "source_location": "L4"
     },
     {
-      "community": 134,
+      "community": 135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -37729,7 +37909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 135,
+      "community": 136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -37738,7 +37918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 135,
+      "community": 136,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -37747,7 +37927,7 @@
       "source_location": "L42"
     },
     {
-      "community": 135,
+      "community": 136,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -37756,7 +37936,7 @@
       "source_location": "L29"
     },
     {
-      "community": 135,
+      "community": 136,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -37765,7 +37945,7 @@
       "source_location": "L49"
     },
     {
-      "community": 135,
+      "community": 136,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -37774,7 +37954,7 @@
       "source_location": "L14"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -37783,7 +37963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -37792,7 +37972,7 @@
       "source_location": "L184"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -37801,7 +37981,7 @@
       "source_location": "L200"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -37810,7 +37990,7 @@
       "source_location": "L244"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -37819,7 +37999,7 @@
       "source_location": "L206"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -37828,7 +38008,7 @@
       "source_location": "L93"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -37837,7 +38017,7 @@
       "source_location": "L75"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -37846,7 +38026,7 @@
       "source_location": "L4"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -37855,7 +38035,7 @@
       "source_location": "L47"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -37864,7 +38044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -37873,7 +38053,7 @@
       "source_location": "L11"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -37882,7 +38062,7 @@
       "source_location": "L25"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -37891,7 +38071,7 @@
       "source_location": "L9"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -37900,57 +38080,12 @@
       "source_location": "L39"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "onlineorder_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "onlineorder_getorder",
-      "label": "getOrder()",
-      "norm_label": "getorder()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "onlineorder_getorders",
-      "label": "getOrders()",
-      "norm_label": "getorders()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "onlineorder_updateordersowner",
-      "label": "updateOrdersOwner()",
-      "norm_label": "updateordersowner()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -38109,6 +38244,51 @@
     {
       "community": 140,
       "file_type": "code",
+      "id": "onlineorder_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "onlineorder_getorder",
+      "label": "getOrder()",
+      "norm_label": "getorder()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "onlineorder_getorders",
+      "label": "getOrders()",
+      "norm_label": "getorders()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "onlineorder_updateordersowner",
+      "label": "updateOrdersOwner()",
+      "norm_label": "updateordersowner()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
       "norm_label": "storefrontuser.ts",
@@ -38116,7 +38296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -38125,7 +38305,7 @@
       "source_location": "L28"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -38134,7 +38314,7 @@
       "source_location": "L5"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -38143,7 +38323,7 @@
       "source_location": "L7"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -38152,7 +38332,7 @@
       "source_location": "L46"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -38161,7 +38341,7 @@
       "source_location": "L147"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -38170,7 +38350,7 @@
       "source_location": "L185"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -38179,7 +38359,7 @@
       "source_location": "L115"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -38188,7 +38368,7 @@
       "source_location": "L31"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -38197,7 +38377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -38206,7 +38386,7 @@
       "source_location": "L14"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -38215,7 +38395,7 @@
       "source_location": "L22"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -38224,7 +38404,7 @@
       "source_location": "L30"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -38233,7 +38413,7 @@
       "source_location": "L3"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -38242,7 +38422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -38251,7 +38431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -38260,7 +38440,7 @@
       "source_location": "L136"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -38269,7 +38449,7 @@
       "source_location": "L154"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -38278,7 +38458,7 @@
       "source_location": "L25"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -38287,7 +38467,7 @@
       "source_location": "L47"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -38296,7 +38476,7 @@
       "source_location": "L109"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -38305,7 +38485,7 @@
       "source_location": "L84"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -38314,7 +38494,7 @@
       "source_location": "L95"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
       "label": "checkout.ts",
@@ -38323,7 +38503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "expensesessions_buildnextexpensesessionnumber",
       "label": "buildNextExpenseSessionNumber()",
@@ -38332,7 +38512,7 @@
       "source_location": "L33"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "expensesessions_listexpensesessionsbystatusbefore",
       "label": "listExpenseSessionsByStatusBefore()",
@@ -38341,7 +38521,7 @@
       "source_location": "L66"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "expensesessions_loadexpensesessionitems",
       "label": "loadExpenseSessionItems()",
@@ -38350,7 +38530,7 @@
       "source_location": "L41"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
       "label": "expenseSessions.ts",
@@ -38359,7 +38539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -38368,7 +38548,7 @@
       "source_location": "L21"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -38377,7 +38557,7 @@
       "source_location": "L35"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -38386,7 +38566,7 @@
       "source_location": "L45"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -38395,7 +38575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -38404,7 +38584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -38413,7 +38593,7 @@
       "source_location": "L21"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -38422,7 +38602,7 @@
       "source_location": "L35"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -38431,7 +38611,7 @@
       "source_location": "L45"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
@@ -38440,7 +38620,7 @@
       "source_location": "L5"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -38449,7 +38629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -38458,48 +38638,12 @@
       "source_location": "L1"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
       "norm_label": "currency.ts",
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "collections_getcachedtokenrecord",
-      "label": "getCachedTokenRecord()",
-      "norm_label": "getcachedtokenrecord()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "collections_resolveaccesstokenforstore",
-      "label": "resolveAccessTokenForStore()",
-      "norm_label": "resolveaccesstokenforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "collections_resolveconfigforstore",
-      "label": "resolveConfigForStore()",
-      "norm_label": "resolveconfigforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_collections_ts",
-      "label": "collections.ts",
-      "norm_label": "collections.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L1"
     },
     {
@@ -38658,6 +38802,42 @@
     {
       "community": 150,
       "file_type": "code",
+      "id": "collections_getcachedtokenrecord",
+      "label": "getCachedTokenRecord()",
+      "norm_label": "getcachedtokenrecord()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "collections_resolveaccesstokenforstore",
+      "label": "resolveAccessTokenForStore()",
+      "norm_label": "resolveaccesstokenforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "collections_resolveconfigforstore",
+      "label": "resolveConfigForStore()",
+      "norm_label": "resolveconfigforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_collections_ts",
+      "label": "collections.ts",
+      "norm_label": "collections.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
       "norm_label": "maskmtnpartyid()",
@@ -38665,7 +38845,7 @@
       "source_location": "L10"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -38674,7 +38854,7 @@
       "source_location": "L18"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -38683,7 +38863,7 @@
       "source_location": "L52"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -38692,7 +38872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -38701,7 +38881,7 @@
       "source_location": "L28"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -38710,7 +38890,7 @@
       "source_location": "L42"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -38719,7 +38899,7 @@
       "source_location": "L73"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -38728,7 +38908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -38737,7 +38917,7 @@
       "source_location": "L8"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -38746,7 +38926,7 @@
       "source_location": "L32"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -38755,7 +38935,7 @@
       "source_location": "L64"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -38764,7 +38944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -38773,7 +38953,7 @@
       "source_location": "L18"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -38782,7 +38962,7 @@
       "source_location": "L25"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -38791,7 +38971,7 @@
       "source_location": "L11"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -38800,7 +38980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -38809,7 +38989,7 @@
       "source_location": "L19"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -38818,7 +38998,7 @@
       "source_location": "L26"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -38827,7 +39007,7 @@
       "source_location": "L12"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -38836,7 +39016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -38845,7 +39025,7 @@
       "source_location": "L21"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -38854,7 +39034,7 @@
       "source_location": "L63"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -38863,7 +39043,7 @@
       "source_location": "L71"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -38872,7 +39052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -38881,7 +39061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -38890,7 +39070,7 @@
       "source_location": "L13"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -38899,7 +39079,7 @@
       "source_location": "L31"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -38908,7 +39088,7 @@
       "source_location": "L9"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -38917,7 +39097,7 @@
       "source_location": "L228"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -38926,7 +39106,7 @@
       "source_location": "L45"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -38935,7 +39115,7 @@
       "source_location": "L26"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -38944,7 +39124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -38953,7 +39133,7 @@
       "source_location": "L55"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -38962,7 +39142,7 @@
       "source_location": "L32"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -38971,48 +39151,12 @@
       "source_location": "L210"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
       "norm_label": "attributestable.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "categorysubcategorymanager_categorymanager",
-      "label": "CategoryManager()",
-      "norm_label": "categorymanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L51"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "categorysubcategorymanager_sidebar",
-      "label": "Sidebar()",
-      "norm_label": "sidebar()",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L26"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "categorysubcategorymanager_subcategorymanager",
-      "label": "SubcategoryManager()",
-      "norm_label": "subcategorymanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L290"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
-      "label": "CategorySubcategoryManager.tsx",
-      "norm_label": "categorysubcategorymanager.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L1"
     },
     {
@@ -39171,6 +39315,42 @@
     {
       "community": 160,
       "file_type": "code",
+      "id": "categorysubcategorymanager_categorymanager",
+      "label": "CategoryManager()",
+      "norm_label": "categorymanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "categorysubcategorymanager_sidebar",
+      "label": "Sidebar()",
+      "norm_label": "sidebar()",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "categorysubcategorymanager_subcategorymanager",
+      "label": "SubcategoryManager()",
+      "norm_label": "subcategorymanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L290"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
+      "label": "CategorySubcategoryManager.tsx",
+      "norm_label": "categorysubcategorymanager.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
       "norm_label": "activecheckoutsessions()",
@@ -39178,7 +39358,7 @@
       "source_location": "L48"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -39187,7 +39367,7 @@
       "source_location": "L88"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -39196,7 +39376,7 @@
       "source_location": "L14"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -39205,7 +39385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -39214,7 +39394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -39223,7 +39403,7 @@
       "source_location": "L15"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -39232,7 +39412,7 @@
       "source_location": "L28"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -39241,7 +39421,7 @@
       "source_location": "L19"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -39250,7 +39430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -39259,7 +39439,7 @@
       "source_location": "L52"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -39268,7 +39448,7 @@
       "source_location": "L3"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -39277,7 +39457,7 @@
       "source_location": "L90"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -39286,7 +39466,7 @@
       "source_location": "L86"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -39295,7 +39475,7 @@
       "source_location": "L76"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -39304,7 +39484,7 @@
       "source_location": "L52"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -39313,7 +39493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -39322,7 +39502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -39331,7 +39511,7 @@
       "source_location": "L67"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -39340,7 +39520,7 @@
       "source_location": "L90"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -39349,7 +39529,7 @@
       "source_location": "L73"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -39358,7 +39538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -39367,7 +39547,7 @@
       "source_location": "L103"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -39376,7 +39556,7 @@
       "source_location": "L95"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -39385,7 +39565,7 @@
       "source_location": "L81"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -39394,7 +39574,7 @@
       "source_location": "L91"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -39403,7 +39583,7 @@
       "source_location": "L68"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -39412,7 +39592,7 @@
       "source_location": "L22"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -39421,7 +39601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -39430,7 +39610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -39439,7 +39619,7 @@
       "source_location": "L247"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -39448,7 +39628,7 @@
       "source_location": "L284"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -39457,7 +39637,7 @@
       "source_location": "L166"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -39466,7 +39646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -39475,7 +39655,7 @@
       "source_location": "L63"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -39484,7 +39664,7 @@
       "source_location": "L54"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -39493,49 +39673,13 @@
       "source_location": "L11"
     },
     {
-      "community": 169,
-      "file_type": "code",
-      "id": "complimentaryproductsview_body",
-      "label": "Body()",
-      "norm_label": "body()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "complimentaryproductsview_complimentaryproductsview",
-      "label": "ComplimentaryProductsView()",
-      "norm_label": "complimentaryproductsview()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "complimentaryproductsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
-      "label": "ComplimentaryProductsView.tsx",
-      "norm_label": "complimentaryproductsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L1"
-    },
-    {
       "community": 17,
       "file_type": "code",
       "id": "orderoperations_assertvalidonlineorderstatustransition",
       "label": "assertValidOnlineOrderStatusTransition()",
       "norm_label": "assertvalidonlineorderstatustransition()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L40"
+      "source_location": "L41"
     },
     {
       "community": 17,
@@ -39544,7 +39688,7 @@
       "label": "getOnlineOrderPaymentAmount()",
       "norm_label": "getonlineorderpaymentamount()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L94"
+      "source_location": "L95"
     },
     {
       "community": 17,
@@ -39553,7 +39697,7 @@
       "label": "getOnlineOrderPaymentMethodLabel()",
       "norm_label": "getonlineorderpaymentmethodlabel()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L84"
+      "source_location": "L85"
     },
     {
       "community": 17,
@@ -39562,7 +39706,7 @@
       "label": "getOnlineOrderStatusEventType()",
       "norm_label": "getonlineorderstatuseventtype()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L28"
+      "source_location": "L29"
     },
     {
       "community": 17,
@@ -39571,7 +39715,7 @@
       "label": "getStoreOrganizationId()",
       "norm_label": "getstoreorganizationid()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L100"
+      "source_location": "L101"
     },
     {
       "community": 17,
@@ -39580,7 +39724,7 @@
       "label": "isPaymentOnDeliveryOrder()",
       "norm_label": "ispaymentondeliveryorder()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L32"
+      "source_location": "L33"
     },
     {
       "community": 17,
@@ -39589,7 +39733,7 @@
       "label": "recordOnlineOrderCreatedEvent()",
       "norm_label": "recordonlineordercreatedevent()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L173"
+      "source_location": "L174"
     },
     {
       "community": 17,
@@ -39598,7 +39742,7 @@
       "label": "recordOnlineOrderFulfillmentMovement()",
       "norm_label": "recordonlineorderfulfillmentmovement()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L369"
+      "source_location": "L381"
     },
     {
       "community": 17,
@@ -39607,7 +39751,7 @@
       "label": "recordOnlineOrderPaymentCollected()",
       "norm_label": "recordonlineorderpaymentcollected()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L287"
+      "source_location": "L288"
     },
     {
       "community": 17,
@@ -39616,7 +39760,7 @@
       "label": "recordOnlineOrderPaymentVerified()",
       "norm_label": "recordonlineorderpaymentverified()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L239"
+      "source_location": "L240"
     },
     {
       "community": 17,
@@ -39625,7 +39769,7 @@
       "label": "recordOnlineOrderRefundAllocation()",
       "norm_label": "recordonlineorderrefundallocation()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L335"
+      "source_location": "L347"
     },
     {
       "community": 17,
@@ -39634,7 +39778,7 @@
       "label": "recordOnlineOrderRestockMovement()",
       "norm_label": "recordonlineorderrestockmovement()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L397"
+      "source_location": "L409"
     },
     {
       "community": 17,
@@ -39643,7 +39787,7 @@
       "label": "recordOnlineOrderStatusEvent()",
       "norm_label": "recordonlineorderstatusevent()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L200"
+      "source_location": "L201"
     },
     {
       "community": 17,
@@ -39652,7 +39796,7 @@
       "label": "resolveCustomerProfileForStoreFrontActor()",
       "norm_label": "resolvecustomerprofileforstorefrontactor()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L108"
+      "source_location": "L109"
     },
     {
       "community": 17,
@@ -39661,7 +39805,7 @@
       "label": "resolveOnlineOrderContext()",
       "norm_label": "resolveonlineordercontext()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L146"
+      "source_location": "L147"
     },
     {
       "community": 17,
@@ -39675,6 +39819,42 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "complimentaryproductsview_body",
+      "label": "Body()",
+      "norm_label": "body()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "complimentaryproductsview_complimentaryproductsview",
+      "label": "ComplimentaryProductsView()",
+      "norm_label": "complimentaryproductsview()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "complimentaryproductsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
+      "label": "ComplimentaryProductsView.tsx",
+      "norm_label": "complimentaryproductsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "label": "ServiceAppointmentsView.tsx",
       "norm_label": "serviceappointmentsview.tsx",
@@ -39682,7 +39862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "serviceappointmentsview_handlesubmit",
       "label": "handleSubmit()",
@@ -39691,7 +39871,7 @@
       "source_location": "L115"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "serviceappointmentsview_parsedatetimelocal",
       "label": "parseDateTimeLocal()",
@@ -39700,7 +39880,7 @@
       "source_location": "L77"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "serviceappointmentsview_withsavestate",
       "label": "withSaveState()",
@@ -39709,7 +39889,7 @@
       "source_location": "L441"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -39718,7 +39898,7 @@
       "source_location": "L75"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -39727,7 +39907,7 @@
       "source_location": "L82"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -39736,7 +39916,7 @@
       "source_location": "L93"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -39745,7 +39925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -39754,7 +39934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -39763,7 +39943,7 @@
       "source_location": "L15"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -39772,7 +39952,7 @@
       "source_location": "L28"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -39781,7 +39961,7 @@
       "source_location": "L54"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -39790,7 +39970,7 @@
       "source_location": "L66"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -39799,7 +39979,7 @@
       "source_location": "L121"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -39808,7 +39988,7 @@
       "source_location": "L74"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -39817,7 +39997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -39826,7 +40006,7 @@
       "source_location": "L51"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -39835,7 +40015,7 @@
       "source_location": "L92"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -39844,7 +40024,7 @@
       "source_location": "L16"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -39853,7 +40033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -39862,7 +40042,7 @@
       "source_location": "L13"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -39871,7 +40051,7 @@
       "source_location": "L46"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -39880,7 +40060,7 @@
       "source_location": "L21"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -39889,7 +40069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -39898,7 +40078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -39907,7 +40087,7 @@
       "source_location": "L8"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -39916,7 +40096,7 @@
       "source_location": "L5"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -39925,7 +40105,7 @@
       "source_location": "L20"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -39934,7 +40114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -39943,7 +40123,7 @@
       "source_location": "L11"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -39952,7 +40132,7 @@
       "source_location": "L9"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -39961,7 +40141,7 @@
       "source_location": "L25"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -39970,7 +40150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -39979,7 +40159,7 @@
       "source_location": "L50"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -39988,49 +40168,13 @@
       "source_location": "L92"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
       "norm_label": "handledismiss()",
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L74"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
-      "label": "ProductReminderBar.tsx",
-      "norm_label": "productreminderbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "productreminderbar_checkscroll",
-      "label": "checkScroll()",
-      "norm_label": "checkscroll()",
-      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "productreminderbar_handleaddtobag",
-      "label": "handleAddToBag()",
-      "norm_label": "handleaddtobag()",
-      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
-      "source_location": "L109"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "productreminderbar_handledismiss",
-      "label": "handleDismiss()",
-      "norm_label": "handledismiss()",
-      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
-      "source_location": "L177"
     },
     {
       "community": 18,
@@ -40179,6 +40323,42 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
+      "label": "ProductReminderBar.tsx",
+      "norm_label": "productreminderbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "productreminderbar_checkscroll",
+      "label": "checkScroll()",
+      "norm_label": "checkscroll()",
+      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "productreminderbar_handleaddtobag",
+      "label": "handleAddToBag()",
+      "norm_label": "handleaddtobag()",
+      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
+      "source_location": "L109"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "productreminderbar_handledismiss",
+      "label": "handleDismiss()",
+      "norm_label": "handledismiss()",
+      "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
+      "source_location": "L177"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
       "norm_label": "clearform()",
@@ -40186,7 +40366,7 @@
       "source_location": "L18"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -40195,7 +40375,7 @@
       "source_location": "L52"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -40204,7 +40384,7 @@
       "source_location": "L68"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -40213,7 +40393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -40222,7 +40402,7 @@
       "source_location": "L68"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -40231,7 +40411,7 @@
       "source_location": "L26"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -40240,7 +40420,7 @@
       "source_location": "L7"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -40249,7 +40429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -40258,7 +40438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -40267,7 +40447,7 @@
       "source_location": "L43"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -40276,7 +40456,7 @@
       "source_location": "L13"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -40285,7 +40465,7 @@
       "source_location": "L88"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -40294,7 +40474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -40303,7 +40483,7 @@
       "source_location": "L111"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -40312,7 +40492,7 @@
       "source_location": "L66"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -40321,7 +40501,7 @@
       "source_location": "L127"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -40330,7 +40510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -40339,7 +40519,7 @@
       "source_location": "L115"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -40348,7 +40528,7 @@
       "source_location": "L105"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -40357,7 +40537,7 @@
       "source_location": "L110"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -40366,7 +40546,7 @@
       "source_location": "L121"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -40375,7 +40555,7 @@
       "source_location": "L26"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -40384,7 +40564,7 @@
       "source_location": "L71"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -40393,7 +40573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -40402,7 +40582,7 @@
       "source_location": "L46"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -40411,7 +40591,7 @@
       "source_location": "L24"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -40420,7 +40600,7 @@
       "source_location": "L20"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -40429,7 +40609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
@@ -40438,7 +40618,7 @@
       "source_location": "L33"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -40447,7 +40627,7 @@
       "source_location": "L6"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -40456,7 +40636,7 @@
       "source_location": "L25"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -40465,7 +40645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -40474,7 +40654,7 @@
       "source_location": "L17"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -40483,7 +40663,7 @@
       "source_location": "L11"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -40492,48 +40672,12 @@
       "source_location": "L24"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
       "norm_label": "graphify-check.test.ts",
       "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "scripts_graphify_rebuild_test_ts",
-      "label": "graphify-rebuild.test.ts",
-      "norm_label": "graphify-rebuild.test.ts",
-      "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L1"
     },
     {
@@ -40674,6 +40818,42 @@
     {
       "community": 190,
       "file_type": "code",
+      "id": "graphify_rebuild_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "scripts_graphify_rebuild_test_ts",
+      "label": "graphify-rebuild.test.ts",
+      "norm_label": "graphify-rebuild.test.ts",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
       "norm_label": "buildharnessdocpaths()",
@@ -40681,7 +40861,7 @@
       "source_location": "L126"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -40690,7 +40870,7 @@
       "source_location": "L130"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -40699,7 +40879,7 @@
       "source_location": "L544"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -40708,7 +40888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -40717,7 +40897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -40726,7 +40906,7 @@
       "source_location": "L8"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -40735,7 +40915,7 @@
       "source_location": "L79"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -40744,7 +40924,7 @@
       "source_location": "L61"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -40753,7 +40933,7 @@
       "source_location": "L49"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -40762,7 +40942,7 @@
       "source_location": "L17"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -40771,7 +40951,7 @@
       "source_location": "L11"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -40780,7 +40960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -40789,7 +40969,7 @@
       "source_location": "L26"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -40798,7 +40978,7 @@
       "source_location": "L72"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -40807,7 +40987,7 @@
       "source_location": "L36"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -40816,7 +40996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -40825,7 +41005,7 @@
       "source_location": "L90"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -40834,7 +41014,7 @@
       "source_location": "L88"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -40843,7 +41023,7 @@
       "source_location": "L89"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -40852,7 +41032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -40861,7 +41041,7 @@
       "source_location": "L98"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -40870,7 +41050,7 @@
       "source_location": "L33"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -40879,7 +41059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -40888,7 +41068,7 @@
       "source_location": "L85"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -40897,7 +41077,7 @@
       "source_location": "L31"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -40906,7 +41086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -40915,7 +41095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -40924,7 +41104,7 @@
       "source_location": "L5"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -40933,7 +41113,7 @@
       "source_location": "L12"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -40942,7 +41122,7 @@
       "source_location": "L43"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -40951,40 +41131,13 @@
       "source_location": "L11"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
       "norm_label": "analyticsutils.ts",
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
-      "label": "staffProfiles.ts",
-      "norm_label": "staffprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "staffprofiles_buildfullname",
-      "label": "buildFullName()",
-      "norm_label": "buildfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "staffprofiles_buildroleassignmentdrafts",
-      "label": "buildRoleAssignmentDrafts()",
-      "norm_label": "buildroleassignmentdrafts()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L17"
     },
     {
       "community": 2,
@@ -41421,6 +41574,33 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
+      "label": "staffProfiles.ts",
+      "norm_label": "staffprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "staffprofiles_buildfullname",
+      "label": "buildFullName()",
+      "norm_label": "buildfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "staffprofiles_buildroleassignmentdrafts",
+      "label": "buildRoleAssignmentDrafts()",
+      "norm_label": "buildroleassignmentdrafts()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
       "norm_label": "listtransactions()",
@@ -41428,7 +41608,7 @@
       "source_location": "L7"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -41437,7 +41617,7 @@
       "source_location": "L109"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -41446,7 +41626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -41455,7 +41635,7 @@
       "source_location": "L16"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -41464,7 +41644,7 @@
       "source_location": "L42"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -41473,7 +41653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -41482,7 +41662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -41491,7 +41671,7 @@
       "source_location": "L23"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -41500,7 +41680,7 @@
       "source_location": "L16"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -41509,7 +41689,7 @@
       "source_location": "L21"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -41518,7 +41698,7 @@
       "source_location": "L17"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -41527,7 +41707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -41536,7 +41716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -41545,7 +41725,7 @@
       "source_location": "L11"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -41554,7 +41734,7 @@
       "source_location": "L6"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -41563,7 +41743,7 @@
       "source_location": "L7"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -41572,7 +41752,7 @@
       "source_location": "L14"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -41581,7 +41761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -41590,7 +41770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -41599,7 +41779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -41608,7 +41788,7 @@
       "source_location": "L4"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -41617,7 +41797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -41626,7 +41806,7 @@
       "source_location": "L18"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -41635,7 +41815,7 @@
       "source_location": "L5"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -41644,7 +41824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -41653,40 +41833,13 @@
       "source_location": "L19"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
       "norm_label": "usesheet()",
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
-      "label": "WigType.tsx",
-      "norm_label": "wigtype.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "wigtype_wigtype",
-      "label": "WigType()",
-      "norm_label": "wigtype()",
-      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "wigtype_wigtypeview",
-      "label": "WigTypeView()",
-      "norm_label": "wigtypeview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
-      "source_location": "L8"
     },
     {
       "community": 21,
@@ -41826,6 +41979,33 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
+      "label": "WigType.tsx",
+      "norm_label": "wigtype.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "wigtype_wigtype",
+      "label": "WigType()",
+      "norm_label": "wigtype()",
+      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "wigtype_wigtypeview",
+      "label": "WigTypeView()",
+      "norm_label": "wigtypeview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
       "norm_label": "copyimagesprovider()",
@@ -41833,7 +42013,7 @@
       "source_location": "L21"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -41842,7 +42022,7 @@
       "source_location": "L13"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -41851,7 +42031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -41860,7 +42040,7 @@
       "source_location": "L100"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -41869,7 +42049,7 @@
       "source_location": "L10"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -41878,7 +42058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -41887,7 +42067,7 @@
       "source_location": "L100"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -41896,7 +42076,7 @@
       "source_location": "L10"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -41905,7 +42085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -41914,7 +42094,7 @@
       "source_location": "L15"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -41923,7 +42103,7 @@
       "source_location": "L39"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -41932,7 +42112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -41941,7 +42121,7 @@
       "source_location": "L48"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -41950,7 +42130,7 @@
       "source_location": "L56"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -41959,7 +42139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -41968,7 +42148,7 @@
       "source_location": "L3"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -41977,7 +42157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -41986,7 +42166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -41995,7 +42175,7 @@
       "source_location": "L53"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -42004,7 +42184,7 @@
       "source_location": "L65"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -42013,7 +42193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -42022,7 +42202,7 @@
       "source_location": "L47"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -42031,7 +42211,7 @@
       "source_location": "L53"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -42040,7 +42220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -42049,7 +42229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -42058,40 +42238,13 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
       "norm_label": "videoplayer()",
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "operationsqueueview_handledecideapprovalrequest",
-      "label": "handleDecideApprovalRequest()",
-      "norm_label": "handledecideapprovalrequest()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L288"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "operationsqueueview_handlesubmitstockbatch",
-      "label": "handleSubmitStockBatch()",
-      "norm_label": "handlesubmitstockbatch()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L278"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
-      "label": "OperationsQueueView.tsx",
-      "norm_label": "operationsqueueview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 22,
@@ -42222,6 +42375,33 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "operationsqueueview_handledecideapprovalrequest",
+      "label": "handleDecideApprovalRequest()",
+      "norm_label": "handledecideapprovalrequest()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L288"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "operationsqueueview_handlesubmitstockbatch",
+      "label": "handleSubmitStockBatch()",
+      "norm_label": "handlesubmitstockbatch()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L278"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
+      "label": "OperationsQueueView.tsx",
+      "norm_label": "operationsqueueview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
       "norm_label": "pickupdetailsview.tsx",
@@ -42229,7 +42409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -42238,7 +42418,7 @@
       "source_location": "L67"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -42247,7 +42427,7 @@
       "source_location": "L9"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
@@ -42256,7 +42436,7 @@
       "source_location": "L99"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -42265,7 +42445,7 @@
       "source_location": "L94"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -42274,7 +42454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -42283,7 +42463,7 @@
       "source_location": "L59"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -42292,7 +42472,7 @@
       "source_location": "L55"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -42301,7 +42481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -42310,7 +42490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -42319,7 +42499,7 @@
       "source_location": "L20"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -42328,7 +42508,7 @@
       "source_location": "L26"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -42337,7 +42517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -42346,7 +42526,7 @@
       "source_location": "L65"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -42355,7 +42535,7 @@
       "source_location": "L20"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -42364,7 +42544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -42373,7 +42553,7 @@
       "source_location": "L16"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -42382,7 +42562,7 @@
       "source_location": "L60"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -42391,7 +42571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -42400,7 +42580,7 @@
       "source_location": "L45"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -42409,7 +42589,7 @@
       "source_location": "L19"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -42418,7 +42598,7 @@
       "source_location": "L128"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -42427,7 +42607,7 @@
       "source_location": "L40"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -42436,7 +42616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -42445,7 +42625,7 @@
       "source_location": "L24"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -42454,39 +42634,12 @@
       "source_location": "L20"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
       "norm_label": "color-picker.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "currency_provider_currencyprovider",
-      "label": "CurrencyProvider()",
-      "norm_label": "currencyprovider()",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "currency_provider_usestorecurrency",
-      "label": "useStoreCurrency()",
-      "norm_label": "usestorecurrency()",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
-      "label": "currency-provider.tsx",
-      "norm_label": "currency-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1"
     },
     {
@@ -42505,7 +42658,7 @@
       "label": "assertValidServiceCaseStatusTransition()",
       "norm_label": "assertvalidservicecasestatustransition()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L215"
+      "source_location": "L216"
     },
     {
       "community": 23,
@@ -42514,7 +42667,7 @@
       "label": "buildServiceCase()",
       "norm_label": "buildservicecase()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L224"
+      "source_location": "L225"
     },
     {
       "community": 23,
@@ -42523,7 +42676,7 @@
       "label": "buildServiceCaseLineItem()",
       "norm_label": "buildservicecaselineitem()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L252"
+      "source_location": "L253"
     },
     {
       "community": 23,
@@ -42532,7 +42685,7 @@
       "label": "createServiceCaseWithCtx()",
       "norm_label": "createservicecasewithctx()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L274"
+      "source_location": "L275"
     },
     {
       "community": 23,
@@ -42541,7 +42694,7 @@
       "label": "deriveServiceCasePaymentStatus()",
       "norm_label": "deriveservicecasepaymentstatus()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L85"
+      "source_location": "L86"
     },
     {
       "community": 23,
@@ -42550,7 +42703,7 @@
       "label": "getServiceCaseContext()",
       "norm_label": "getservicecasecontext()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L189"
+      "source_location": "L190"
     },
     {
       "community": 23,
@@ -42559,7 +42712,7 @@
       "label": "listPendingApprovalRequestsWithCtx()",
       "norm_label": "listpendingapprovalrequestswithctx()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L142"
+      "source_location": "L143"
     },
     {
       "community": 23,
@@ -42568,7 +42721,7 @@
       "label": "listServiceCaseAllocationsWithCtx()",
       "norm_label": "listservicecaseallocationswithctx()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L129"
+      "source_location": "L130"
     },
     {
       "community": 23,
@@ -42577,7 +42730,7 @@
       "label": "listServiceCaseLineItemsWithCtx()",
       "norm_label": "listservicecaselineitemswithctx()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L109"
+      "source_location": "L110"
     },
     {
       "community": 23,
@@ -42586,7 +42739,7 @@
       "label": "listServiceInventoryUsageWithCtx()",
       "norm_label": "listserviceinventoryusagewithctx()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L119"
+      "source_location": "L120"
     },
     {
       "community": 23,
@@ -42595,7 +42748,7 @@
       "label": "mapServiceCaseStatusToWorkItemStatus()",
       "norm_label": "mapservicecasestatustoworkitemstatus()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L69"
+      "source_location": "L70"
     },
     {
       "community": 23,
@@ -42604,10 +42757,37 @@
       "label": "syncServiceCaseFinancialsWithCtx()",
       "norm_label": "syncservicecasefinancialswithctx()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L154"
+      "source_location": "L155"
     },
     {
       "community": 230,
+      "file_type": "code",
+      "id": "currency_provider_currencyprovider",
+      "label": "CurrencyProvider()",
+      "norm_label": "currencyprovider()",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "currency_provider_usestorecurrency",
+      "label": "useStoreCurrency()",
+      "norm_label": "usestorecurrency()",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
+      "label": "currency-provider.tsx",
+      "norm_label": "currency-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -42616,7 +42796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "serviceintakeview_handlecreateintake",
       "label": "handleCreateIntake()",
@@ -42625,7 +42805,7 @@
       "source_location": "L238"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -42634,7 +42814,7 @@
       "source_location": "L69"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -42643,7 +42823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -42652,7 +42832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -42661,7 +42841,7 @@
       "source_location": "L3"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -42670,7 +42850,7 @@
       "source_location": "L9"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -42679,7 +42859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -42688,7 +42868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -42697,7 +42877,7 @@
       "source_location": "L3"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -42706,7 +42886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -42715,7 +42895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -42724,7 +42904,7 @@
       "source_location": "L3"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -42733,7 +42913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -42742,7 +42922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -42751,7 +42931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -42760,7 +42940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -42769,7 +42949,7 @@
       "source_location": "L3"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -42778,7 +42958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -42787,7 +42967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -42796,7 +42976,7 @@
       "source_location": "L3"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -42805,7 +42985,7 @@
       "source_location": "L4"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -42814,7 +42994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -42823,7 +43003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -42832,7 +43012,7 @@
       "source_location": "L104"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -42841,39 +43021,12 @@
       "source_location": "L36"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
       "norm_label": "feesview.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "app_context_menu_appcontextmenu",
-      "label": "AppContextMenu()",
-      "norm_label": "appcontextmenu()",
-      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
-      "label": "app-context-menu.tsx",
-      "norm_label": "app-context-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/app-context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
-      "label": "app-context-menu.tsx",
-      "norm_label": "app-context-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1"
     },
     {
@@ -42996,6 +43149,33 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "app_context_menu_appcontextmenu",
+      "label": "AppContextMenu()",
+      "norm_label": "appcontextmenu()",
+      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
+      "label": "app-context-menu.tsx",
+      "norm_label": "app-context-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/app-context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
+      "label": "app-context-menu.tsx",
+      "norm_label": "app-context-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
       "norm_label": "badge()",
@@ -43003,7 +43183,7 @@
       "source_location": "L30"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -43012,7 +43192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -43021,7 +43201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -43030,7 +43210,7 @@
       "source_location": "L9"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -43039,7 +43219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -43048,7 +43228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -43057,7 +43237,7 @@
       "source_location": "L38"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -43066,7 +43246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -43075,7 +43255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -43084,7 +43264,7 @@
       "source_location": "L20"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -43093,7 +43273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -43102,7 +43282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -43111,7 +43291,7 @@
       "source_location": "L12"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -43120,7 +43300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -43129,7 +43309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -43138,7 +43318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -43147,7 +43327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -43156,7 +43336,7 @@
       "source_location": "L3"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -43165,7 +43345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -43174,7 +43354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -43183,7 +43363,7 @@
       "source_location": "L6"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -43192,7 +43372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -43201,7 +43381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -43210,7 +43390,7 @@
       "source_location": "L3"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -43219,7 +43399,7 @@
       "source_location": "L44"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -43228,40 +43408,13 @@
       "source_location": "L19"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
       "norm_label": "activitysummarycards.tsx",
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
-      "label": "TimelineEventCard.tsx",
-      "norm_label": "timelineeventcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "timelineeventcard_formatobservabilitylabel",
-      "label": "formatObservabilityLabel()",
-      "norm_label": "formatobservabilitylabel()",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
-      "source_location": "L159"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "timelineeventcard_loadmore",
-      "label": "loadMore()",
-      "norm_label": "loadmore()",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
-      "source_location": "L195"
     },
     {
       "community": 25,
@@ -43383,6 +43536,33 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
+      "label": "TimelineEventCard.tsx",
+      "norm_label": "timelineeventcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "timelineeventcard_formatobservabilitylabel",
+      "label": "formatObservabilityLabel()",
+      "norm_label": "formatobservabilitylabel()",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
+      "source_location": "L159"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "timelineeventcard_loadmore",
+      "label": "loadMore()",
+      "norm_label": "loadmore()",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
+      "source_location": "L195"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
       "norm_label": "useractivity.tsx",
@@ -43390,7 +43570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -43399,7 +43579,7 @@
       "source_location": "L22"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -43408,7 +43588,7 @@
       "source_location": "L45"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -43417,7 +43597,7 @@
       "source_location": "L24"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -43426,7 +43606,7 @@
       "source_location": "L38"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -43435,7 +43615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -43444,7 +43624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -43453,7 +43633,7 @@
       "source_location": "L23"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -43462,7 +43642,7 @@
       "source_location": "L51"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -43471,7 +43651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -43480,7 +43660,7 @@
       "source_location": "L54"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -43489,7 +43669,7 @@
       "source_location": "L282"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -43498,7 +43678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -43507,7 +43687,7 @@
       "source_location": "L12"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -43516,7 +43696,7 @@
       "source_location": "L37"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -43525,7 +43705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -43534,7 +43714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -43543,7 +43723,7 @@
       "source_location": "L4"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -43552,7 +43732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -43561,7 +43741,7 @@
       "source_location": "L9"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -43570,7 +43750,7 @@
       "source_location": "L50"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -43579,7 +43759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -43588,7 +43768,7 @@
       "source_location": "L6"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -43597,7 +43777,7 @@
       "source_location": "L31"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -43606,7 +43786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -43615,40 +43795,13 @@
       "source_location": "L5"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
       "norm_label": "usegetunresolvedproducts()",
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L31"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposoperations_ts",
-      "label": "usePOSOperations.ts",
-      "norm_label": "useposoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "useposoperations_useposoperations",
-      "label": "usePOSOperations()",
-      "norm_label": "useposoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "useposoperations_useposstate",
-      "label": "usePOSState()",
-      "norm_label": "useposstate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
-      "source_location": "L580"
     },
     {
       "community": 26,
@@ -43761,6 +43914,33 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useposoperations_ts",
+      "label": "usePOSOperations.ts",
+      "norm_label": "useposoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "useposoperations_useposoperations",
+      "label": "usePOSOperations()",
+      "norm_label": "useposoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "useposoperations_useposstate",
+      "label": "usePOSState()",
+      "norm_label": "useposstate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
+      "source_location": "L580"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
       "norm_label": "isinmaintenancemode()",
@@ -43768,7 +43948,7 @@
       "source_location": "L7"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -43777,7 +43957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -43786,7 +43966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -43795,7 +43975,7 @@
       "source_location": "L3"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -43804,7 +43984,7 @@
       "source_location": "L10"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -43813,7 +43993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -43822,7 +44002,7 @@
       "source_location": "L31"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -43831,7 +44011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -43840,7 +44020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -43849,7 +44029,7 @@
       "source_location": "L18"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -43858,7 +44038,7 @@
       "source_location": "L38"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -43867,7 +44047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -43876,7 +44056,7 @@
       "source_location": "L127"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -43885,7 +44065,7 @@
       "source_location": "L106"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -43894,7 +44074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -43903,7 +44083,7 @@
       "source_location": "L66"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -43912,7 +44092,7 @@
       "source_location": "L20"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -43921,7 +44101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -43930,7 +44110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -43939,7 +44119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -43948,7 +44128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -43957,7 +44137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -43966,7 +44146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -43975,7 +44155,7 @@
       "source_location": "L16"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -43984,7 +44164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -43993,7 +44173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -44002,7 +44182,106 @@
       "source_location": "L19"
     },
     {
-      "community": 269,
+      "community": 27,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 270,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -44011,7 +44290,7 @@
       "source_location": "L32"
     },
     {
-      "community": 269,
+      "community": 270,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -44020,7 +44299,7 @@
       "source_location": "L3"
     },
     {
-      "community": 269,
+      "community": 270,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -44029,106 +44308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 27,
-      "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -44137,7 +44317,7 @@
       "source_location": "L7"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -44146,7 +44326,7 @@
       "source_location": "L5"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -44155,7 +44335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -44164,7 +44344,7 @@
       "source_location": "L6"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -44173,7 +44353,7 @@
       "source_location": "L18"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -44182,7 +44362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -44191,7 +44371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -44200,7 +44380,7 @@
       "source_location": "L3"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -44209,7 +44389,7 @@
       "source_location": "L5"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -44218,7 +44398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -44227,7 +44407,7 @@
       "source_location": "L18"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -44236,7 +44416,7 @@
       "source_location": "L23"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -44245,7 +44425,7 @@
       "source_location": "L22"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -44254,7 +44434,7 @@
       "source_location": "L55"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -44263,7 +44443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -44272,7 +44452,7 @@
       "source_location": "L77"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -44281,7 +44461,7 @@
       "source_location": "L11"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -44290,7 +44470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -44299,7 +44479,7 @@
       "source_location": "L11"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -44308,7 +44488,7 @@
       "source_location": "L22"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -44317,7 +44497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -44326,7 +44506,7 @@
       "source_location": "L110"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -44335,7 +44515,7 @@
       "source_location": "L89"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -44344,7 +44524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -44353,7 +44533,7 @@
       "source_location": "L4"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -44362,7 +44542,7 @@
       "source_location": "L24"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -44371,7 +44551,106 @@
       "source_location": "L1"
     },
     {
-      "community": 279,
+      "community": 28,
+      "file_type": "code",
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 28,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -44380,7 +44659,7 @@
       "source_location": "L131"
     },
     {
-      "community": 279,
+      "community": 280,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -44389,7 +44668,7 @@
       "source_location": "L12"
     },
     {
-      "community": 279,
+      "community": 280,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -44398,106 +44677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 28,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usepossessions_ts",
-      "label": "usePOSSessions.ts",
-      "norm_label": "usepossessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "usepossessions_useposactivesession",
-      "label": "usePOSActiveSession()",
-      "norm_label": "useposactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "usepossessions_usepossession",
-      "label": "usePOSSession()",
-      "norm_label": "usepossession()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "usepossessions_usepossessioncomplete",
-      "label": "usePOSSessionComplete()",
-      "norm_label": "usepossessioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "usepossessions_usepossessioncreate",
-      "label": "usePOSSessionCreate()",
-      "norm_label": "usepossessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "usepossessions_usepossessionhold",
-      "label": "usePOSSessionHold()",
-      "norm_label": "usepossessionhold()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "usepossessions_usepossessionmanager",
-      "label": "usePOSSessionManager()",
-      "norm_label": "usepossessionmanager()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "usepossessions_usepossessionresume",
-      "label": "usePOSSessionResume()",
-      "norm_label": "usepossessionresume()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "usepossessions_usepossessionupdate",
-      "label": "usePOSSessionUpdate()",
-      "norm_label": "usepossessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "usepossessions_usepossessionvoid",
-      "label": "usePOSSessionVoid()",
-      "norm_label": "usepossessionvoid()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 28,
-      "file_type": "code",
-      "id": "usepossessions_useposstoresessions",
-      "label": "usePOSStoreSessions()",
-      "norm_label": "useposstoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -44506,7 +44686,7 @@
       "source_location": "L20"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -44515,7 +44695,7 @@
       "source_location": "L46"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -44524,7 +44704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -44533,7 +44713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -44542,7 +44722,7 @@
       "source_location": "L20"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -44551,7 +44731,7 @@
       "source_location": "L59"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -44560,7 +44740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -44569,7 +44749,7 @@
       "source_location": "L25"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -44578,7 +44758,7 @@
       "source_location": "L20"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -44587,7 +44767,7 @@
       "source_location": "L30"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -44596,7 +44776,7 @@
       "source_location": "L95"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -44605,7 +44785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -44614,7 +44794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -44623,7 +44803,7 @@
       "source_location": "L61"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -44632,7 +44812,7 @@
       "source_location": "L65"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -44641,7 +44821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -44650,7 +44830,7 @@
       "source_location": "L150"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -44659,7 +44839,7 @@
       "source_location": "L157"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -44668,7 +44848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -44677,7 +44857,7 @@
       "source_location": "L63"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -44686,7 +44866,7 @@
       "source_location": "L48"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -44695,7 +44875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -44704,7 +44884,7 @@
       "source_location": "L63"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -44713,7 +44893,7 @@
       "source_location": "L76"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -44722,7 +44902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -44731,7 +44911,7 @@
       "source_location": "L51"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -44740,7 +44920,106 @@
       "source_location": "L36"
     },
     {
-      "community": 289,
+      "community": 29,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usepossessions_ts",
+      "label": "usePOSSessions.ts",
+      "norm_label": "usepossessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "usepossessions_useposactivesession",
+      "label": "usePOSActiveSession()",
+      "norm_label": "useposactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "usepossessions_usepossession",
+      "label": "usePOSSession()",
+      "norm_label": "usepossession()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "usepossessions_usepossessioncomplete",
+      "label": "usePOSSessionComplete()",
+      "norm_label": "usepossessioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "usepossessions_usepossessioncreate",
+      "label": "usePOSSessionCreate()",
+      "norm_label": "usepossessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "usepossessions_usepossessionhold",
+      "label": "usePOSSessionHold()",
+      "norm_label": "usepossessionhold()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "usepossessions_usepossessionmanager",
+      "label": "usePOSSessionManager()",
+      "norm_label": "usepossessionmanager()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "usepossessions_usepossessionresume",
+      "label": "usePOSSessionResume()",
+      "norm_label": "usepossessionresume()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L137"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "usepossessions_usepossessionupdate",
+      "label": "usePOSSessionUpdate()",
+      "norm_label": "usepossessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "usepossessions_usepossessionvoid",
+      "label": "usePOSSessionVoid()",
+      "norm_label": "usepossessionvoid()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "usepossessions_useposstoresessions",
+      "label": "usePOSStoreSessions()",
+      "norm_label": "useposstoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 290,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -44749,7 +45028,7 @@
       "source_location": "L16"
     },
     {
-      "community": 289,
+      "community": 290,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -44758,7 +45037,7 @@
       "source_location": "L39"
     },
     {
-      "community": 289,
+      "community": 290,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -44767,106 +45046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 29,
-      "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -44875,7 +45055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -44884,7 +45064,7 @@
       "source_location": "L25"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -44893,7 +45073,7 @@
       "source_location": "L82"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -44902,7 +45082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -44911,7 +45091,7 @@
       "source_location": "L20"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -44920,7 +45100,7 @@
       "source_location": "L55"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -44929,7 +45109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -44938,7 +45118,7 @@
       "source_location": "L107"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -44947,7 +45127,7 @@
       "source_location": "L25"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -44956,7 +45136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -44965,7 +45145,7 @@
       "source_location": "L556"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -44974,7 +45154,7 @@
       "source_location": "L52"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -44983,7 +45163,7 @@
       "source_location": "L429"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -44992,7 +45172,7 @@
       "source_location": "L102"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -45001,7 +45181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -45010,7 +45190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -45019,7 +45199,7 @@
       "source_location": "L250"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -45028,7 +45208,7 @@
       "source_location": "L46"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -45037,7 +45217,7 @@
       "source_location": "L17"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -45046,7 +45226,7 @@
       "source_location": "L63"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -45055,7 +45235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -45064,7 +45244,7 @@
       "source_location": "L47"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -45073,7 +45253,7 @@
       "source_location": "L141"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
@@ -45082,7 +45262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
@@ -45091,7 +45271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -45100,40 +45280,13 @@
       "source_location": "L21"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
       "norm_label": "verifycheckoutsessionpayment()",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L107"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_signup_tsx",
-      "label": "signup.tsx",
-      "norm_label": "signup.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "signup_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "signup_signupbeforeload",
-      "label": "signupBeforeLoad()",
-      "norm_label": "signupbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L66"
     },
     {
       "community": 3,
@@ -45417,104 +45570,131 @@
     {
       "community": 30,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
     },
     {
       "community": 300,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_signup_tsx",
+      "label": "signup.tsx",
+      "norm_label": "signup.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "signup_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "signup_signupbeforeload",
+      "label": "signupBeforeLoad()",
+      "norm_label": "signupbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 301,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -45523,7 +45703,7 @@
       "source_location": "L11"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -45532,7 +45712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -45541,7 +45721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -45550,7 +45730,7 @@
       "source_location": "L16"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -45559,7 +45739,7 @@
       "source_location": "L10"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -45568,7 +45748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -45577,7 +45757,7 @@
       "source_location": "L17"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -45586,7 +45766,7 @@
       "source_location": "L11"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -45595,7 +45775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -45604,7 +45784,7 @@
       "source_location": "L21"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -45613,7 +45793,7 @@
       "source_location": "L15"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -45622,7 +45802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -45631,7 +45811,7 @@
       "source_location": "L48"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -45640,7 +45820,7 @@
       "source_location": "L42"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -45649,7 +45829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -45658,7 +45838,7 @@
       "source_location": "L16"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -45667,7 +45847,7 @@
       "source_location": "L10"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -45676,7 +45856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -45685,7 +45865,7 @@
       "source_location": "L19"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -45694,7 +45874,7 @@
       "source_location": "L13"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -45703,7 +45883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -45712,7 +45892,7 @@
       "source_location": "L16"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -45721,7 +45901,7 @@
       "source_location": "L10"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -45730,7 +45910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -45739,7 +45919,7 @@
       "source_location": "L20"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -45748,39 +45928,12 @@
       "source_location": "L14"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
       "norm_label": "harness-test.test.ts",
       "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "scripts_pre_commit_generated_artifacts_test_ts",
-      "label": "pre-commit-generated-artifacts.test.ts",
-      "norm_label": "pre-commit-generated-artifacts.test.ts",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
       "source_location": "L1"
     },
     {
@@ -45885,6 +46038,33 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_test_ts",
+      "label": "pre-commit-generated-artifacts.test.ts",
+      "norm_label": "pre-commit-generated-artifacts.test.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
       "norm_label": "runprecommitgeneratedartifacts()",
@@ -45892,7 +46072,7 @@
       "source_location": "L45"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
       "label": "stageTrackedGraphifyArtifacts()",
@@ -45901,7 +46081,7 @@
       "source_location": "L20"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -45910,7 +46090,25 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
+      "label": "paymentAllocationAttribution.test.ts",
+      "norm_label": "paymentallocationattribution.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "paymentallocationattribution_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -45919,7 +46117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -45928,7 +46126,7 @@
       "source_location": "L8"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -45937,7 +46135,7 @@
       "source_location": "L10"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -45946,7 +46144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -45955,7 +46153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -45964,7 +46162,7 @@
       "source_location": "L18"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -45973,7 +46171,7 @@
       "source_location": "L10"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -45982,7 +46180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -45991,7 +46189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -46000,7 +46198,7 @@
       "source_location": "L6"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "cashier_authenticatehandler",
       "label": "authenticateHandler()",
@@ -46009,7 +46207,7 @@
       "source_location": "L239"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -46018,7 +46216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -46027,49 +46225,13 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
       "norm_label": "readprojectfile()",
       "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
       "source_location": "L8"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
-      "label": "sessionQueryIndexes.test.ts",
-      "norm_label": "sessionqueryindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "sessionqueryindexes_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "stores_tov2onlyconfig",
-      "label": "toV2OnlyConfig()",
-      "norm_label": "tov2onlyconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L27"
     },
     {
       "community": 32,
@@ -46173,6 +46335,42 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
+      "label": "sessionQueryIndexes.test.ts",
+      "norm_label": "sessionqueryindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "sessionqueryindexes_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "stores_tov2onlyconfig",
+      "label": "toV2OnlyConfig()",
+      "norm_label": "tov2onlyconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
       "norm_label": "callllmprovider()",
@@ -46180,7 +46378,7 @@
       "source_location": "L4"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -46189,7 +46387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -46198,7 +46396,7 @@
       "source_location": "L3"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -46207,7 +46405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -46216,7 +46414,7 @@
       "source_location": "L3"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -46225,7 +46423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -46234,7 +46432,7 @@
       "source_location": "L6"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -46243,7 +46441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -46252,7 +46450,7 @@
       "source_location": "L3"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -46261,7 +46459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -46270,7 +46468,7 @@
       "source_location": "L7"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -46279,7 +46477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestwithctx",
       "label": "decideApprovalRequestWithCtx()",
@@ -46288,7 +46486,7 @@
       "source_location": "L15"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "label": "approvalRequests.ts",
@@ -46297,7 +46495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -46306,49 +46504,13 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
       "norm_label": "eventbuilders.ts",
       "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
-      "label": "serviceIntake.test.ts",
-      "norm_label": "serviceintake.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "serviceintake_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_otp_verificationcodeemail_tsx",
-      "label": "VerificationCodeEmail.tsx",
-      "norm_label": "verificationcodeemail.tsx",
-      "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "verificationcodeemail_verificationcodeemail",
-      "label": "VerificationCodeEmail()",
-      "norm_label": "verificationcodeemail()",
-      "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
-      "source_location": "L11"
     },
     {
       "community": 33,
@@ -46443,6 +46605,42 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
+      "label": "serviceIntake.test.ts",
+      "norm_label": "serviceintake.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "serviceintake_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_otp_verificationcodeemail_tsx",
+      "label": "VerificationCodeEmail.tsx",
+      "norm_label": "verificationcodeemail.tsx",
+      "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "verificationcodeemail_verificationcodeemail",
+      "label": "VerificationCodeEmail()",
+      "norm_label": "verificationcodeemail()",
+      "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
       "norm_label": "buildservicecatalogitem()",
@@ -46450,7 +46648,7 @@
       "source_location": "L8"
     },
     {
-      "community": 330,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -46459,7 +46657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -46468,7 +46666,7 @@
       "source_location": "L4"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -46477,7 +46675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -46486,7 +46684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -46495,7 +46693,7 @@
       "source_location": "L8"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -46504,7 +46702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -46513,7 +46711,7 @@
       "source_location": "L13"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -46522,7 +46720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -46531,7 +46729,7 @@
       "source_location": "L5"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -46540,7 +46738,7 @@
       "source_location": "L15"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -46549,7 +46747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -46558,7 +46756,7 @@
       "source_location": "L8"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -46567,7 +46765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -46576,48 +46774,12 @@
       "source_location": "L17"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
       "norm_label": "customerobservabilitytimeline.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "helperorchestration_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
-      "label": "helperOrchestration.test.ts",
-      "norm_label": "helperorchestration.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "customerengagementevents_test_createmutationctx",
-      "label": "createMutationCtx()",
-      "norm_label": "createmutationctx()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
-      "label": "customerEngagementEvents.test.ts",
-      "norm_label": "customerengagementevents.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
       "source_location": "L1"
     },
     {
@@ -46713,6 +46875,42 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "helperorchestration_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
+      "label": "helperOrchestration.test.ts",
+      "norm_label": "helperorchestration.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "customerengagementevents_test_createmutationctx",
+      "label": "createMutationCtx()",
+      "norm_label": "createmutationctx()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
+      "label": "customerEngagementEvents.test.ts",
+      "norm_label": "customerengagementevents.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
       "norm_label": "updateonlineorderitem()",
@@ -46720,7 +46918,7 @@
       "source_location": "L25"
     },
     {
-      "community": 340,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -46729,7 +46927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -46738,7 +46936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -46747,7 +46945,7 @@
       "source_location": "L17"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -46756,7 +46954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -46765,7 +46963,7 @@
       "source_location": "L7"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -46774,7 +46972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -46783,7 +46981,7 @@
       "source_location": "L14"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -46792,7 +46990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -46801,7 +46999,7 @@
       "source_location": "L8"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -46810,7 +47008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -46819,7 +47017,7 @@
       "source_location": "L3"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -46828,7 +47026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -46837,7 +47035,7 @@
       "source_location": "L5"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -46846,49 +47044,13 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
       "norm_label": "getstorefrontactorbyid()",
       "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
       "source_location": "L16"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "useroffers_determineoffereligibility",
-      "label": "determineOfferEligibility()",
-      "norm_label": "determineoffereligibility()",
-      "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "organizationview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organizationview_tsx",
-      "label": "OrganizationView.tsx",
-      "norm_label": "organizationview.tsx",
-      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 35,
@@ -46983,6 +47145,42 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "useroffers_determineoffereligibility",
+      "label": "determineOfferEligibility()",
+      "norm_label": "determineoffereligibility()",
+      "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "organizationview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organizationview_tsx",
+      "label": "OrganizationView.tsx",
+      "norm_label": "organizationview.tsx",
+      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
@@ -46990,7 +47188,7 @@
       "source_location": "L12"
     },
     {
-      "community": 350,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -46999,7 +47197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -47008,7 +47206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -47017,7 +47215,7 @@
       "source_location": "L11"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -47026,7 +47224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -47035,7 +47233,7 @@
       "source_location": "L11"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -47044,7 +47242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -47053,7 +47251,7 @@
       "source_location": "L3"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -47062,7 +47260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -47071,7 +47269,7 @@
       "source_location": "L12"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -47080,7 +47278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -47089,7 +47287,7 @@
       "source_location": "L42"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -47098,7 +47296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -47107,7 +47305,7 @@
       "source_location": "L13"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -47116,49 +47314,13 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
       "norm_label": "storesdropdown()",
       "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
       "source_location": "L42"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "barcodeqrviewer_handleprint",
-      "label": "handlePrint()",
-      "norm_label": "handleprint()",
-      "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
-      "label": "BarcodeQRViewer.tsx",
-      "norm_label": "barcodeqrviewer.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
-      "label": "ProcessingFees.tsx",
-      "norm_label": "processingfees.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "processingfees_processingfeesview",
-      "label": "ProcessingFeesView()",
-      "norm_label": "processingfeesview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
-      "source_location": "L10"
     },
     {
       "community": 36,
@@ -47253,6 +47415,42 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "barcodeqrviewer_handleprint",
+      "label": "handlePrint()",
+      "norm_label": "handleprint()",
+      "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
+      "label": "BarcodeQRViewer.tsx",
+      "norm_label": "barcodeqrviewer.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
+      "label": "ProcessingFees.tsx",
+      "norm_label": "processingfees.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "processingfees_processingfeesview",
+      "label": "ProcessingFeesView()",
+      "norm_label": "processingfeesview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
       "norm_label": "productattributes.tsx",
@@ -47260,7 +47458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 362,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -47269,7 +47467,7 @@
       "source_location": "L14"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -47278,7 +47476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -47287,7 +47485,7 @@
       "source_location": "L5"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -47296,7 +47494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -47305,7 +47503,7 @@
       "source_location": "L10"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -47314,7 +47512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -47323,7 +47521,7 @@
       "source_location": "L15"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -47332,7 +47530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -47341,7 +47539,7 @@
       "source_location": "L13"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -47350,7 +47548,7 @@
       "source_location": "L116"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -47359,7 +47557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -47368,7 +47566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 368,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -47377,7 +47575,7 @@
       "source_location": "L47"
     },
     {
-      "community": 367,
+      "community": 369,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -47386,48 +47584,12 @@
       "source_location": "L151"
     },
     {
-      "community": 367,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
       "norm_label": "activitytimeline.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "analyticsitems_analyticsitems",
-      "label": "AnalyticsItems()",
-      "norm_label": "analyticsitems()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
-      "label": "AnalyticsItems.tsx",
-      "norm_label": "analyticsitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "analyticsproducts_analyticsproducts",
-      "label": "AnalyticsProducts()",
-      "norm_label": "analyticsproducts()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
-      "label": "AnalyticsProducts.tsx",
-      "norm_label": "analyticsproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
       "source_location": "L1"
     },
     {
@@ -47523,6 +47685,42 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "analyticsitems_analyticsitems",
+      "label": "AnalyticsItems()",
+      "norm_label": "analyticsitems()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
+      "label": "AnalyticsItems.tsx",
+      "norm_label": "analyticsitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "analyticsproducts_analyticsproducts",
+      "label": "AnalyticsProducts()",
+      "norm_label": "analyticsproducts()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
+      "label": "AnalyticsProducts.tsx",
+      "norm_label": "analyticsproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
       "norm_label": "analyticsusers()",
@@ -47530,7 +47728,7 @@
       "source_location": "L7"
     },
     {
-      "community": 370,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -47539,7 +47737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 373,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -47548,7 +47746,7 @@
       "source_location": "L42"
     },
     {
-      "community": 371,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -47557,7 +47755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -47566,7 +47764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 374,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -47575,7 +47773,7 @@
       "source_location": "L66"
     },
     {
-      "community": 373,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -47584,7 +47782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 375,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -47593,7 +47791,7 @@
       "source_location": "L18"
     },
     {
-      "community": 374,
+      "community": 376,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -47602,7 +47800,7 @@
       "source_location": "L6"
     },
     {
-      "community": 374,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -47611,7 +47809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 377,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -47620,7 +47818,7 @@
       "source_location": "L10"
     },
     {
-      "community": 375,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -47629,7 +47827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 378,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -47638,7 +47836,7 @@
       "source_location": "L27"
     },
     {
-      "community": 376,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -47647,7 +47845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -47656,49 +47854,13 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 379,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
       "norm_label": "useloadlogitems()",
       "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "auth_auth",
-      "label": "Auth()",
-      "norm_label": "auth()",
-      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_auth_tsx",
-      "label": "Auth.tsx",
-      "norm_label": "auth.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "index_login",
-      "label": "Login()",
-      "norm_label": "login()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 38,
@@ -47793,6 +47955,42 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "auth_auth",
+      "label": "Auth()",
+      "norm_label": "auth()",
+      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_auth_tsx",
+      "label": "Auth.tsx",
+      "norm_label": "auth.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "index_login",
+      "label": "Login()",
+      "norm_label": "login()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
       "norm_label": "handleloadproducts()",
@@ -47800,7 +47998,7 @@
       "source_location": "L49"
     },
     {
-      "community": 380,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -47809,7 +48007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 383,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -47818,7 +48016,7 @@
       "source_location": "L23"
     },
     {
-      "community": 381,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -47827,7 +48025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 384,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -47836,7 +48034,7 @@
       "source_location": "L50"
     },
     {
-      "community": 382,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -47845,7 +48043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 385,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -47854,7 +48052,7 @@
       "source_location": "L13"
     },
     {
-      "community": 383,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -47863,7 +48061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 386,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -47872,7 +48070,7 @@
       "source_location": "L11"
     },
     {
-      "community": 384,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -47881,7 +48079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -47890,7 +48088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 387,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -47899,7 +48097,7 @@
       "source_location": "L7"
     },
     {
-      "community": 386,
+      "community": 388,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -47908,7 +48106,7 @@
       "source_location": "L29"
     },
     {
-      "community": 386,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -47917,7 +48115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 389,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -47926,48 +48124,12 @@
       "source_location": "L37"
     },
     {
-      "community": 387,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
       "norm_label": "featuredsectiondialog.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "home_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_home_tsx",
-      "label": "Home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "landingpagereelversion_handleupdateconfig",
-      "label": "handleUpdateConfig()",
-      "norm_label": "handleupdateconfig()",
-      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
-      "label": "LandingPageReelVersion.tsx",
-      "norm_label": "landingpagereelversion.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
       "source_location": "L1"
     },
     {
@@ -48063,6 +48225,42 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "home_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_home_tsx",
+      "label": "Home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "landingpagereelversion_handleupdateconfig",
+      "label": "handleUpdateConfig()",
+      "norm_label": "handleupdateconfig()",
+      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
+      "label": "LandingPageReelVersion.tsx",
+      "norm_label": "landingpagereelversion.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 392,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
       "norm_label": "shoplookdialog.tsx",
@@ -48070,7 +48268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 392,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -48079,7 +48277,7 @@
       "source_location": "L35"
     },
     {
-      "community": 391,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -48088,7 +48286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 393,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -48097,7 +48295,7 @@
       "source_location": "L28"
     },
     {
-      "community": 392,
+      "community": 394,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -48106,7 +48304,7 @@
       "source_location": "L11"
     },
     {
-      "community": 392,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -48115,7 +48313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 395,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -48124,7 +48322,7 @@
       "source_location": "L13"
     },
     {
-      "community": 393,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -48133,7 +48331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 396,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -48142,7 +48340,7 @@
       "source_location": "L41"
     },
     {
-      "community": 394,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -48151,7 +48349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 397,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -48160,7 +48358,7 @@
       "source_location": "L33"
     },
     {
-      "community": 395,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -48169,7 +48367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 398,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -48178,7 +48376,7 @@
       "source_location": "L68"
     },
     {
-      "community": 396,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -48187,7 +48385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 399,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -48196,49 +48394,13 @@
       "source_location": "L35"
     },
     {
-      "community": 397,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
       "norm_label": "ordersview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
-      "label": "RefundsView.tsx",
-      "norm_label": "refundsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "refundsview_handlerefundorder",
-      "label": "handleRefundOrder()",
-      "norm_label": "handlerefundorder()",
-      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
-      "source_location": "L79"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
-      "label": "useGetActiveOnlineOrder.ts",
-      "norm_label": "usegetactiveonlineorder.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "usegetactiveonlineorder_usegetactiveonlineorder",
-      "label": "useGetActiveOnlineOrder()",
-      "norm_label": "usegetactiveonlineorder()",
-      "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
-      "source_location": "L6"
     },
     {
       "community": 4,
@@ -48585,6 +48747,42 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
+      "label": "RefundsView.tsx",
+      "norm_label": "refundsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "refundsview_handlerefundorder",
+      "label": "handleRefundOrder()",
+      "norm_label": "handlerefundorder()",
+      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
+      "source_location": "L79"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
+      "label": "useGetActiveOnlineOrder.ts",
+      "norm_label": "usegetactiveonlineorder.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "usegetactiveonlineorder_usegetactiveonlineorder",
+      "label": "useGetActiveOnlineOrder()",
+      "norm_label": "usegetactiveonlineorder()",
+      "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
       "norm_label": "handleclearfilters()",
@@ -48592,7 +48790,7 @@
       "source_location": "L34"
     },
     {
-      "community": 400,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -48601,7 +48799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 403,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -48610,7 +48808,7 @@
       "source_location": "L89"
     },
     {
-      "community": 401,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -48619,7 +48817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 404,
       "file_type": "code",
       "id": "cashierview_handlesignout",
       "label": "handleSignOut()",
@@ -48628,7 +48826,7 @@
       "source_location": "L63"
     },
     {
-      "community": 402,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -48637,7 +48835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 405,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -48646,7 +48844,7 @@
       "source_location": "L5"
     },
     {
-      "community": 403,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -48655,7 +48853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 406,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -48664,7 +48862,7 @@
       "source_location": "L7"
     },
     {
-      "community": 404,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -48673,7 +48871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -48682,7 +48880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 407,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -48691,7 +48889,7 @@
       "source_location": "L13"
     },
     {
-      "community": 406,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -48700,7 +48898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 408,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
@@ -48709,7 +48907,7 @@
       "source_location": "L35"
     },
     {
-      "community": 407,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -48718,49 +48916,13 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 409,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
       "norm_label": "printinstructions()",
       "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
-      "label": "ProductCard.tsx",
-      "norm_label": "productcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "productcard_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
-      "label": "ProductEntry.tsx",
-      "norm_label": "productentry.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "productentry_handleclearsearch",
-      "label": "handleClearSearch()",
-      "norm_label": "handleclearsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L86"
     },
     {
       "community": 41,
@@ -48778,7 +48940,7 @@
       "label": "createTransactionFromSessionHandler()",
       "norm_label": "createtransactionfromsessionhandler()",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L943"
+      "source_location": "L978"
     },
     {
       "community": 41,
@@ -48787,7 +48949,7 @@
       "label": "isConvexProductId()",
       "norm_label": "isconvexproductid()",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L11"
+      "source_location": "L13"
     },
     {
       "community": 41,
@@ -48796,7 +48958,7 @@
       "label": "listCompletedTransactionsForDay()",
       "norm_label": "listcompletedtransactionsforday()",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L102"
+      "source_location": "L104"
     },
     {
       "community": 41,
@@ -48805,7 +48967,7 @@
       "label": "listMatchingStoreSkus()",
       "norm_label": "listmatchingstoreskus()",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L36"
+      "source_location": "L38"
     },
     {
       "community": 41,
@@ -48814,7 +48976,7 @@
       "label": "listProductSkusByProductId()",
       "norm_label": "listproductskusbyproductid()",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L25"
+      "source_location": "L27"
     },
     {
       "community": 41,
@@ -48823,7 +48985,7 @@
       "label": "listSessionItems()",
       "norm_label": "listsessionitems()",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L94"
+      "source_location": "L96"
     },
     {
       "community": 41,
@@ -48832,7 +48994,7 @@
       "label": "listTransactionItems()",
       "norm_label": "listtransactionitems()",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L83"
+      "source_location": "L85"
     },
     {
       "community": 41,
@@ -48841,10 +49003,46 @@
       "label": "readAllQueryResults()",
       "norm_label": "readallqueryresults()",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L15"
+      "source_location": "L17"
     },
     {
       "community": 410,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
+      "label": "ProductCard.tsx",
+      "norm_label": "productcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "productcard_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
+      "label": "ProductEntry.tsx",
+      "norm_label": "productentry.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "productentry_handleclearsearch",
+      "label": "handleClearSearch()",
+      "norm_label": "handleclearsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L86"
+    },
+    {
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_quickactionsbar_tsx",
       "label": "QuickActionsBar.tsx",
@@ -48853,7 +49051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 412,
       "file_type": "code",
       "id": "quickactionsbar_quickactionsbar",
       "label": "QuickActionsBar()",
@@ -48862,7 +49060,7 @@
       "source_location": "L11"
     },
     {
-      "community": 411,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -48871,7 +49069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 413,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -48880,7 +49078,7 @@
       "source_location": "L15"
     },
     {
-      "community": 412,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -48889,7 +49087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 414,
       "file_type": "code",
       "id": "totalsdisplay_totalsdisplay",
       "label": "TotalsDisplay()",
@@ -48898,7 +49096,7 @@
       "source_location": "L14"
     },
     {
-      "community": 413,
+      "community": 415,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -48907,7 +49105,7 @@
       "source_location": "L18"
     },
     {
-      "community": 413,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -48916,7 +49114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 416,
       "file_type": "code",
       "id": "hooks_useposcashier",
       "label": "usePOSCashier()",
@@ -48925,7 +49123,7 @@
       "source_location": "L5"
     },
     {
-      "community": 414,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_hooks_ts",
       "label": "hooks.ts",
@@ -48934,7 +49132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 417,
       "file_type": "code",
       "id": "holdsessiondialog_holdsessiondialog",
       "label": "HoldSessionDialog()",
@@ -48943,7 +49141,7 @@
       "source_location": "L19"
     },
     {
-      "community": 415,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_holdsessiondialog_tsx",
       "label": "HoldSessionDialog.tsx",
@@ -48952,7 +49150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_voidsessiondialog_tsx",
       "label": "VoidSessionDialog.tsx",
@@ -48961,7 +49159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 418,
       "file_type": "code",
       "id": "voidsessiondialog_voidsessiondialog",
       "label": "VoidSessionDialog()",
@@ -48970,7 +49168,7 @@
       "source_location": "L19"
     },
     {
-      "community": 417,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -48979,49 +49177,13 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 419,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
       "norm_label": "getpaymentmethodicon()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L22"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "barcodeview_barcodeview",
-      "label": "BarcodeView()",
-      "norm_label": "barcodeview()",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
-      "label": "BarcodeView.tsx",
-      "norm_label": "barcodeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "categorizationview_categorizationview",
-      "label": "CategorizationView()",
-      "norm_label": "categorizationview()",
-      "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
-      "label": "CategorizationView.tsx",
-      "norm_label": "categorizationview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 42,
@@ -49107,6 +49269,42 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "barcodeview_barcodeview",
+      "label": "BarcodeView()",
+      "norm_label": "barcodeview()",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
+      "label": "BarcodeView.tsx",
+      "norm_label": "barcodeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "categorizationview_categorizationview",
+      "label": "CategorizationView()",
+      "norm_label": "categorizationview()",
+      "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
+      "label": "CategorizationView.tsx",
+      "norm_label": "categorizationview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
       "norm_label": "handlekeydown()",
@@ -49114,7 +49312,7 @@
       "source_location": "L38"
     },
     {
-      "community": 420,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -49123,7 +49321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -49132,7 +49330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 423,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -49141,7 +49339,7 @@
       "source_location": "L10"
     },
     {
-      "community": 422,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -49150,7 +49348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 424,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -49159,7 +49357,7 @@
       "source_location": "L6"
     },
     {
-      "community": 423,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -49168,7 +49366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 425,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -49177,7 +49375,7 @@
       "source_location": "L5"
     },
     {
-      "community": 424,
+      "community": 426,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -49186,7 +49384,7 @@
       "source_location": "L17"
     },
     {
-      "community": 424,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -49195,7 +49393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -49204,7 +49402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 427,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -49213,7 +49411,7 @@
       "source_location": "L4"
     },
     {
-      "community": 426,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -49222,7 +49420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 428,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -49231,7 +49429,7 @@
       "source_location": "L84"
     },
     {
-      "community": 427,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -49240,49 +49438,13 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 429,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
       "norm_label": "handledeletepromocode()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
       "source_location": "L22"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
-      "label": "PromoCodesView.tsx",
-      "norm_label": "promocodesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "promocodesview_promocodesview",
-      "label": "PromoCodesView()",
-      "norm_label": "promocodesview()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
-      "label": "SelectableCategories.tsx",
-      "norm_label": "selectablecategories.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "selectablecategories_toggle",
-      "label": "toggle()",
-      "norm_label": "toggle()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
-      "source_location": "L23"
     },
     {
       "community": 43,
@@ -49368,6 +49530,42 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
+      "label": "PromoCodesView.tsx",
+      "norm_label": "promocodesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "promocodesview_promocodesview",
+      "label": "PromoCodesView()",
+      "norm_label": "promocodesview()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
+      "label": "SelectableCategories.tsx",
+      "norm_label": "selectablecategories.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "selectablecategories_toggle",
+      "label": "toggle()",
+      "norm_label": "toggle()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
       "norm_label": "discounttypetogglegroup()",
@@ -49375,7 +49573,7 @@
       "source_location": "L5"
     },
     {
-      "community": 430,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -49384,7 +49582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -49393,7 +49591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 433,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -49402,7 +49600,7 @@
       "source_location": "L4"
     },
     {
-      "community": 432,
+      "community": 434,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -49411,7 +49609,7 @@
       "source_location": "L13"
     },
     {
-      "community": 432,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -49420,7 +49618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -49429,7 +49627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 435,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -49438,7 +49636,7 @@
       "source_location": "L29"
     },
     {
-      "community": 434,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -49447,7 +49645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 436,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -49456,7 +49654,7 @@
       "source_location": "L20"
     },
     {
-      "community": 435,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -49465,7 +49663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 437,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -49474,7 +49672,7 @@
       "source_location": "L171"
     },
     {
-      "community": 436,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -49483,7 +49681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 438,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -49492,7 +49690,7 @@
       "source_location": "L52"
     },
     {
-      "community": 437,
+      "community": 439,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -49501,48 +49699,12 @@
       "source_location": "L29"
     },
     {
-      "community": 437,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
       "norm_label": "empty-state.tsx",
       "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "nopermission_nopermission",
-      "label": "NoPermission()",
-      "norm_label": "nopermission()",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
-      "label": "NoPermission.tsx",
-      "norm_label": "nopermission.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "nopermissionview_nopermissionview",
-      "label": "NoPermissionView()",
-      "norm_label": "nopermissionview()",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
-      "label": "NoPermissionView.tsx",
-      "norm_label": "nopermissionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L1"
     },
     {
@@ -49629,6 +49791,42 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "nopermission_nopermission",
+      "label": "NoPermission()",
+      "norm_label": "nopermission()",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
+      "label": "NoPermission.tsx",
+      "norm_label": "nopermission.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "nopermissionview_nopermissionview",
+      "label": "NoPermissionView()",
+      "norm_label": "nopermissionview()",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
+      "label": "NoPermissionView.tsx",
+      "norm_label": "nopermissionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
       "norm_label": "notfoundview()",
@@ -49636,7 +49834,7 @@
       "source_location": "L4"
     },
     {
-      "community": 440,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -49645,7 +49843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 443,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -49654,7 +49852,7 @@
       "source_location": "L9"
     },
     {
-      "community": 441,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -49663,7 +49861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 444,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -49672,7 +49870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -49681,7 +49879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 445,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -49690,7 +49888,7 @@
       "source_location": "L13"
     },
     {
-      "community": 443,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -49699,7 +49897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -49708,7 +49906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 446,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -49717,7 +49915,7 @@
       "source_location": "L25"
     },
     {
-      "community": 445,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -49726,7 +49924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 447,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -49735,7 +49933,7 @@
       "source_location": "L19"
     },
     {
-      "community": 446,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -49744,7 +49942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 448,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -49753,7 +49951,7 @@
       "source_location": "L63"
     },
     {
-      "community": 447,
+      "community": 449,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -49762,48 +49960,12 @@
       "source_location": "L7"
     },
     {
-      "community": 447,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
       "norm_label": "calendar.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "chart_usechart",
-      "label": "useChart()",
-      "norm_label": "usechart()",
-      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_chart_tsx",
-      "label": "chart.tsx",
-      "norm_label": "chart.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "copy_button_handlecopy",
-      "label": "handleCopy()",
-      "norm_label": "handlecopy()",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
-      "label": "copy-button.tsx",
-      "norm_label": "copy-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
       "source_location": "L1"
     },
     {
@@ -49890,6 +50052,42 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "chart_usechart",
+      "label": "useChart()",
+      "norm_label": "usechart()",
+      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_chart_tsx",
+      "label": "chart.tsx",
+      "norm_label": "chart.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "copy_button_handlecopy",
+      "label": "handleCopy()",
+      "norm_label": "handlecopy()",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
+      "label": "copy-button.tsx",
+      "norm_label": "copy-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
       "norm_label": "handlecopy()",
@@ -49897,7 +50095,7 @@
       "source_location": "L21"
     },
     {
-      "community": 450,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -49906,7 +50104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 453,
       "file_type": "code",
       "id": "date_time_picker_datetimepicker",
       "label": "DateTimePicker()",
@@ -49915,7 +50113,7 @@
       "source_location": "L21"
     },
     {
-      "community": 451,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -49924,7 +50122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 454,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -49933,7 +50131,7 @@
       "source_location": "L6"
     },
     {
-      "community": 452,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -49942,7 +50140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 455,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -49951,7 +50149,7 @@
       "source_location": "L25"
     },
     {
-      "community": 453,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -49960,7 +50158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -49969,7 +50167,7 @@
       "source_location": "L49"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -49978,7 +50176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -49987,7 +50185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -49996,7 +50194,7 @@
       "source_location": "L63"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -50005,7 +50203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -50014,7 +50212,7 @@
       "source_location": "L5"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -50023,49 +50221,13 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
       "norm_label": "welcomebackmodal()",
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L12"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
-      "label": "select-native.tsx",
-      "norm_label": "select-native.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "select_native_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
-      "label": "timeline-item.tsx",
-      "norm_label": "timeline-item.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "timeline_item_timelineitem",
-      "label": "TimelineItem()",
-      "norm_label": "timelineitem()",
-      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
-      "source_location": "L3"
     },
     {
       "community": 46,
@@ -50151,6 +50313,42 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
+      "label": "select-native.tsx",
+      "norm_label": "select-native.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "select_native_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
+      "label": "timeline-item.tsx",
+      "norm_label": "timeline-item.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "timeline_item_timelineitem",
+      "label": "TimelineItem()",
+      "norm_label": "timelineitem()",
+      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
       "norm_label": "webp-image.tsx",
@@ -50158,7 +50356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 462,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -50167,7 +50365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -50176,7 +50374,7 @@
       "source_location": "L5"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -50185,7 +50383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -50194,7 +50392,7 @@
       "source_location": "L11"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -50203,7 +50401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -50212,7 +50410,7 @@
       "source_location": "L4"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -50221,7 +50419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -50230,7 +50428,7 @@
       "source_location": "L110"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -50239,7 +50437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -50248,7 +50446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -50257,7 +50455,7 @@
       "source_location": "L13"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -50266,7 +50464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -50275,7 +50473,7 @@
       "source_location": "L7"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -50284,49 +50482,13 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
       "norm_label": "useronlineorders()",
       "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
-      "label": "UserStatus.tsx",
-      "norm_label": "userstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "userstatus_userstatus",
-      "label": "UserStatus()",
-      "norm_label": "userstatus()",
-      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userview_tsx",
-      "label": "UserView.tsx",
-      "norm_label": "userview.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "userview_useractions",
-      "label": "UserActions()",
-      "norm_label": "useractions()",
-      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
-      "source_location": "L45"
     },
     {
       "community": 47,
@@ -50412,6 +50574,42 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
+      "label": "UserStatus.tsx",
+      "norm_label": "userstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "userstatus_userstatus",
+      "label": "UserStatus()",
+      "norm_label": "userstatus()",
+      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userview_tsx",
+      "label": "UserView.tsx",
+      "norm_label": "userview.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "userview_useractions",
+      "label": "UserActions()",
+      "norm_label": "useractions()",
+      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
       "norm_label": "customerjourneystagecard()",
@@ -50419,7 +50617,7 @@
       "source_location": "L13"
     },
     {
-      "community": 470,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -50428,7 +50626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -50437,7 +50635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -50446,7 +50644,7 @@
       "source_location": "L7"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -50455,7 +50653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -50464,7 +50662,7 @@
       "source_location": "L5"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -50473,7 +50671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -50482,7 +50680,7 @@
       "source_location": "L5"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -50491,7 +50689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -50500,7 +50698,7 @@
       "source_location": "L7"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -50509,7 +50707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -50518,7 +50716,7 @@
       "source_location": "L9"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -50527,7 +50725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -50536,7 +50734,7 @@
       "source_location": "L6"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -50545,49 +50743,13 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
       "norm_label": "makesku()",
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L168"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usecartoperations_ts",
-      "label": "useCartOperations.ts",
-      "norm_label": "usecartoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "usecartoperations_usecartoperations",
-      "label": "useCartOperations()",
-      "norm_label": "usecartoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
-      "label": "useCopyText.ts",
-      "norm_label": "usecopytext.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "usecopytext_usecopytext",
-      "label": "useCopyText()",
-      "norm_label": "usecopytext()",
-      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
-      "source_location": "L1"
     },
     {
       "community": 48,
@@ -50673,6 +50835,42 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usecartoperations_ts",
+      "label": "useCartOperations.ts",
+      "norm_label": "usecartoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "usecartoperations_usecartoperations",
+      "label": "useCartOperations()",
+      "norm_label": "usecartoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
+      "label": "useCopyText.ts",
+      "norm_label": "usecopytext.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "usecopytext_usecopytext",
+      "label": "useCopyText()",
+      "norm_label": "usecopytext()",
+      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
       "norm_label": "usecreatecomplimentaryproduct.ts",
@@ -50680,7 +50878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 482,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -50689,7 +50887,7 @@
       "source_location": "L6"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecustomeroperations_ts",
       "label": "useCustomerOperations.ts",
@@ -50698,7 +50896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "usecustomeroperations_usecustomeroperations",
       "label": "useCustomerOperations()",
@@ -50707,7 +50905,7 @@
       "source_location": "L21"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -50716,7 +50914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -50725,7 +50923,7 @@
       "source_location": "L12"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -50734,7 +50932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
@@ -50743,7 +50941,7 @@
       "source_location": "L23"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -50752,7 +50950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -50761,7 +50959,7 @@
       "source_location": "L6"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -50770,7 +50968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -50779,7 +50977,7 @@
       "source_location": "L4"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -50788,7 +50986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -50797,7 +50995,7 @@
       "source_location": "L5"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -50806,48 +51004,12 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
       "norm_label": "usegetcomplimentaryproducts()",
       "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
-      "label": "useGetCurrencyFormatter.ts",
-      "norm_label": "usegetcurrencyformatter.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "usegetcurrencyformatter_usegetcurrencyformatter",
-      "label": "useGetCurrencyFormatter()",
-      "norm_label": "usegetcurrencyformatter()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
-      "label": "useGetSubcategories.ts",
-      "norm_label": "usegetsubcategories.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "usegetsubcategories_usegetsubcategories",
-      "label": "useGetSubcategories()",
-      "norm_label": "usegetsubcategories()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
       "source_location": "L5"
     },
     {
@@ -50934,6 +51096,42 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
+      "label": "useGetCurrencyFormatter.ts",
+      "norm_label": "usegetcurrencyformatter.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "usegetcurrencyformatter_usegetcurrencyformatter",
+      "label": "useGetCurrencyFormatter()",
+      "norm_label": "usegetcurrencyformatter()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
+      "label": "useGetSubcategories.ts",
+      "norm_label": "usegetsubcategories.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "usegetsubcategories_usegetsubcategories",
+      "label": "useGetSubcategories()",
+      "norm_label": "usegetsubcategories()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
       "norm_label": "usegetterminal.ts",
@@ -50941,7 +51139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -50950,7 +51148,7 @@
       "source_location": "L6"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -50959,7 +51157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -50968,7 +51166,7 @@
       "source_location": "L8"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -50977,7 +51175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -50986,7 +51184,7 @@
       "source_location": "L13"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -50995,7 +51193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -51004,7 +51202,7 @@
       "source_location": "L3"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -51013,7 +51211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -51022,7 +51220,7 @@
       "source_location": "L26"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -51031,7 +51229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -51040,7 +51238,7 @@
       "source_location": "L7"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagement_ts",
       "label": "useSessionManagement.ts",
@@ -51049,7 +51247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "usesessionmanagement_usesessionmanagement",
       "label": "useSessionManagement()",
@@ -51058,7 +51256,7 @@
       "source_location": "L17"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -51067,49 +51265,13 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
       "norm_label": "usesessionmanagementexpense()",
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L17"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usesessionmanageroperations_ts",
-      "label": "useSessionManagerOperations.ts",
-      "norm_label": "usesessionmanageroperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "usesessionmanageroperations_usesessionmanageroperations",
-      "label": "useSessionManagerOperations()",
-      "norm_label": "usesessionmanageroperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
-      "label": "useSkusReservedInCheckout.ts",
-      "norm_label": "useskusreservedincheckout.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInCheckout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "useskusreservedincheckout_useskusreservedincheckout",
-      "label": "useSkusReservedInCheckout()",
-      "norm_label": "useskusreservedincheckout()",
-      "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInCheckout.ts",
-      "source_location": "L12"
     },
     {
       "community": 5,
@@ -51438,6 +51600,42 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usesessionmanageroperations_ts",
+      "label": "useSessionManagerOperations.ts",
+      "norm_label": "usesessionmanageroperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "usesessionmanageroperations_usesessionmanageroperations",
+      "label": "useSessionManagerOperations()",
+      "norm_label": "usesessionmanageroperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
+      "label": "useSkusReservedInCheckout.ts",
+      "norm_label": "useskusreservedincheckout.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInCheckout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "useskusreservedincheckout_useskusreservedincheckout",
+      "label": "useSkusReservedInCheckout()",
+      "norm_label": "useskusreservedincheckout()",
+      "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInCheckout.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
       "norm_label": "useskusreservedinpossession.ts",
@@ -51445,7 +51643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -51454,7 +51652,7 @@
       "source_location": "L12"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -51463,7 +51661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -51472,7 +51670,7 @@
       "source_location": "L5"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -51481,7 +51679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -51490,7 +51688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -51499,7 +51697,7 @@
       "source_location": "L10"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -51508,7 +51706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -51517,7 +51715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -51526,7 +51724,7 @@
       "source_location": "L12"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -51535,7 +51733,7 @@
       "source_location": "L13"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -51544,7 +51742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -51553,7 +51751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -51562,7 +51760,7 @@
       "source_location": "L9"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -51571,48 +51769,12 @@
       "source_location": "L13"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "layout_index_athenaloginreadyview",
-      "label": "AthenaLoginReadyView()",
-      "norm_label": "athenaloginreadyview()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
-      "label": "_layout.index.tsx",
-      "norm_label": "_layout.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "layout_loginlayout",
-      "label": "LoginLayout()",
-      "norm_label": "loginlayout()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L36"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_tsx",
-      "label": "_layout.tsx",
-      "norm_label": "_layout.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
       "source_location": "L1"
     },
     {
@@ -51690,6 +51852,42 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "layout_index_athenaloginreadyview",
+      "label": "AthenaLoginReadyView()",
+      "norm_label": "athenaloginreadyview()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
+      "label": "_layout.index.tsx",
+      "norm_label": "_layout.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "layout_loginlayout",
+      "label": "LoginLayout()",
+      "norm_label": "loginlayout()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_tsx",
+      "label": "_layout.tsx",
+      "norm_label": "_layout.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
       "norm_label": "organizationsettingsaccordion()",
@@ -51697,7 +51895,7 @@
       "source_location": "L13"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -51706,7 +51904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -51715,7 +51913,7 @@
       "source_location": "L5"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -51724,7 +51922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -51733,7 +51931,7 @@
       "source_location": "L17"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -51742,7 +51940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -51751,7 +51949,7 @@
       "source_location": "L15"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -51760,7 +51958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -51769,7 +51967,7 @@
       "source_location": "L12"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -51778,7 +51976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -51787,7 +51985,7 @@
       "source_location": "L5"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -51796,7 +51994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -51805,7 +52003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -51814,7 +52012,7 @@
       "source_location": "L13"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -51823,49 +52021,13 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
       "norm_label": "sheetshowcase()",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
-      "label": "Tooltip.stories.tsx",
-      "norm_label": "tooltip.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "tooltip_stories_tooltipshowcase",
-      "label": "TooltipShowcase()",
-      "norm_label": "tooltipshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "overview_stories_templatesoverview",
-      "label": "TemplatesOverview()",
-      "norm_label": "templatesoverview()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
-      "source_location": "L1"
     },
     {
       "community": 52,
@@ -51942,6 +52104,42 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
+      "label": "Tooltip.stories.tsx",
+      "norm_label": "tooltip.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "tooltip_stories_tooltipshowcase",
+      "label": "TooltipShowcase()",
+      "norm_label": "tooltipshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "overview_stories_templatesoverview",
+      "label": "TemplatesOverview()",
+      "norm_label": "templatesoverview()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
       "norm_label": "storybook-theme-decorator.tsx",
@@ -51949,7 +52147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 520,
+      "community": 522,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -51958,7 +52156,7 @@
       "source_location": "L17"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -51967,7 +52165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -51976,7 +52174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -51985,7 +52183,7 @@
       "source_location": "L4"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -51994,7 +52192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -52003,7 +52201,7 @@
       "source_location": "L27"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -52012,7 +52210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -52021,7 +52219,7 @@
       "source_location": "L4"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -52030,7 +52228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -52039,7 +52237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -52048,7 +52246,7 @@
       "source_location": "L5"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -52057,7 +52255,7 @@
       "source_location": "L10"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -52066,7 +52264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -52075,49 +52273,13 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
       "norm_label": "productcardloadingskeleton()",
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L10"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "auth_authcomponent",
-      "label": "AuthComponent()",
-      "norm_label": "authcomponent()",
-      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
-      "label": "Auth.tsx",
-      "norm_label": "auth.tsx",
-      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "bagsummary_tobagsummaryitems",
-      "label": "toBagSummaryItems()",
-      "norm_label": "tobagsummaryitems()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
-      "source_location": "L39"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
-      "label": "BagSummary.tsx",
-      "norm_label": "bagsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
-      "source_location": "L1"
     },
     {
       "community": 53,
@@ -52194,6 +52356,42 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "auth_authcomponent",
+      "label": "AuthComponent()",
+      "norm_label": "authcomponent()",
+      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
+      "label": "Auth.tsx",
+      "norm_label": "auth.tsx",
+      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "bagsummary_tobagsummaryitems",
+      "label": "toBagSummaryItems()",
+      "norm_label": "tobagsummaryitems()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
+      "label": "BagSummary.tsx",
+      "norm_label": "bagsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
       "norm_label": "checkoutform()",
@@ -52201,7 +52399,7 @@
       "source_location": "L18"
     },
     {
-      "community": 530,
+      "community": 532,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -52210,7 +52408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -52219,7 +52417,7 @@
       "source_location": "L71"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -52228,7 +52426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -52237,7 +52435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -52246,7 +52444,7 @@
       "source_location": "L12"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -52255,7 +52453,7 @@
       "source_location": "L6"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -52264,7 +52462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -52273,7 +52471,7 @@
       "source_location": "L18"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -52282,7 +52480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -52291,7 +52489,7 @@
       "source_location": "L10"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -52300,7 +52498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -52309,7 +52507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -52318,7 +52516,7 @@
       "source_location": "L8"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -52327,49 +52525,13 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
       "norm_label": "paymentsection()",
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
       "source_location": "L27"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "deliveryfees_calculatedeliveryfee",
-      "label": "calculateDeliveryFee()",
-      "norm_label": "calculatedeliveryfee()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
-      "label": "deliveryFees.ts",
-      "norm_label": "deliveryfees.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "derivecheckoutstate_derivecheckoutstate",
-      "label": "deriveCheckoutState()",
-      "norm_label": "derivecheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
-      "label": "deriveCheckoutState.ts",
-      "norm_label": "derivecheckoutstate.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L1"
     },
     {
       "community": 54,
@@ -52446,6 +52608,42 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "deliveryfees_calculatedeliveryfee",
+      "label": "calculateDeliveryFee()",
+      "norm_label": "calculatedeliveryfee()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
+      "label": "deliveryFees.ts",
+      "norm_label": "deliveryfees.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "derivecheckoutstate_derivecheckoutstate",
+      "label": "deriveCheckoutState()",
+      "norm_label": "derivecheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
+      "label": "deriveCheckoutState.ts",
+      "norm_label": "derivecheckoutstate.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
       "norm_label": "getissuemap()",
@@ -52453,7 +52651,7 @@
       "source_location": "L8"
     },
     {
-      "community": 540,
+      "community": 542,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -52462,7 +52660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -52471,7 +52669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -52480,7 +52678,7 @@
       "source_location": "L12"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -52489,7 +52687,7 @@
       "source_location": "L77"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -52498,7 +52696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -52507,7 +52705,7 @@
       "source_location": "L161"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -52516,7 +52714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -52525,7 +52723,7 @@
       "source_location": "L3"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -52534,7 +52732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -52543,7 +52741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -52552,7 +52750,7 @@
       "source_location": "L4"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -52561,7 +52759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -52570,7 +52768,7 @@
       "source_location": "L14"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -52579,48 +52777,12 @@
       "source_location": "L27"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
       "norm_label": "filter.tsx",
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "bestsellerssection_bestsellerssection",
-      "label": "BestSellersSection()",
-      "norm_label": "bestsellerssection()",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
-      "label": "BestSellersSection.tsx",
-      "norm_label": "bestsellerssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "homepagecontent_resolvehomepagecontent",
-      "label": "resolveHomepageContent()",
-      "norm_label": "resolvehomepagecontent()",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
-      "label": "homePageContent.ts",
-      "norm_label": "homepagecontent.ts",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
       "source_location": "L1"
     },
     {
@@ -52698,6 +52860,42 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "bestsellerssection_bestsellerssection",
+      "label": "BestSellersSection()",
+      "norm_label": "bestsellerssection()",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
+      "label": "BestSellersSection.tsx",
+      "norm_label": "bestsellerssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "homepagecontent_resolvehomepagecontent",
+      "label": "resolveHomepageContent()",
+      "norm_label": "resolvehomepagecontent()",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
+      "label": "homePageContent.ts",
+      "norm_label": "homepagecontent.ts",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
       "norm_label": "handleonlinkclick()",
@@ -52705,7 +52903,7 @@
       "source_location": "L47"
     },
     {
-      "community": 550,
+      "community": 552,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -52714,7 +52912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -52723,7 +52921,7 @@
       "source_location": "L7"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -52732,7 +52930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -52741,7 +52939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -52750,7 +52948,7 @@
       "source_location": "L17"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -52759,7 +52957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -52768,7 +52966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -52777,7 +52975,7 @@
       "source_location": "L12"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -52786,7 +52984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -52795,7 +52993,7 @@
       "source_location": "L7"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -52804,7 +53002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -52813,7 +53011,7 @@
       "source_location": "L45"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -52822,7 +53020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -52831,49 +53029,13 @@
       "source_location": "L5"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
       "norm_label": "onsaleproduct.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
-      "label": "ProductActions.tsx",
-      "norm_label": "productactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "productactions_productactions",
-      "label": "ProductActions()",
-      "norm_label": "productactions()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
-      "label": "ProductAttributes.tsx",
-      "norm_label": "productattributes.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "productattributes_productattributes",
-      "label": "ProductAttributes()",
-      "norm_label": "productattributes()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
-      "source_location": "L3"
     },
     {
       "community": 56,
@@ -52950,6 +53112,42 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
+      "label": "ProductActions.tsx",
+      "norm_label": "productactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "productactions_productactions",
+      "label": "ProductActions()",
+      "norm_label": "productactions()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
+      "label": "ProductAttributes.tsx",
+      "norm_label": "productattributes.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "productattributes_productattributes",
+      "label": "ProductAttributes()",
+      "norm_label": "productattributes()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
       "norm_label": "productpage.tsx",
@@ -52957,7 +53155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 560,
+      "community": 562,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -52966,7 +53164,7 @@
       "source_location": "L78"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -52975,7 +53173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -52984,7 +53182,7 @@
       "source_location": "L87"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -52993,7 +53191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -53002,7 +53200,7 @@
       "source_location": "L8"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -53011,7 +53209,7 @@
       "source_location": "L12"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -53020,7 +53218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -53029,7 +53227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -53038,7 +53236,7 @@
       "source_location": "L18"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -53047,7 +53245,7 @@
       "source_location": "L10"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -53056,7 +53254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -53065,7 +53263,7 @@
       "source_location": "L11"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -53074,7 +53272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -53083,49 +53281,13 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
       "norm_label": "handleclaimpoints()",
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L59"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
-      "label": "RewardsPanel.tsx",
-      "norm_label": "rewardspanel.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "rewardspanel_handleredeemreward",
-      "label": "handleRedeemReward()",
-      "norm_label": "handleredeemreward()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "bagitem_bagitem",
-      "label": "BagItem()",
-      "norm_label": "bagitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
-      "label": "BagItem.tsx",
-      "norm_label": "bagitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
-      "source_location": "L1"
     },
     {
       "community": 57,
@@ -53202,6 +53364,42 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
+      "label": "RewardsPanel.tsx",
+      "norm_label": "rewardspanel.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "rewardspanel_handleredeemreward",
+      "label": "handleRedeemReward()",
+      "norm_label": "handleredeemreward()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "bagitem_bagitem",
+      "label": "BagItem()",
+      "norm_label": "bagitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
+      "label": "BagItem.tsx",
+      "norm_label": "bagitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
       "norm_label": "checkoutunavailable()",
@@ -53209,7 +53407,7 @@
       "source_location": "L4"
     },
     {
-      "community": 570,
+      "community": 572,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -53218,7 +53416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -53227,7 +53425,7 @@
       "source_location": "L22"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -53236,7 +53434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -53245,7 +53443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -53254,7 +53452,7 @@
       "source_location": "L11"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -53263,7 +53461,7 @@
       "source_location": "L3"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -53272,7 +53470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -53281,7 +53479,7 @@
       "source_location": "L3"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -53290,7 +53488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -53299,7 +53497,7 @@
       "source_location": "L9"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -53308,7 +53506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -53317,7 +53515,7 @@
       "source_location": "L66"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -53326,7 +53524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -53335,49 +53533,13 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
       "norm_label": "upsellmodalsuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
       "source_location": "L19"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
-      "label": "WelcomeBackModalSuccess.tsx",
-      "norm_label": "welcomebackmodalsuccess.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
-      "label": "WelcomeBackModalSuccess()",
-      "norm_label": "welcomebackmodalsuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "leavereviewmodalconfig_getmodalconfig",
-      "label": "getModalConfig()",
-      "norm_label": "getmodalconfig()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
-      "label": "leaveReviewModalConfig.tsx",
-      "norm_label": "leavereviewmodalconfig.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
-      "source_location": "L1"
     },
     {
       "community": 58,
@@ -53454,6 +53616,42 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
+      "label": "WelcomeBackModalSuccess.tsx",
+      "norm_label": "welcomebackmodalsuccess.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
+      "label": "WelcomeBackModalSuccess()",
+      "norm_label": "welcomebackmodalsuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "leavereviewmodalconfig_getmodalconfig",
+      "label": "getModalConfig()",
+      "norm_label": "getmodalconfig()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
+      "label": "leaveReviewModalConfig.tsx",
+      "norm_label": "leavereviewmodalconfig.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
       "norm_label": "welcomebackmodalconfig.tsx",
@@ -53461,7 +53659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 582,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -53470,7 +53668,7 @@
       "source_location": "L46"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -53479,7 +53677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -53488,7 +53686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -53497,7 +53695,7 @@
       "source_location": "L15"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -53506,7 +53704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -53515,7 +53713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -53524,7 +53722,7 @@
       "source_location": "L5"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -53533,7 +53731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -53542,7 +53740,7 @@
       "source_location": "L14"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -53551,7 +53749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -53560,7 +53758,7 @@
       "source_location": "L29"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -53569,7 +53767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -53578,7 +53776,7 @@
       "source_location": "L5"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -53587,49 +53785,13 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
       "norm_label": "usegetproductquery()",
       "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
-      "label": "useGetProductFilters.ts",
-      "norm_label": "usegetproductfilters.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "usegetproductfilters_usegetproductfilters",
-      "label": "useGetProductFilters()",
-      "norm_label": "usegetproductfilters()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
-      "label": "useGetProductReviews.ts",
-      "norm_label": "usegetproductreviews.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "usegetproductreviews_usegetproductreviewsquery",
-      "label": "useGetProductReviewsQuery()",
-      "norm_label": "usegetproductreviewsquery()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
-      "source_location": "L4"
     },
     {
       "community": 59,
@@ -53706,6 +53868,42 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
+      "label": "useGetProductFilters.ts",
+      "norm_label": "usegetproductfilters.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "usegetproductfilters_usegetproductfilters",
+      "label": "useGetProductFilters()",
+      "norm_label": "usegetproductfilters()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
+      "label": "useGetProductReviews.ts",
+      "norm_label": "usegetproductreviews.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "usegetproductreviews_usegetproductreviewsquery",
+      "label": "useGetProductReviewsQuery()",
+      "norm_label": "usegetproductreviewsquery()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
       "norm_label": "usegetstore.ts",
@@ -53713,7 +53911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 590,
+      "community": 592,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -53722,7 +53920,7 @@
       "source_location": "L4"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -53731,7 +53929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -53740,7 +53938,7 @@
       "source_location": "L9"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -53749,7 +53947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -53758,7 +53956,7 @@
       "source_location": "L17"
     },
     {
-      "community": 593,
+      "community": 595,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -53767,7 +53965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 595,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -53776,7 +53974,7 @@
       "source_location": "L5"
     },
     {
-      "community": 594,
+      "community": 596,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -53785,7 +53983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 596,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -53794,7 +53992,7 @@
       "source_location": "L15"
     },
     {
-      "community": 595,
+      "community": 597,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -53803,7 +54001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 597,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -53812,7 +54010,7 @@
       "source_location": "L18"
     },
     {
-      "community": 596,
+      "community": 598,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -53821,7 +54019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 598,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -53830,7 +54028,7 @@
       "source_location": "L9"
     },
     {
-      "community": 597,
+      "community": 599,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -53839,49 +54037,13 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 599,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
       "norm_label": "usepromoalert()",
       "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
       "source_location": "L16"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
-      "label": "useQueryEnabled.ts",
-      "norm_label": "usequeryenabled.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "usequeryenabled_usequeryenabled",
-      "label": "useQueryEnabled()",
-      "norm_label": "usequeryenabled()",
-      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
-      "label": "useRewardsAlert.tsx",
-      "norm_label": "userewardsalert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "userewardsalert_userewardsalert",
-      "label": "useRewardsAlert()",
-      "norm_label": "userewardsalert()",
-      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
-      "source_location": "L11"
     },
     {
       "community": 6,
@@ -54183,6 +54345,42 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
+      "label": "useQueryEnabled.ts",
+      "norm_label": "usequeryenabled.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "usequeryenabled_usequeryenabled",
+      "label": "useQueryEnabled()",
+      "norm_label": "usequeryenabled()",
+      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
+      "label": "useRewardsAlert.tsx",
+      "norm_label": "userewardsalert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "userewardsalert_userewardsalert",
+      "label": "useRewardsAlert()",
+      "norm_label": "userewardsalert()",
+      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
       "norm_label": "usescrolltotop.ts",
@@ -54190,7 +54388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 602,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -54199,7 +54397,7 @@
       "source_location": "L3"
     },
     {
-      "community": 601,
+      "community": 603,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -54208,7 +54406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 603,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -54217,7 +54415,7 @@
       "source_location": "L7"
     },
     {
-      "community": 602,
+      "community": 604,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -54226,7 +54424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 604,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -54235,7 +54433,7 @@
       "source_location": "L4"
     },
     {
-      "community": 603,
+      "community": 605,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -54244,7 +54442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 605,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -54253,7 +54451,7 @@
       "source_location": "L14"
     },
     {
-      "community": 604,
+      "community": 606,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -54262,7 +54460,7 @@
       "source_location": "L4"
     },
     {
-      "community": 604,
+      "community": 606,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -54271,7 +54469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 607,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -54280,7 +54478,7 @@
       "source_location": "L7"
     },
     {
-      "community": 605,
+      "community": 607,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -54289,7 +54487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 608,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -54298,7 +54496,7 @@
       "source_location": "L6"
     },
     {
-      "community": 606,
+      "community": 608,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -54307,7 +54505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 609,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -54316,48 +54514,12 @@
       "source_location": "L10"
     },
     {
-      "community": 607,
+      "community": 609,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
       "norm_label": "checkout.ts",
       "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "inventory_useinventoryqueries",
-      "label": "useInventoryQueries()",
-      "norm_label": "useinventoryqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
-      "label": "inventory.ts",
-      "norm_label": "inventory.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "onlineorder_useonlineorderqueries",
-      "label": "useOnlineOrderQueries()",
-      "norm_label": "useonlineorderqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -54426,6 +54588,42 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "inventory_useinventoryqueries",
+      "label": "useInventoryQueries()",
+      "norm_label": "useinventoryqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
+      "label": "inventory.ts",
+      "norm_label": "inventory.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "onlineorder_useonlineorderqueries",
+      "label": "useOnlineOrderQueries()",
+      "norm_label": "useonlineorderqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
@@ -54433,7 +54631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 612,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -54442,7 +54640,7 @@
       "source_location": "L14"
     },
     {
-      "community": 611,
+      "community": 613,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -54451,7 +54649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 613,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -54460,7 +54658,7 @@
       "source_location": "L9"
     },
     {
-      "community": 612,
+      "community": 614,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -54469,7 +54667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 614,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -54478,7 +54676,7 @@
       "source_location": "L10"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -54487,7 +54685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -54496,7 +54694,7 @@
       "source_location": "L11"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -54505,7 +54703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -54514,7 +54712,7 @@
       "source_location": "L6"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -54523,7 +54721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -54532,7 +54730,7 @@
       "source_location": "L5"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -54541,7 +54739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -54550,7 +54748,7 @@
       "source_location": "L6"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -54559,49 +54757,13 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
       "norm_label": "buildv2config()",
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
-      "label": "storefrontObservability.test.ts",
-      "norm_label": "storefrontobservability.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "storefrontobservability_test_creatememorystorage",
-      "label": "createMemoryStorage()",
-      "norm_label": "creatememorystorage()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "email_validateemail",
-      "label": "validateEmail()",
-      "norm_label": "validateemail()",
-      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_validations_email_ts",
-      "label": "email.ts",
-      "norm_label": "email.ts",
-      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
-      "source_location": "L1"
     },
     {
       "community": 62,
@@ -54669,6 +54831,42 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
+      "label": "storefrontObservability.test.ts",
+      "norm_label": "storefrontobservability.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "storefrontobservability_test_creatememorystorage",
+      "label": "createMemoryStorage()",
+      "norm_label": "creatememorystorage()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "email_validateemail",
+      "label": "validateEmail()",
+      "norm_label": "validateemail()",
+      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_validations_email_ts",
+      "label": "email.ts",
+      "norm_label": "email.ts",
+      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
       "norm_label": "router.tsx",
@@ -54676,7 +54874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 622,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -54685,7 +54883,7 @@
       "source_location": "L6"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -54694,7 +54892,7 @@
       "source_location": "L13"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -54703,7 +54901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -54712,7 +54910,7 @@
       "source_location": "L8"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -54721,7 +54919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -54730,7 +54928,7 @@
       "source_location": "L14"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -54739,7 +54937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 626,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -54748,7 +54946,7 @@
       "source_location": "L13"
     },
     {
-      "community": 624,
+      "community": 626,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -54757,7 +54955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 627,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -54766,7 +54964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 627,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -54775,7 +54973,7 @@
       "source_location": "L9"
     },
     {
-      "community": 626,
+      "community": 628,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -54784,7 +54982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 628,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -54793,7 +54991,7 @@
       "source_location": "L15"
     },
     {
-      "community": 627,
+      "community": 629,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -54802,49 +55000,13 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 629,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
       "norm_label": "component()",
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L16"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "layout_layoutcomponent",
-      "label": "LayoutComponent()",
-      "norm_label": "layoutcomponent()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_tsx",
-      "label": "_layout.tsx",
-      "norm_label": "_layout.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "index_homeroute",
-      "label": "HomeRoute()",
-      "norm_label": "homeroute()",
-      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 63,
@@ -54912,6 +55074,42 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "layout_layoutcomponent",
+      "label": "LayoutComponent()",
+      "norm_label": "layoutcomponent()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_tsx",
+      "label": "_layout.tsx",
+      "norm_label": "_layout.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "index_homeroute",
+      "label": "HomeRoute()",
+      "norm_label": "homeroute()",
+      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
       "norm_label": "checkoutcanceledview()",
@@ -54919,7 +55117,7 @@
       "source_location": "L21"
     },
     {
-      "community": 630,
+      "community": 632,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -54928,7 +55126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 633,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -54937,7 +55135,7 @@
       "source_location": "L33"
     },
     {
-      "community": 631,
+      "community": 633,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -54946,7 +55144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 634,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -54955,7 +55153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 634,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -54964,7 +55162,7 @@
       "source_location": "L193"
     },
     {
-      "community": 633,
+      "community": 635,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -54973,7 +55171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 635,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -54982,7 +55180,7 @@
       "source_location": "L7"
     },
     {
-      "community": 634,
+      "community": 636,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -54991,7 +55189,7 @@
       "source_location": "L10"
     },
     {
-      "community": 634,
+      "community": 636,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -55000,7 +55198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 637,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -55009,7 +55207,7 @@
       "source_location": "L32"
     },
     {
-      "community": 635,
+      "community": 637,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -55018,7 +55216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 638,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -55027,7 +55225,7 @@
       "source_location": "L211"
     },
     {
-      "community": 636,
+      "community": 638,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -55036,7 +55234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 639,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -55045,39 +55243,12 @@
       "source_location": "L85"
     },
     {
-      "community": 637,
+      "community": 639,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
       "norm_label": "sample-app.ts",
       "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "harness_runtime_trends_test_buildreportline",
-      "label": "buildReportLine()",
-      "norm_label": "buildreportline()",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "scripts_harness_runtime_trends_test_ts",
-      "label": "harness-runtime-trends.test.ts",
-      "norm_label": "harness-runtime-trends.test.ts",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_api_d_ts",
-      "label": "api.d.ts",
-      "norm_label": "api.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
       "source_location": "L1"
     },
     {
@@ -55146,6 +55317,33 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "harness_runtime_trends_test_buildreportline",
+      "label": "buildReportLine()",
+      "norm_label": "buildreportline()",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "scripts_harness_runtime_trends_test_ts",
+      "label": "harness-runtime-trends.test.ts",
+      "norm_label": "harness-runtime-trends.test.ts",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_api_d_ts",
+      "label": "api.d.ts",
+      "norm_label": "api.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
       "norm_label": "api.js",
@@ -55153,7 +55351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -55162,7 +55360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -55171,7 +55369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -55180,7 +55378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -55189,7 +55387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -55198,7 +55396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -55207,30 +55405,12 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
       "norm_label": "registersessions.test.ts",
       "source_file": "packages/athena-webapp/convex/cashControls/registerSessions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_email_ts",
-      "label": "email.ts",
-      "norm_label": "email.ts",
-      "source_file": "packages/athena-webapp/convex/constants/email.ts",
       "source_location": "L1"
     },
     {
@@ -55299,6 +55479,24 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_email_ts",
+      "label": "email.ts",
+      "norm_label": "email.ts",
+      "source_file": "packages/athena-webapp/convex/constants/email.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
       "norm_label": "ghana.ts",
@@ -55306,7 +55504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -55315,7 +55513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -55324,7 +55522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -55333,7 +55531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -55342,7 +55540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -55351,7 +55549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -55360,30 +55558,12 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
       "norm_label": "env.ts",
       "source_file": "packages/athena-webapp/convex/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts",
       "source_location": "L1"
     },
     {
@@ -55452,6 +55632,24 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
@@ -55459,7 +55657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -55468,7 +55666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -55477,7 +55675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -55486,7 +55684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
@@ -55495,7 +55693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
@@ -55504,7 +55702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
       "label": "stores.ts",
@@ -55513,30 +55711,12 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
       "label": "subcategories.ts",
       "norm_label": "subcategories.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
       "source_location": "L1"
     },
     {
@@ -55605,6 +55785,24 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
@@ -55612,7 +55810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
@@ -55621,7 +55819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
@@ -55630,7 +55828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
@@ -55639,7 +55837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -55648,7 +55846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
@@ -55657,7 +55855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
       "label": "reviews.ts",
@@ -55666,30 +55864,12 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
-      "label": "security.test.ts",
-      "norm_label": "security.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
       "source_location": "L1"
     },
     {
@@ -55758,6 +55938,24 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
+      "label": "security.test.ts",
+      "norm_label": "security.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
       "norm_label": "storefront.ts",
@@ -55765,7 +55963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 683,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
@@ -55774,7 +55972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -55783,7 +55981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -55792,7 +55990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -55801,7 +55999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 687,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -55810,7 +56008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 688,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -55819,7 +56017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 689,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -55828,7 +56026,70 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 69,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 69,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 690,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -55837,7 +56098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 689,
+      "community": 691,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -55846,70 +56107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 69,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 69,
-      "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
-    },
-    {
-      "community": 690,
+      "community": 692,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -55918,7 +56116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 693,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -55927,7 +56125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 694,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -55936,7 +56134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -55945,7 +56143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -55954,7 +56152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -55963,7 +56161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -55972,30 +56170,12 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
       "norm_label": "organizationmembers.ts",
       "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_organizations_ts",
-      "label": "organizations.ts",
-      "norm_label": "organizations.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
-      "label": "posCustomers.ts",
-      "norm_label": "poscustomers.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
       "source_location": "L1"
     },
     {
@@ -56226,68 +56406,86 @@
     {
       "community": 70,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 700,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_organizations_ts",
+      "label": "organizations.ts",
+      "norm_label": "organizations.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
+      "label": "posCustomers.ts",
+      "norm_label": "poscustomers.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -56296,7 +56494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -56305,7 +56503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -56314,7 +56512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -56323,7 +56521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -56332,7 +56530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -56341,7 +56539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
@@ -56350,7 +56548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -56359,7 +56557,70 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 71,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 710,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -56368,7 +56629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 709,
+      "community": 711,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -56377,70 +56638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 71,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 710,
+      "community": 712,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -56449,7 +56647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 713,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -56458,7 +56656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 714,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -56467,7 +56665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 715,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -56476,7 +56674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 716,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -56485,7 +56683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 717,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -56494,7 +56692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 718,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -56503,30 +56701,12 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 719,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
       "norm_label": "inventorymovements.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
-      "label": "paymentAllocations.test.ts",
-      "norm_label": "paymentallocations.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
-      "label": "staffProfiles.test.ts",
-      "norm_label": "staffprofiles.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
       "source_location": "L1"
     },
     {
@@ -56595,6 +56775,24 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
+      "label": "paymentAllocations.test.ts",
+      "norm_label": "paymentallocations.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
+      "label": "staffProfiles.test.ts",
+      "norm_label": "staffprofiles.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_resendotp_ts",
       "label": "ResendOTP.ts",
       "norm_label": "resendotp.ts",
@@ -56602,7 +56800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 723,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -56611,7 +56809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 724,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -56620,7 +56818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 725,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -56629,7 +56827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -56638,7 +56836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -56647,7 +56845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -56656,30 +56854,12 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
-      "label": "color.ts",
-      "norm_label": "color.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
-      "label": "complimentaryProduct.ts",
-      "norm_label": "complimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
       "source_location": "L1"
     },
     {
@@ -56748,6 +56928,24 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
+      "label": "color.ts",
+      "norm_label": "color.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
+      "label": "complimentaryProduct.ts",
+      "norm_label": "complimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 732,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
       "norm_label": "featureditem.ts",
@@ -56755,7 +56953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 733,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -56764,7 +56962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -56773,7 +56971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -56782,7 +56980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -56791,7 +56989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -56800,7 +56998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -56809,30 +57007,12 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
       "norm_label": "redeemedpromocode.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
       "source_location": "L1"
     },
     {
@@ -56901,6 +57081,24 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 742,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
       "norm_label": "approvalrequest.ts",
@@ -56908,7 +57106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 743,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -56917,7 +57115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -56926,7 +57124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -56935,7 +57133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -56944,7 +57142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -56953,7 +57151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -56962,30 +57160,12 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
       "norm_label": "registersession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/registerSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 748,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
-      "label": "staffProfile.ts",
-      "norm_label": "staffprofile.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/staffProfile.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
-      "label": "staffRoleAssignment.ts",
-      "norm_label": "staffroleassignment.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/staffRoleAssignment.ts",
       "source_location": "L1"
     },
     {
@@ -57045,6 +57225,24 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
+      "label": "staffProfile.ts",
+      "norm_label": "staffprofile.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/staffProfile.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
+      "label": "staffRoleAssignment.ts",
+      "norm_label": "staffroleassignment.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/staffRoleAssignment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 752,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
       "norm_label": "mtncollections.ts",
@@ -57052,7 +57250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 753,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -57061,7 +57259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -57070,7 +57268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -57079,7 +57277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -57088,7 +57286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -57097,7 +57295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -57106,7 +57304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -57115,7 +57313,61 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 76,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "label": "paymentAllocationAttribution.ts",
+      "norm_label": "paymentallocationattribution.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "paymentallocationattribution_buildinstorepaymentallocations",
+      "label": "buildInStorePaymentAllocations()",
+      "norm_label": "buildinstorepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "paymentallocationattribution_isactiveregistersessionstatus",
+      "label": "isActiveRegisterSessionStatus()",
+      "norm_label": "isactiveregistersessionstatus()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "paymentallocationattribution_normalizeinstorepayments",
+      "label": "normalizeInStorePayments()",
+      "norm_label": "normalizeinstorepayments()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
+      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "paymentallocationattribution_selectregistersessionforattribution",
+      "label": "selectRegisterSessionForAttribution()",
+      "norm_label": "selectregistersessionforattribution()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 760,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -57124,7 +57376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 759,
+      "community": 761,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -57133,61 +57385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 760,
+      "community": 762,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -57196,7 +57394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -57205,7 +57403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -57214,7 +57412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -57223,7 +57421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -57232,7 +57430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -57241,7 +57439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -57250,7 +57448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -57259,7 +57457,61 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 770,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -57268,7 +57520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 769,
+      "community": 771,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -57277,61 +57529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 77,
-      "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 770,
+      "community": 772,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -57340,7 +57538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 773,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -57349,7 +57547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -57358,7 +57556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
@@ -57367,7 +57565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -57376,7 +57574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -57385,7 +57583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -57394,7 +57592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -57403,7 +57601,61 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 78,
+      "file_type": "code",
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 780,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -57412,7 +57664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 779,
+      "community": 781,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
       "label": "customer.ts",
@@ -57421,61 +57673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 78,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
-      "label": "purchaseOrders.ts",
-      "norm_label": "purchaseorders.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
-      "label": "assertValidPurchaseOrderStatusTransition()",
-      "norm_label": "assertvalidpurchaseorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordernumber",
-      "label": "buildPurchaseOrderNumber()",
-      "norm_label": "buildpurchaseordernumber()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "purchaseorders_calculatepurchaseordertotals",
-      "label": "calculatePurchaseOrderTotals()",
-      "norm_label": "calculatepurchaseordertotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "purchaseorders_getoperationalworkitemstatus",
-      "label": "getOperationalWorkItemStatus()",
-      "norm_label": "getoperationalworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "purchaseorders_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 780,
+      "community": 782,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -57484,7 +57682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -57493,7 +57691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -57502,7 +57700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -57511,7 +57709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -57520,7 +57718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -57529,7 +57727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -57538,7 +57736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -57547,7 +57745,61 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 79,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
+      "label": "purchaseOrders.ts",
+      "norm_label": "purchaseorders.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
+      "label": "assertValidPurchaseOrderStatusTransition()",
+      "norm_label": "assertvalidpurchaseorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "purchaseorders_buildpurchaseordernumber",
+      "label": "buildPurchaseOrderNumber()",
+      "norm_label": "buildpurchaseordernumber()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "purchaseorders_calculatepurchaseordertotals",
+      "label": "calculatePurchaseOrderTotals()",
+      "norm_label": "calculatepurchaseordertotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "purchaseorders_getoperationalworkitemstatus",
+      "label": "getOperationalWorkItemStatus()",
+      "norm_label": "getoperationalworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "purchaseorders_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 790,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -57556,7 +57808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 789,
+      "community": 791,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -57565,61 +57817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 79,
-      "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 790,
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -57628,7 +57826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -57637,7 +57835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -57646,7 +57844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -57655,7 +57853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -57664,7 +57862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -57673,7 +57871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -57682,30 +57880,12 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
-      "label": "onlineOrderUtilFns.ts",
-      "norm_label": "onlineorderutilfns.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
-      "label": "orderOperations.test.ts",
-      "norm_label": "orderoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/orderOperations.test.ts",
       "source_location": "L1"
     },
     {
@@ -57909,59 +58089,77 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "onlineorder_appendtransition",
-      "label": "appendTransition()",
-      "norm_label": "appendtransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L59"
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L19"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "onlineorder_applyonlineorderupdate",
-      "label": "applyOnlineOrderUpdate()",
-      "norm_label": "applyonlineorderupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L83"
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L124"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereplacementsourceid",
-      "label": "buildReturnExchangeReplacementSourceId()",
-      "norm_label": "buildreturnexchangereplacementsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L202"
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereturnsourceid",
-      "label": "buildReturnExchangeReturnSourceId()",
-      "norm_label": "buildreturnexchangereturnsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L210"
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L77"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "onlineorder_listorderitems",
-      "label": "listOrderItems()",
-      "norm_label": "listorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L49"
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L182"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1"
     },
     {
       "community": 800,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
+      "label": "onlineOrderUtilFns.ts",
+      "norm_label": "onlineorderutilfns.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
+      "label": "orderOperations.test.ts",
+      "norm_label": "orderoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/orderOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 802,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -57970,7 +58168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -57979,7 +58177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -57988,7 +58186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -57997,7 +58195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -58006,7 +58204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -58015,7 +58213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -58024,7 +58222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -58033,7 +58231,61 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 81,
+      "file_type": "code",
+      "id": "onlineorder_appendtransition",
+      "label": "appendTransition()",
+      "norm_label": "appendtransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "onlineorder_applyonlineorderupdate",
+      "label": "applyOnlineOrderUpdate()",
+      "norm_label": "applyonlineorderupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereplacementsourceid",
+      "label": "buildReturnExchangeReplacementSourceId()",
+      "norm_label": "buildreturnexchangereplacementsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L204"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereturnsourceid",
+      "label": "buildReturnExchangeReturnSourceId()",
+      "norm_label": "buildreturnexchangereturnsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L212"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "onlineorder_listorderitems",
+      "label": "listOrderItems()",
+      "norm_label": "listorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 810,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -58042,7 +58294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 809,
+      "community": 811,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -58051,61 +58303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 81,
-      "file_type": "code",
-      "id": "data_table_toolbar_datatabletoolbar",
-      "label": "DataTableToolbar()",
-      "norm_label": "datatabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 810,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -58114,7 +58312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -58123,7 +58321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -58132,7 +58330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -58141,7 +58339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -58150,7 +58348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -58159,7 +58357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -58168,7 +58366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58177,7 +58375,61 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 82,
+      "file_type": "code",
+      "id": "data_table_toolbar_datatabletoolbar",
+      "label": "DataTableToolbar()",
+      "norm_label": "datatabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 820,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -58186,7 +58438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 819,
+      "community": 821,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -58195,61 +58447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 82,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 820,
+      "community": 822,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -58258,7 +58456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -58267,7 +58465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -58276,7 +58474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -58285,7 +58483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -58294,7 +58492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58303,7 +58501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -58312,7 +58510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -58321,7 +58519,61 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 83,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 830,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -58330,7 +58582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 829,
+      "community": 831,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -58339,61 +58591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 83,
-      "file_type": "code",
-      "id": "cashiermanagement_buildusername",
-      "label": "buildUsername()",
-      "norm_label": "buildusername()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "cashiermanagement_handledelete",
-      "label": "handleDelete()",
-      "norm_label": "handledelete()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L320"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "cashiermanagement_handlepinkeydown",
-      "label": "handlePinKeyDown()",
-      "norm_label": "handlepinkeydown()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L169"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "cashiermanagement_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L109"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "cashiermanagement_normalizenamesegment",
-      "label": "normalizeNameSegment()",
-      "norm_label": "normalizenamesegment()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cashiers_cashiermanagement_tsx",
-      "label": "CashierManagement.tsx",
-      "norm_label": "cashiermanagement.tsx",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 830,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58402,7 +58600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -58411,7 +58609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -58420,7 +58618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -58429,7 +58627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58438,7 +58636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -58447,7 +58645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -58456,7 +58654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -58465,7 +58663,61 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 84,
+      "file_type": "code",
+      "id": "cashiermanagement_buildusername",
+      "label": "buildUsername()",
+      "norm_label": "buildusername()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "cashiermanagement_handledelete",
+      "label": "handleDelete()",
+      "norm_label": "handledelete()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L320"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "cashiermanagement_handlepinkeydown",
+      "label": "handlePinKeyDown()",
+      "norm_label": "handlepinkeydown()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L169"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "cashiermanagement_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L109"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "cashiermanagement_normalizenamesegment",
+      "label": "normalizeNameSegment()",
+      "norm_label": "normalizenamesegment()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cashiers_cashiermanagement_tsx",
+      "label": "CashierManagement.tsx",
+      "norm_label": "cashiermanagement.tsx",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 840,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58474,7 +58726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 839,
+      "community": 841,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -58483,61 +58735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 84,
-      "file_type": "code",
-      "id": "bannermessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L123"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleactivetoggle",
-      "label": "handleActiveToggle()",
-      "norm_label": "handleactivetoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleclear",
-      "label": "handleClear()",
-      "norm_label": "handleclear()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L113"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "label": "BannerMessageEditor.tsx",
-      "norm_label": "bannermessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 840,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -58546,7 +58744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -58555,7 +58753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -58564,7 +58762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58573,7 +58771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -58582,7 +58780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -58591,7 +58789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -58600,7 +58798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58609,7 +58807,61 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 85,
+      "file_type": "code",
+      "id": "bannermessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L123"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleactivetoggle",
+      "label": "handleActiveToggle()",
+      "norm_label": "handleactivetoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L113"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
+      "label": "BannerMessageEditor.tsx",
+      "norm_label": "bannermessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 850,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -58618,7 +58870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 849,
+      "community": 851,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -58627,61 +58879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 85,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
-      "label": "PaymentsAddedList.tsx",
-      "norm_label": "paymentsaddedlist.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "label": "getPaymentMethodLabel()",
-      "norm_label": "getpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handleremovepayment",
-      "label": "handleRemovePayment()",
-      "norm_label": "handleremovepayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handlestartedit",
-      "label": "handleStartEdit()",
-      "norm_label": "handlestartedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L59"
-    },
-    {
-      "community": 850,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -58690,7 +58888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -58699,7 +58897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58708,7 +58906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -58717,7 +58915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -58726,7 +58924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -58735,7 +58933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -58744,7 +58942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -58753,7 +58951,61 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 86,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
+      "label": "PaymentsAddedList.tsx",
+      "norm_label": "paymentsaddedlist.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "paymentsaddedlist_getpaymentmethodlabel",
+      "label": "getPaymentMethodLabel()",
+      "norm_label": "getpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "paymentsaddedlist_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "paymentsaddedlist_handleremovepayment",
+      "label": "handleRemovePayment()",
+      "norm_label": "handleremovepayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "paymentsaddedlist_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "paymentsaddedlist_handlestartedit",
+      "label": "handleStartEdit()",
+      "norm_label": "handlestartedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 860,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -58762,7 +59014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 859,
+      "community": 861,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58771,61 +59023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 86,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "label": "ReviewsView.tsx",
-      "norm_label": "reviewsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "reviewsview_handleapprove",
-      "label": "handleApprove()",
-      "norm_label": "handleapprove()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "reviewsview_handlepublish",
-      "label": "handlePublish()",
-      "norm_label": "handlepublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "reviewsview_handlereject",
-      "label": "handleReject()",
-      "norm_label": "handlereject()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "reviewsview_handleunpublish",
-      "label": "handleUnpublish()",
-      "norm_label": "handleunpublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "reviewsview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 860,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -58834,7 +59032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -58843,7 +59041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -58852,7 +59050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -58861,7 +59059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -58870,7 +59068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -58879,7 +59077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -58888,7 +59086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -58897,7 +59095,61 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 87,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
+      "label": "ReviewsView.tsx",
+      "norm_label": "reviewsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "reviewsview_handleapprove",
+      "label": "handleApprove()",
+      "norm_label": "handleapprove()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "reviewsview_handlepublish",
+      "label": "handlePublish()",
+      "norm_label": "handlepublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "reviewsview_handlereject",
+      "label": "handleReject()",
+      "norm_label": "handlereject()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "reviewsview_handleunpublish",
+      "label": "handleUnpublish()",
+      "norm_label": "handleunpublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "reviewsview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 870,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -58906,7 +59158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 869,
+      "community": 871,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -58915,61 +59167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 87,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 870,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -58978,7 +59176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -58987,7 +59185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -58996,7 +59194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -59005,7 +59203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -59014,7 +59212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -59023,7 +59221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
       "label": "index.tsx",
@@ -59032,7 +59230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -59041,7 +59239,61 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 88,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 880,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -59050,7 +59302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 879,
+      "community": 881,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -59059,61 +59311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 88,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 880,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -59122,7 +59320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -59131,7 +59329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -59140,7 +59338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -59149,7 +59347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -59158,7 +59356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -59167,7 +59365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -59176,7 +59374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -59185,7 +59383,61 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 89,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 890,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
@@ -59194,7 +59446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 889,
+      "community": 891,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -59203,61 +59455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 89,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 890,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -59266,7 +59464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -59275,7 +59473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -59284,7 +59482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -59293,7 +59491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -59302,7 +59500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -59311,7 +59509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -59320,30 +59518,12 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -59538,59 +59718,77 @@
     {
       "community": 90,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
-      "label": "usePOSCustomers.ts",
-      "norm_label": "useposcustomers.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "useposcustomers_useposcustomer",
-      "label": "usePOSCustomer()",
-      "norm_label": "useposcustomer()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L18"
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L33"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "useposcustomers_useposcustomercreate",
-      "label": "usePOSCustomerCreate()",
-      "norm_label": "useposcustomercreate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L26"
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L23"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "useposcustomers_useposcustomersearch",
-      "label": "usePOSCustomerSearch()",
-      "norm_label": "useposcustomersearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L7"
     },
     {
-      "community": 90,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomertransactions",
-      "label": "usePOSCustomerTransactions()",
-      "norm_label": "useposcustomertransactions()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomerupdate",
-      "label": "usePOSCustomerUpdate()",
-      "norm_label": "useposcustomerupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L57"
-    },
-    {
       "community": 900,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -59599,7 +59797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -59608,7 +59806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -59617,7 +59815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -59626,7 +59824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -59635,7 +59833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -59644,7 +59842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -59653,7 +59851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -59662,7 +59860,61 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 91,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
+      "label": "usePOSCustomers.ts",
+      "norm_label": "useposcustomers.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomer",
+      "label": "usePOSCustomer()",
+      "norm_label": "useposcustomer()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomercreate",
+      "label": "usePOSCustomerCreate()",
+      "norm_label": "useposcustomercreate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomersearch",
+      "label": "usePOSCustomerSearch()",
+      "norm_label": "useposcustomersearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomertransactions",
+      "label": "usePOSCustomerTransactions()",
+      "norm_label": "useposcustomertransactions()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomerupdate",
+      "label": "usePOSCustomerUpdate()",
+      "norm_label": "useposcustomerupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 910,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -59671,7 +59923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 909,
+      "community": 911,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -59680,61 +59932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 91,
-      "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 910,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -59743,7 +59941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -59752,7 +59950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -59761,7 +59959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -59770,7 +59968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -59779,7 +59977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -59788,7 +59986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -59797,7 +59995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
@@ -59806,7 +60004,61 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 92,
+      "file_type": "code",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 920,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -59815,7 +60067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 919,
+      "community": 921,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
@@ -59824,61 +60076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 92,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
-    },
-    {
-      "community": 920,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -59887,7 +60085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -59896,7 +60094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -59905,7 +60103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -59914,7 +60112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -59923,7 +60121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -59932,7 +60130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -59941,7 +60139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -59950,7 +60148,61 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 93,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 930,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -59959,7 +60211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 929,
+      "community": 931,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -59968,61 +60220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 93,
-      "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L198"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L71"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 930,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -60031,7 +60229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -60040,7 +60238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -60049,7 +60247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -60058,7 +60256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -60067,7 +60265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -60076,7 +60274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -60085,7 +60283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -60094,7 +60292,61 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 94,
+      "file_type": "code",
+      "id": "organizationsettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L198"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L71"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 940,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -60103,7 +60355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 939,
+      "community": 941,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -60112,61 +60364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 94,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L232"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "storesettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 940,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -60175,7 +60373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -60184,7 +60382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -60193,7 +60391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -60202,7 +60400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -60211,7 +60409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -60220,7 +60418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -60229,7 +60427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -60238,7 +60436,61 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 95,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L232"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 950,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -60247,7 +60499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 949,
+      "community": 951,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -60256,61 +60508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 95,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 950,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -60319,7 +60517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -60328,7 +60526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -60337,7 +60535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -60346,7 +60544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -60355,7 +60553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -60364,7 +60562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -60373,7 +60571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -60382,7 +60580,61 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 96,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 960,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -60391,7 +60643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 959,
+      "community": 961,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -60400,61 +60652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 96,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 960,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -60463,7 +60661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -60472,7 +60670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -60481,7 +60679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -60490,7 +60688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -60499,7 +60697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -60508,7 +60706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -60517,7 +60715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -60526,7 +60724,61 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 97,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 970,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -60535,7 +60787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 969,
+      "community": 971,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -60544,61 +60796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 97,
-      "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 970,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -60607,7 +60805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -60616,7 +60814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -60625,7 +60823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -60634,7 +60832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -60643,7 +60841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -60652,7 +60850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -60661,7 +60859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -60670,7 +60868,61 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 98,
+      "file_type": "code",
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 980,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -60679,7 +60931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 979,
+      "community": 981,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -60688,61 +60940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 98,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 980,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -60751,7 +60949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -60760,7 +60958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -60769,7 +60967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -60778,7 +60976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -60787,7 +60985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -60796,7 +60994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -60805,7 +61003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -60814,7 +61012,61 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 99,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 990,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -60823,7 +61075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 989,
+      "community": 991,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -60832,61 +61084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 99,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 990,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -60895,7 +61093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -60904,7 +61102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -60913,7 +61111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -60922,7 +61120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -60931,7 +61129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -60940,7 +61138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -60949,30 +61147,12 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
       "norm_label": "bagview.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1330
-- Graph nodes: 3177
-- Graph edges: 2698
-- Communities: 1246
+- Code files discovered: 1332
+- Graph nodes: 3185
+- Graph edges: 2707
+- Communities: 1248
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -18,7 +18,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 
 ## Graph Hotspots
 - `storeConfigV2.ts` (27 edges, Community 4) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
-- `ProductStock.tsx` (19 edges, Community 11) - [`packages/athena-webapp/src/components/add-product/ProductStock.tsx`](../../../packages/athena-webapp/src/components/add-product/ProductStock.tsx)
+- `ProductStock.tsx` (19 edges, Community 10) - [`packages/athena-webapp/src/components/add-product/ProductStock.tsx`](../../../packages/athena-webapp/src/components/add-product/ProductStock.tsx)
 - `checkoutSession.ts` (17 edges, Community 12) - [`packages/athena-webapp/convex/storeFront/checkoutSession.ts`](../../../packages/athena-webapp/convex/storeFront/checkoutSession.ts)
 - `DataTableViewOptions()` (16 edges, Community 14) - [`packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx`](../../../packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx)
 - `storeConfig.ts` (16 edges, Community 8) - [`packages/athena-webapp/src/lib/storeConfig.ts`](../../../packages/athena-webapp/src/lib/storeConfig.ts)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 26) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 187) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 188) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 26) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 26) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 26) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts
+++ b/packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts
@@ -1,0 +1,172 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { Id } from "../_generated/dataModel";
+import {
+  buildInStorePaymentAllocations,
+  normalizeInStorePayments,
+  selectRegisterSessionForAttribution,
+} from "./paymentAllocationAttribution";
+
+const projectRoot = process.cwd();
+const readProjectFile = (...segments: string[]) =>
+  readFileSync(join(projectRoot, ...segments), "utf8");
+
+describe("cash-control payment allocation attribution", () => {
+  it("normalizes split payments so change only reduces retained cash", () => {
+    expect(
+      normalizeInStorePayments({
+        changeGiven: 2000,
+        payments: [
+          { amount: 9000, method: "cash", timestamp: 1 },
+          { amount: 3000, method: "card", timestamp: 2 },
+        ],
+      })
+    ).toEqual([
+      { amount: 7000, method: "cash", timestamp: 1 },
+      { amount: 3000, method: "card", timestamp: 2 },
+    ]);
+
+    expect(
+      normalizeInStorePayments({
+        changeGiven: 1000,
+        payments: [
+          { amount: 4000, method: "cash", timestamp: 1 },
+          { amount: 3000, method: "cash", timestamp: 2 },
+        ],
+      })
+    ).toEqual([
+      { amount: 4000, method: "cash", timestamp: 1 },
+      { amount: 2000, method: "cash", timestamp: 2 },
+    ]);
+  });
+
+  it("builds one retained allocation per payment with register-session metadata", () => {
+    const allocations = buildInStorePaymentAllocations({
+      allocationType: "retail_sale",
+      changeGiven: 1000,
+      externalReferencePrefix: "tx-123",
+      payments: [
+        { amount: 9000, method: "cash", timestamp: 1 },
+        { amount: 3000, method: "card", timestamp: 2 },
+      ],
+      registerSessionId: "session_1" as Id<"registerSession">,
+      storeId: "store_1" as Id<"store">,
+      targetId: "transaction_1",
+      targetType: "pos_transaction",
+    });
+
+    expect(allocations).toEqual([
+      expect.objectContaining({
+        allocationType: "retail_sale",
+        amount: 8000,
+        collectedInStore: true,
+        externalReference: "tx-123:0",
+        method: "cash",
+        registerSessionId: "session_1",
+        storeId: "store_1",
+        targetId: "transaction_1",
+        targetType: "pos_transaction",
+      }),
+      expect.objectContaining({
+        allocationType: "retail_sale",
+        amount: 3000,
+        collectedInStore: true,
+        externalReference: "tx-123:1",
+        method: "card",
+        registerSessionId: "session_1",
+        storeId: "store_1",
+        targetId: "transaction_1",
+        targetType: "pos_transaction",
+      }),
+    ]);
+  });
+
+  it("prefers an explicit session and refuses ambiguous actor-owned sessions", () => {
+    const explicitSessionId = selectRegisterSessionForAttribution({
+      actorUserId: "user_1" as Id<"athenaUser">,
+      registerSessionId: "session_explicit" as Id<"registerSession">,
+      sessions: [
+        {
+          _id: "session_a" as Id<"registerSession">,
+          openedByUserId: "user_2" as Id<"athenaUser">,
+          status: "active",
+        },
+      ],
+    });
+
+    expect(explicitSessionId).toBe("session_explicit");
+
+    expect(
+      selectRegisterSessionForAttribution({
+        actorUserId: "user_1" as Id<"athenaUser">,
+        sessions: [
+          {
+            _id: "session_a" as Id<"registerSession">,
+            openedByUserId: "user_1" as Id<"athenaUser">,
+            status: "active",
+          },
+          {
+            _id: "session_b" as Id<"registerSession">,
+            openedByUserId: "user_1" as Id<"athenaUser">,
+            status: "open",
+          },
+        ],
+      })
+    ).toBeUndefined();
+
+    expect(
+      selectRegisterSessionForAttribution({
+        actorStaffProfileId: "staff_1" as Id<"staffProfile">,
+        sessions: [
+          {
+            _id: "session_staff" as Id<"registerSession">,
+            openedByStaffProfileId: "staff_1" as Id<"staffProfile">,
+            status: "active",
+          },
+        ],
+      })
+    ).toBe("session_staff");
+
+    expect(
+      selectRegisterSessionForAttribution({
+        sessions: [
+          {
+            _id: "session_only" as Id<"registerSession">,
+            status: "open",
+          },
+        ],
+      })
+    ).toBe("session_only");
+  });
+
+  it("threads attribution helpers through the cash-bearing service, order, and POS flows", () => {
+    const serviceIntake = readProjectFile("convex", "operations", "serviceIntake.ts");
+    const orderOperations = readProjectFile(
+      "convex",
+      "storeFront",
+      "helpers",
+      "orderOperations.ts"
+    );
+    const serviceCases = readProjectFile(
+      "convex",
+      "serviceOps",
+      "serviceCases.ts"
+    );
+    const pos = readProjectFile("convex", "inventory", "pos.ts");
+
+    expect(serviceIntake).toContain("resolveRegisterSessionForInStoreCollectionWithCtx");
+    expect(serviceIntake).toContain('args.intakeChannel === "walk_in"');
+    expect(serviceIntake).toContain("registerSessionId: resolvedRegisterSessionId");
+
+    expect(orderOperations).toContain('args.order.deliveryMethod === "pickup"');
+    expect(orderOperations).toContain("resolveRegisterSessionForInStoreCollectionWithCtx");
+    expect(orderOperations).toContain("registerSessionId: resolvedRegisterSessionId");
+
+    expect(serviceCases).toContain("resolveRegisterSessionForInStoreCollectionWithCtx");
+    expect(serviceCases).toContain("registerSessionId: resolvedRegisterSessionId");
+
+    expect(pos).toContain("buildInStorePaymentAllocations");
+    expect(pos).toContain("recordPaymentAllocationWithCtx");
+  });
+});

--- a/packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts
+++ b/packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts
@@ -1,0 +1,162 @@
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+import type { RecordPaymentAllocationArgs } from "../operations/paymentAllocations";
+
+type RegisterSessionStatus = "open" | "active" | "closing" | "closed";
+type RegisterSessionAttributionCandidate = {
+  _id: Id<"registerSession">;
+  openedByStaffProfileId?: Id<"staffProfile">;
+  openedByUserId?: Id<"athenaUser">;
+  status: RegisterSessionStatus;
+};
+type InStorePayment = {
+  amount: number;
+  method: string;
+  timestamp: number;
+};
+
+const ACTIVE_REGISTER_SESSION_STATUSES = ["open", "active"] as const;
+
+function isActiveRegisterSessionStatus(status: RegisterSessionStatus) {
+  return status === "open" || status === "active";
+}
+
+export function normalizeInStorePayments(args: {
+  changeGiven?: number;
+  payments: InStorePayment[];
+}) {
+  const normalizedPayments = args.payments.map((payment) => ({ ...payment }));
+  let remainingChange = args.changeGiven ?? 0;
+
+  for (let index = normalizedPayments.length - 1; index >= 0; index -= 1) {
+    const payment = normalizedPayments[index];
+    if (payment.method !== "cash" || remainingChange <= 0) {
+      continue;
+    }
+
+    const appliedChange = Math.min(payment.amount, remainingChange);
+    normalizedPayments[index] = {
+      ...payment,
+      amount: payment.amount - appliedChange,
+    };
+    remainingChange -= appliedChange;
+  }
+
+  return normalizedPayments.filter((payment) => payment.amount > 0);
+}
+
+export function buildInStorePaymentAllocations(
+  args: Omit<
+    RecordPaymentAllocationArgs,
+    "amount" | "collectedInStore" | "direction" | "method"
+  > & {
+    changeGiven?: number;
+    direction?: "in" | "out";
+    externalReferencePrefix?: string;
+    payments: InStorePayment[];
+  }
+) {
+  const {
+    changeGiven,
+    externalReference,
+    externalReferencePrefix,
+    payments,
+    ...baseArgs
+  } = args;
+
+  return normalizeInStorePayments({
+    changeGiven,
+    payments,
+  }).map((payment, index) => ({
+    ...baseArgs,
+    amount: payment.amount,
+    collectedInStore: true,
+    direction: args.direction ?? "in",
+    externalReference:
+      externalReferencePrefix !== undefined
+        ? `${externalReferencePrefix}:${index}`
+        : externalReference,
+    method: payment.method,
+  }));
+}
+
+export function selectRegisterSessionForAttribution(args: {
+  actorStaffProfileId?: Id<"staffProfile">;
+  actorUserId?: Id<"athenaUser">;
+  registerSessionId?: Id<"registerSession">;
+  sessions: RegisterSessionAttributionCandidate[];
+}) {
+  if (args.registerSessionId) {
+    return args.registerSessionId;
+  }
+
+  const activeSessions = args.sessions.filter((session) =>
+    isActiveRegisterSessionStatus(session.status)
+  );
+
+  if (args.actorStaffProfileId) {
+    const staffSessions = activeSessions.filter(
+      (session) => session.openedByStaffProfileId === args.actorStaffProfileId
+    );
+
+    if (staffSessions.length === 1) {
+      return staffSessions[0]._id;
+    }
+  }
+
+  if (args.actorUserId) {
+    const userSessions = activeSessions.filter(
+      (session) => session.openedByUserId === args.actorUserId
+    );
+
+    if (userSessions.length === 1) {
+      return userSessions[0]._id;
+    }
+  }
+
+  return activeSessions.length === 1 ? activeSessions[0]._id : undefined;
+}
+
+export async function resolveRegisterSessionForInStoreCollectionWithCtx(
+  ctx: MutationCtx,
+  args: {
+    actorStaffProfileId?: Id<"staffProfile">;
+    actorUserId?: Id<"athenaUser">;
+    registerSessionId?: Id<"registerSession">;
+    storeId: Id<"store">;
+  }
+) {
+  if (args.registerSessionId) {
+    const registerSession = await ctx.db.get("registerSession", args.registerSessionId);
+
+    if (!registerSession || registerSession.storeId !== args.storeId) {
+      throw new Error("Register session not found for this store.");
+    }
+
+    if (!isActiveRegisterSessionStatus(registerSession.status)) {
+      throw new Error("Register session is not accepting new collections.");
+    }
+
+    return registerSession._id;
+  }
+
+  const sessions = (
+    await Promise.all(
+      ACTIVE_REGISTER_SESSION_STATUSES.map((status) =>
+        // eslint-disable-next-line @convex-dev/no-collect-in-query -- Store-scoped open/active session attribution needs the complete candidate set to avoid guessing across drawers.
+        ctx.db
+          .query("registerSession")
+          .withIndex("by_storeId_status", (q) =>
+            q.eq("storeId", args.storeId).eq("status", status)
+          )
+          .collect()
+      )
+    )
+  ).flat();
+
+  return selectRegisterSessionForAttribution({
+    actorStaffProfileId: args.actorStaffProfileId,
+    actorUserId: args.actorUserId,
+    sessions,
+  });
+}

--- a/packages/athena-webapp/convex/inventory/pos.ts
+++ b/packages/athena-webapp/convex/inventory/pos.ts
@@ -2,6 +2,8 @@ import { internal } from "../_generated/api";
 import { query, mutation, MutationCtx, QueryCtx } from "../_generated/server";
 import { v } from "convex/values";
 import type { Doc, Id } from "../_generated/dataModel";
+import { buildInStorePaymentAllocations } from "../cashControls/paymentAllocationAttribution";
+import { recordPaymentAllocationWithCtx } from "../operations/paymentAllocations";
 import { capitalizeWords, generateTransactionNumber } from "../utils";
 
 const CONVEX_PRODUCT_ID_PATTERN = /^[a-z0-9]{32}$/;
@@ -579,6 +581,22 @@ export const completeTransaction = mutation({
       );
     }
 
+    const store = await ctx.db.get("store", args.storeId);
+    await Promise.all(
+      buildInStorePaymentAllocations({
+        allocationType: "retail_sale",
+        changeGiven,
+        externalReferencePrefix: `${transactionNumber}:sale`,
+        organizationId: store?.organizationId,
+        payments: args.payments,
+        posTransactionId: transactionId,
+        registerSessionId: args.registerSessionId,
+        storeId: args.storeId,
+        targetId: transactionId,
+        targetType: "pos_transaction",
+      }).map((allocation) => recordPaymentAllocationWithCtx(ctx, allocation))
+    );
+
     // Update customer statistics if customer is linked
     if (args.customerId) {
       const customer = await ctx.db.get("posCustomer", args.customerId);
@@ -913,6 +931,23 @@ export const voidTransaction = mutation({
       );
     }
 
+    const store = await ctx.db.get("store", transaction.storeId);
+    await Promise.all(
+      buildInStorePaymentAllocations({
+        allocationType: "retail_sale_void",
+        changeGiven: transaction.changeGiven,
+        direction: "out",
+        externalReferencePrefix: `${transaction.transactionNumber}:void`,
+        organizationId: store?.organizationId,
+        payments: transaction.payments,
+        posTransactionId: transaction._id,
+        registerSessionId: transaction.registerSessionId,
+        storeId: transaction.storeId,
+        targetId: transaction._id,
+        targetType: "pos_transaction",
+      }).map((allocation) => recordPaymentAllocationWithCtx(ctx, allocation))
+    );
+
     // Update transaction status
     await ctx.db.patch("posTransaction", args.transactionId, {
       status: "void",
@@ -1063,6 +1098,22 @@ export async function createTransactionFromSessionHandler(
       }
     );
   }
+
+  const store = await ctx.db.get("store", session.storeId);
+  await Promise.all(
+    buildInStorePaymentAllocations({
+      allocationType: "retail_sale",
+      changeGiven,
+      externalReferencePrefix: `${transactionNumber}:sale`,
+      organizationId: store?.organizationId,
+      payments: args.payments,
+      posTransactionId: transactionId,
+      registerSessionId: args.registerSessionId,
+      storeId: session.storeId,
+      targetId: transactionId,
+      targetType: "pos_transaction",
+    }).map((allocation) => recordPaymentAllocationWithCtx(ctx, allocation))
+  );
 
   // Update customer statistics if customer is linked
   if (session.customerId) {

--- a/packages/athena-webapp/convex/operations/serviceIntake.ts
+++ b/packages/athena-webapp/convex/operations/serviceIntake.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { mutation, query } from "../_generated/server";
 import { buildApprovalRequest } from "./approvalRequestHelpers";
+import { resolveRegisterSessionForInStoreCollectionWithCtx } from "../cashControls/paymentAllocationAttribution";
 import { normalizeLookupValue, normalizePhoneNumber } from "./helpers/linking";
 import { recordInventoryMovementWithCtx } from "./inventoryMovements";
 import { createOperationalWorkItemWithCtx } from "./operationalWorkItems";
@@ -229,6 +230,7 @@ export const createServiceIntake = mutation({
     priority: v.optional(
       v.union(v.literal("normal"), v.literal("high"), v.literal("urgent"))
     ),
+    registerSessionId: v.optional(v.id("registerSession")),
     scheduledAt: v.optional(v.number()),
     serviceTitle: v.string(),
     storeId: v.id("store"),
@@ -289,6 +291,15 @@ export const createServiceIntake = mutation({
     }
 
     const hasDeposit = args.depositAmount !== undefined && args.depositAmount > 0;
+    const collectedInStore = args.intakeChannel === "walk_in";
+    const resolvedRegisterSessionId = hasDeposit && collectedInStore
+      ? await resolveRegisterSessionForInStoreCollectionWithCtx(ctx, {
+          actorStaffProfileId: createdByStaffProfile?._id,
+          actorUserId: args.createdByUserId,
+          registerSessionId: args.registerSessionId,
+          storeId: args.storeId,
+        })
+      : undefined;
     const workItem = await createOperationalWorkItemWithCtx(ctx, {
       approvalState: hasDeposit ? "pending" : "not_required",
       assignedToStaffProfileId: args.assignedStaffProfileId,
@@ -340,6 +351,7 @@ export const createServiceIntake = mutation({
               organizationId: store.organizationId,
               reason: `Approve deposit for ${args.serviceTitle.trim()}`,
               requestType: "service_deposit_review",
+              registerSessionId: resolvedRegisterSessionId,
               requestedByStaffProfileId: createdByStaffProfile?._id,
               requestedByUserId: args.createdByUserId,
               storeId: args.storeId,
@@ -379,10 +391,11 @@ export const createServiceIntake = mutation({
             actorUserId: args.createdByUserId,
             allocationType: "service_deposit",
             amount: args.depositAmount!,
-            collectedInStore: true,
+            collectedInStore,
             customerProfileId: customerProfile._id,
             method: args.depositMethod,
             organizationId: store.organizationId,
+            registerSessionId: resolvedRegisterSessionId,
             storeId: args.storeId,
             targetId: serviceCase._id,
             targetType: "service_case",
@@ -404,6 +417,7 @@ export const createServiceIntake = mutation({
       },
       organizationId: store.organizationId,
       paymentAllocationId: paymentAllocation?._id,
+      registerSessionId: resolvedRegisterSessionId,
       storeId: args.storeId,
       subjectId: serviceCase._id,
       subjectLabel: workItem.title,

--- a/packages/athena-webapp/convex/serviceOps/serviceCases.ts
+++ b/packages/athena-webapp/convex/serviceOps/serviceCases.ts
@@ -3,6 +3,7 @@
 import { mutation, query, MutationCtx, QueryCtx } from "../_generated/server";
 import { Id } from "../_generated/dataModel";
 import { v } from "convex/values";
+import { resolveRegisterSessionForInStoreCollectionWithCtx } from "../cashControls/paymentAllocationAttribution";
 import {
   recordInventoryMovementWithCtx,
   summarizeInventoryMovements,
@@ -572,25 +573,37 @@ export const recordServicePayment = mutation({
     actorStaffProfileId: v.optional(v.id("staffProfile")),
     actorUserId: v.optional(v.id("athenaUser")),
     amount: v.number(),
+    collectedInStore: v.optional(v.boolean()),
     direction: v.optional(v.union(v.literal("in"), v.literal("out"))),
     method: v.string(),
     notes: v.optional(v.string()),
+    registerSessionId: v.optional(v.id("registerSession")),
     serviceCaseId: v.id("serviceCase"),
   },
   handler: async (ctx, args) => {
     const { serviceCase, workItem } = await getServiceCaseContext(ctx, args.serviceCaseId);
+    const collectedInStore = args.collectedInStore ?? true;
+    const resolvedRegisterSessionId = collectedInStore
+      ? await resolveRegisterSessionForInStoreCollectionWithCtx(ctx, {
+          actorStaffProfileId: args.actorStaffProfileId,
+          actorUserId: args.actorUserId,
+          registerSessionId: args.registerSessionId,
+          storeId: serviceCase.storeId,
+        })
+      : undefined;
 
     const paymentAllocation = await recordPaymentAllocationWithCtx(ctx, {
       actorStaffProfileId: args.actorStaffProfileId,
       actorUserId: args.actorUserId,
       allocationType: args.direction === "out" ? "service_refund" : "service_payment",
       amount: args.amount,
-      collectedInStore: true,
+      collectedInStore,
       customerProfileId: serviceCase.customerProfileId,
       direction: args.direction,
       method: args.method,
       notes: args.notes,
       organizationId: serviceCase.organizationId,
+      registerSessionId: resolvedRegisterSessionId,
       storeId: serviceCase.storeId,
       targetId: serviceCase._id,
       targetType: "service_case",
@@ -606,6 +619,7 @@ export const recordServicePayment = mutation({
       eventType: args.direction === "out" ? "service_case_refunded" : "service_case_paid",
       organizationId: serviceCase.organizationId,
       paymentAllocationId: paymentAllocation?._id,
+      registerSessionId: resolvedRegisterSessionId,
       storeId: serviceCase.storeId,
       subjectId: serviceCase._id,
       subjectType: "service_case",

--- a/packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts
+++ b/packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts
@@ -1,5 +1,6 @@
 import { Doc, Id } from "../../_generated/dataModel";
 import { MutationCtx } from "../../_generated/server";
+import { resolveRegisterSessionForInStoreCollectionWithCtx } from "../../cashControls/paymentAllocationAttribution";
 import { ensureCustomerProfileFromSourcesWithCtx } from "../../operations/customerProfiles";
 import { recordInventoryMovementWithCtx } from "../../operations/inventoryMovements";
 import { recordOperationalEventWithCtx } from "../../operations/operationalEvents";
@@ -288,6 +289,7 @@ export async function recordOnlineOrderPaymentCollected(
   ctx: MutationCtx,
   args: {
     order: Doc<"onlineOrder">;
+    registerSessionId?: Id<"registerSession">;
     signedInAthenaUser?: SignedInAthenaUser;
   }
 ) {
@@ -300,18 +302,27 @@ export async function recordOnlineOrderPaymentCollected(
     ctx,
     args.order
   );
+  const collectedInStore = args.order.deliveryMethod === "pickup";
+  const resolvedRegisterSessionId = collectedInStore
+    ? await resolveRegisterSessionForInStoreCollectionWithCtx(ctx, {
+        actorUserId: args.signedInAthenaUser?.id,
+        registerSessionId: args.registerSessionId,
+        storeId: args.order.storeId,
+      })
+    : undefined;
 
   const allocation = await recordPaymentAllocationWithCtx(ctx, {
     actorUserId: args.signedInAthenaUser?.id,
     allocationType: "payment_on_delivery_collection",
     amount,
-    collectedInStore: true,
+    collectedInStore,
     customerProfileId,
     externalReference:
       args.order.externalTransactionId ?? args.order.externalReference,
     method: getOnlineOrderPaymentMethodLabel(args.order),
     onlineOrderId: args.order._id,
     organizationId,
+    registerSessionId: resolvedRegisterSessionId,
     storeId: args.order.storeId,
     targetId: args.order._id,
     targetType: "online_order",
@@ -324,6 +335,7 @@ export async function recordOnlineOrderPaymentCollected(
     onlineOrderId: args.order._id,
     organizationId,
     paymentAllocationId: allocation?._id,
+    registerSessionId: resolvedRegisterSessionId,
     reason: getOnlineOrderPaymentMethodLabel(args.order),
     storeId: args.order.storeId,
     subjectId: args.order._id,

--- a/packages/athena-webapp/convex/storeFront/onlineOrder.ts
+++ b/packages/athena-webapp/convex/storeFront/onlineOrder.ts
@@ -84,6 +84,7 @@ async function applyOnlineOrderUpdate(
   ctx: MutationCtx,
   order: Doc<"onlineOrder">,
   args: {
+    registerSessionId?: Id<"registerSession">;
     returnItemsToStock?: boolean;
     signedInAthenaUser?: SignedInAthenaUser;
     update: Record<string, any>;
@@ -192,6 +193,7 @@ async function applyOnlineOrderUpdate(
   if (paymentCollectedChanged) {
     await recordOnlineOrderPaymentCollected(ctx, {
       order: nextOrder,
+      registerSessionId: args.registerSessionId,
       signedInAthenaUser: args.signedInAthenaUser,
     });
   }
@@ -573,6 +575,7 @@ export const update = mutation({
   args: {
     orderId: v.optional(v.id("onlineOrder")),
     externalReference: v.optional(v.string()),
+    registerSessionId: v.optional(v.id("registerSession")),
     update: v.record(v.string(), v.any()),
     returnItemsToStock: v.optional(v.boolean()),
     signedInAthenaUser: v.optional(
@@ -650,6 +653,7 @@ export const updateInternal = internalMutation({
   args: {
     orderId: v.optional(v.id("onlineOrder")),
     externalReference: v.optional(v.string()),
+    registerSessionId: v.optional(v.id("registerSession")),
     update: v.record(v.string(), v.any()),
     returnItemsToStock: v.optional(v.boolean()),
     signedInAthenaUser: v.optional(

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -16,7 +16,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Backend and test surfaces
 
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 274 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 276 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 6 file(s); key children: README.md, SUMMARY.md, pos.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -15,6 +15,7 @@ This index enumerates the current automated test files and ties them back to the
 
 ## Section `convex`
 
+- [`convex/cashControls/paymentAllocationAttribution.test.ts`](../../convex/cashControls/paymentAllocationAttribution.test.ts)
 - [`convex/cashControls/registerSessions.test.ts`](../../convex/cashControls/registerSessions.test.ts)
 - [`convex/convexAuditScript.test.ts`](../../convex/convexAuditScript.test.ts)
 - [`convex/http/domains/storeFront/routes/security.test.ts`](../../convex/http/domains/storeFront/routes/security.test.ts)


### PR DESCRIPTION
## Summary
- add a shared in-store payment-allocation attribution helper that normalizes split-tender cash and resolves the correct register session when cash is actually collected in store
- record retail sale and void allocations from POS, and thread register-session attribution through walk-in service intake, service case payments, and pickup order collection flows
- add focused regression coverage for attribution rules and refresh generated harness and Graphify artifacts required by the repo

## Why
- the next cash-control tickets need payment allocations to become the authoritative source for which register session collected each in-store tender
- delivery and non-walk-in deposits should stay out of drawer closeouts so later variance and deposit workflows are based on real in-register cash movement

## Validation
- `bun run --filter @athena/webapp test -- convex/cashControls/paymentAllocationAttribution.test.ts convex/operations/serviceIntake.test.ts convex/storeFront/orderOperations.test.ts convex/storeFront/helperOrchestration.test.ts convex/serviceOps/serviceCases.test.ts`
- `bun run --filter @athena/webapp test`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run --filter @athena/webapp audit:convex`
- `bun run graphify:rebuild`
- `bun run harness:generate`
- `bun run pr:athena`

Linear: https://linear.app/yaegars/issue/V26-292
