### PR TITLE
[V26-299]: Route warning: exclude Athena login readiness test from the route tree

### DIFF
--- a/packages/athena-webapp/vite.config.ts
+++ b/packages/athena-webapp/vite.config.ts
@@ -28,7 +28,13 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: (mode === "test"
     ? [react()]
-    : [TanStackRouterVite(), react()]) as any,
+    : [
+        TanStackRouterVite({
+          // Keep colocated route tests out of route generation.
+          routeFileIgnorePattern: "\\.test\\.",
+        }),
+        react(),
+      ]) as any,
   resolve: {
     alias: {
       "~": __dirname,


### PR DESCRIPTION
## Summary
- configure TanStack Router in `packages/athena-webapp/vite.config.ts` to ignore colocated `.test.` files during route generation
- preserve the existing login readiness test and route component without renaming files or changing the runtime route tree
- keep the fix scoped to the Athena build warning only

## Why
- `bun run --filter '@athena/webapp' build` warned that `src/routes/login/_layout.index.test.tsx` looked like a route file but exported no `Route`
- excluding `.test.` files at the router plugin layer removes the warning while preserving colocated route coverage

## Validation
- `bun run --filter '@athena/webapp' test src/routes/login/_layout.index.test.tsx`
- `bun run --filter '@athena/webapp' test`
- `bun run --filter '@athena/webapp' build`
- `bun run graphify:rebuild`
- `bun run graphify:check`
- `git diff --check`

Linear: https://linear.app/v26-labs/issue/V26-299/route-warning-exclude-athena-login-readiness-test-from-the-route-tree
