### PR TITLE
[V26-300]: Lay browser POS domain foundation for the layered register architecture

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1359 files · ~0 words
+- 1366 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3295 nodes · 2825 edges · 1275 communities detected
+- 3317 nodes · 2850 edges · 1282 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1285,6 +1285,13 @@
 - [[_COMMUNITY_Community 1272|Community 1272]]
 - [[_COMMUNITY_Community 1273|Community 1273]]
 - [[_COMMUNITY_Community 1274|Community 1274]]
+- [[_COMMUNITY_Community 1275|Community 1275]]
+- [[_COMMUNITY_Community 1276|Community 1276]]
+- [[_COMMUNITY_Community 1277|Community 1277]]
+- [[_COMMUNITY_Community 1278|Community 1278]]
+- [[_COMMUNITY_Community 1279|Community 1279]]
+- [[_COMMUNITY_Community 1280|Community 1280]]
+- [[_COMMUNITY_Community 1281|Community 1281]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1613,76 +1620,76 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 75 - "Community 75"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
 ### Community 76 - "Community 76"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 77 - "Community 77"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 78 - "Community 78"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.53
 Nodes (5): buildInStorePaymentAllocations(), isActiveRegisterSessionStatus(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 85 - "Community 85"
-Cohesion: 0.73
-Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 86 - "Community 86"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.73
+Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 87 - "Community 87"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 88 - "Community 88"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 89 - "Community 89"
 Cohesion: 0.4
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.4
 Nodes (2): buildUsername(), normalizeNameSegment()
-
-### Community 92 - "Community 92"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 93 - "Community 93"
 Cohesion: 0.33
@@ -1693,20 +1700,20 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 95 - "Community 95"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 96 - "Community 96"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 97 - "Community 97"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 98 - "Community 98"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 99 - "Community 99"
 Cohesion: 0.33
@@ -1721,51 +1728,51 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 102 - "Community 102"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 103 - "Community 103"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 104 - "Community 104"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 104 - "Community 104"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
 ### Community 105 - "Community 105"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 106 - "Community 106"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 107 - "Community 107"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 108 - "Community 108"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 110 - "Community 110"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 109 - "Community 109"
+### Community 111 - "Community 111"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 110 - "Community 110"
+### Community 112 - "Community 112"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 111 - "Community 111"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 112 - "Community 112"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 113 - "Community 113"
-Cohesion: 0.4
+Cohesion: 0.33
 Nodes (0):
 
 ### Community 114 - "Community 114"
@@ -1777,44 +1784,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 116 - "Community 116"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 117 - "Community 117"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 118 - "Community 118"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 117 - "Community 117"
+### Community 119 - "Community 119"
 Cohesion: 0.5
 Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
 
-### Community 118 - "Community 118"
+### Community 120 - "Community 120"
 Cohesion: 0.5
 Nodes (2): buildPaymentAllocation(), recordPaymentAllocationWithCtx()
 
-### Community 119 - "Community 119"
+### Community 121 - "Community 121"
 Cohesion: 0.6
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 120 - "Community 120"
+### Community 122 - "Community 122"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 121 - "Community 121"
+### Community 123 - "Community 123"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 122 - "Community 122"
+### Community 124 - "Community 124"
 Cohesion: 0.6
 Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 123 - "Community 123"
+### Community 125 - "Community 125"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 124 - "Community 124"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 125 - "Community 125"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 126 - "Community 126"
 Cohesion: 0.4
@@ -1825,16 +1832,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 128 - "Community 128"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 129 - "Community 129"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 130 - "Community 130"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 131 - "Community 131"
 Cohesion: 0.4
@@ -1842,7 +1849,7 @@ Nodes (0):
 
 ### Community 132 - "Community 132"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 133 - "Community 133"
 Cohesion: 0.4
@@ -1850,7 +1857,7 @@ Nodes (0):
 
 ### Community 134 - "Community 134"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 135 - "Community 135"
 Cohesion: 0.4
@@ -1873,124 +1880,124 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 140 - "Community 140"
-Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 141 - "Community 141"
 Cohesion: 0.4
-Nodes (1): MockImage
+Nodes (0):
 
 ### Community 142 - "Community 142"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
 ### Community 143 - "Community 143"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 144 - "Community 144"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 145 - "Community 145"
+Cohesion: 0.6
+Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
+
+### Community 146 - "Community 146"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 148 - "Community 148"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 149 - "Community 149"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 147 - "Community 147"
+### Community 150 - "Community 150"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 148 - "Community 148"
+### Community 151 - "Community 151"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 149 - "Community 149"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 150 - "Community 150"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 151 - "Community 151"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
 ### Community 152 - "Community 152"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 153 - "Community 153"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0):
 
 ### Community 154 - "Community 154"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 155 - "Community 155"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
 ### Community 156 - "Community 156"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 157 - "Community 157"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 158 - "Community 158"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 159 - "Community 159"
-Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 160 - "Community 160"
 Cohesion: 0.67
-Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 161 - "Community 161"
-Cohesion: 0.67
-Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
 ### Community 162 - "Community 162"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 163 - "Community 163"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
 ### Community 164 - "Community 164"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
 ### Community 165 - "Community 165"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 166 - "Community 166"
-Cohesion: 0.83
-Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 167 - "Community 167"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 168 - "Community 168"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 169 - "Community 169"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 170 - "Community 170"
 Cohesion: 0.5
@@ -2005,8 +2012,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 173 - "Community 173"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 174 - "Community 174"
 Cohesion: 0.5
@@ -2018,7 +2025,7 @@ Nodes (0):
 
 ### Community 176 - "Community 176"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 177 - "Community 177"
 Cohesion: 0.5
@@ -2029,8 +2036,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 179 - "Community 179"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 180 - "Community 180"
 Cohesion: 0.5
@@ -2041,48 +2048,48 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 182 - "Community 182"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), parseDateTimeLocal()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 183 - "Community 183"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 184 - "Community 184"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 185 - "Community 185"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 185 - "Community 185"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), parseDateTimeLocal()
 
 ### Community 186 - "Community 186"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 187 - "Community 187"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
+
+### Community 188 - "Community 188"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 189 - "Community 189"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 190 - "Community 190"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 188 - "Community 188"
+### Community 191 - "Community 191"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 189 - "Community 189"
+### Community 192 - "Community 192"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 190 - "Community 190"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 191 - "Community 191"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 192 - "Community 192"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 193 - "Community 193"
 Cohesion: 0.5
@@ -2097,59 +2104,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 196 - "Community 196"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 197 - "Community 197"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 198 - "Community 198"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 199 - "Community 199"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 197 - "Community 197"
+### Community 200 - "Community 200"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 198 - "Community 198"
+### Community 201 - "Community 201"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 199 - "Community 199"
+### Community 202 - "Community 202"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 200 - "Community 200"
+### Community 203 - "Community 203"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 201 - "Community 201"
+### Community 204 - "Community 204"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 202 - "Community 202"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
-
-### Community 203 - "Community 203"
-Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
-
-### Community 204 - "Community 204"
-Cohesion: 0.83
-Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.67
-Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 206 - "Community 206"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
 ### Community 207 - "Community 207"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.67
-Nodes (0):
+Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
 ### Community 209 - "Community 209"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 210 - "Community 210"
@@ -2157,8 +2164,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 211 - "Community 211"
-Cohesion: 1.0
-Nodes (2): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestWithCtx()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 212 - "Community 212"
 Cohesion: 0.67
@@ -2169,60 +2176,60 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 214 - "Community 214"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestWithCtx()
 
 ### Community 215 - "Community 215"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 216 - "Community 216"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 217 - "Community 217"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 218 - "Community 218"
-Cohesion: 0.67
-Nodes (1): View()
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 219 - "Community 219"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 220 - "Community 220"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 221 - "Community 221"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 222 - "Community 222"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 223 - "Community 223"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 224 - "Community 224"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 225 - "Community 225"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 226 - "Community 226"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 227 - "Community 227"
-Cohesion: 0.67
-Nodes (1): FadeIn()
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 228 - "Community 228"
 Cohesion: 0.67
@@ -2234,7 +2241,7 @@ Nodes (0):
 
 ### Community 230 - "Community 230"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (1): FadeIn()
 
 ### Community 231 - "Community 231"
 Cohesion: 0.67
@@ -2246,7 +2253,7 @@ Nodes (0):
 
 ### Community 233 - "Community 233"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 234 - "Community 234"
 Cohesion: 0.67
@@ -2286,83 +2293,83 @@ Nodes (0):
 
 ### Community 243 - "Community 243"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 244 - "Community 244"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 245 - "Community 245"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (0):
 
 ### Community 246 - "Community 246"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 248 - "Community 248"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 249 - "Community 249"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): DashboardSkeleton()
 
 ### Community 250 - "Community 250"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): TableSkeleton()
 
 ### Community 251 - "Community 251"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 252 - "Community 252"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): NotFound()
 
 ### Community 253 - "Community 253"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 254 - "Community 254"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): AppContextMenu()
 
 ### Community 255 - "Community 255"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): Badge()
 
 ### Community 256 - "Community 256"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): LoadingButton()
 
 ### Community 257 - "Community 257"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): onChange()
 
 ### Community 258 - "Community 258"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): AlertModal()
 
 ### Community 259 - "Community 259"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): OverlayModal()
 
 ### Community 260 - "Community 260"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Skeleton()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 263 - "Community 263"
 Cohesion: 0.67
@@ -2382,7 +2389,7 @@ Nodes (0):
 
 ### Community 267 - "Community 267"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 268 - "Community 268"
 Cohesion: 0.67
@@ -2394,7 +2401,7 @@ Nodes (0):
 
 ### Community 270 - "Community 270"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 271 - "Community 271"
 Cohesion: 0.67
@@ -2402,7 +2409,7 @@ Nodes (0):
 
 ### Community 272 - "Community 272"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 273 - "Community 273"
 Cohesion: 0.67
@@ -2410,67 +2417,67 @@ Nodes (0):
 
 ### Community 274 - "Community 274"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 275 - "Community 275"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 277 - "Community 277"
-Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 278 - "Community 278"
 Cohesion: 0.67
-Nodes (1): hashPassword()
+Nodes (0):
 
 ### Community 279 - "Community 279"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (0):
 
 ### Community 280 - "Community 280"
-Cohesion: 0.67
-Nodes (1): manualChunks()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 281 - "Community 281"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 282 - "Community 282"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (1): createVersionChecker()
 
 ### Community 283 - "Community 283"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 284 - "Community 284"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 285 - "Community 285"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 286 - "Community 286"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 287 - "Community 287"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 288 - "Community 288"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 289 - "Community 289"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 290 - "Community 290"
 Cohesion: 0.67
@@ -2481,12 +2488,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 292 - "Community 292"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 293 - "Community 293"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 294 - "Community 294"
 Cohesion: 0.67
@@ -2497,8 +2504,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 296 - "Community 296"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 297 - "Community 297"
 Cohesion: 0.67
@@ -2569,52 +2576,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 314 - "Community 314"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 315 - "Community 315"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 316 - "Community 316"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 317 - "Community 317"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 318 - "Community 318"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 319 - "Community 319"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 320 - "Community 320"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 321 - "Community 321"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 322 - "Community 322"
 Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 323 - "Community 323"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 324 - "Community 324"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 325 - "Community 325"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 326 - "Community 326"
 Cohesion: 1.0
@@ -6412,1910 +6419,1946 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1275 - "Community 1275"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1276 - "Community 1276"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1277 - "Community 1277"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1278 - "Community 1278"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1279 - "Community 1279"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1280 - "Community 1280"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1281 - "Community 1281"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 323`** (2 nodes): `getSource()`, `closeouts.test.ts`
+- **Thin community `Community 326`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 327`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 328`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 329`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 330`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 331`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 329`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 332`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 333`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 331`** (2 nodes): `authenticateHandler()`, `cashier.ts`
+- **Thin community `Community 334`** (2 nodes): `authenticateHandler()`, `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 332`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 335`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 336`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 334`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 337`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 335`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 338`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 336`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 339`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 337`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 340`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 338`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 341`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 339`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 342`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 340`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 343`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 341`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 344`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 342`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
+- **Thin community `Community 345`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 343`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
+- **Thin community `Community 346`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 344`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 347`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 345`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 348`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 346`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 349`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 347`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 350`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 348`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 351`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 349`** (2 nodes): `receiving.test.ts`, `getSource()`
+- **Thin community `Community 352`** (2 nodes): `receiving.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 350`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 353`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 351`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 354`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 352`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 355`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 356`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 357`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 358`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 359`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 360`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 361`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 362`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 363`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 364`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 365`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 366`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 367`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 368`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 369`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 370`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 371`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 372`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 373`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 374`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 375`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 376`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 377`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 378`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 379`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 380`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 381`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 382`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 383`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 384`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 385`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 386`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 387`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 388`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 389`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 390`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 391`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 392`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 393`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 394`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 395`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 396`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 397`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 398`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 399`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 400`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 401`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 402`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 403`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 404`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 405`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 406`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 407`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 408`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 409`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 410`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 411`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 412`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 413`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 414`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
+- **Thin community `Community 415`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 416`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 417`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 418`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 419`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 420`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
+- **Thin community `Community 421`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 422`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 423`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 424`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 425`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 426`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 427`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 428`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
+- **Thin community `Community 429`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 430`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 431`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 432`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `usePOSCashier()`, `hooks.ts`
+- **Thin community `Community 433`** (2 nodes): `usePOSCashier()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
+- **Thin community `Community 434`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
+- **Thin community `Community 435`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 436`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 437`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 438`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 439`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 440`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 441`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 442`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 443`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 444`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 445`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 446`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 447`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 448`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 449`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 450`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 451`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 452`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 453`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
+- **Thin community `Community 454`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 455`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 456`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 457`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 458`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 459`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 460`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 461`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 462`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 463`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 464`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 465`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 466`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 467`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 468`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 469`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
+- **Thin community `Community 470`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 471`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 472`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 473`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 474`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 475`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 476`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 477`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 478`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 479`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 480`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 481`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 482`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 483`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 484`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 485`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 486`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 487`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 488`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 489`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 490`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 491`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 492`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 493`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 494`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 495`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 496`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
+- **Thin community `Community 497`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 498`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 499`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
+- **Thin community `Community 500`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 501`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 502`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 503`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 504`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 505`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 506`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 507`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 508`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 509`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 510`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 511`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 512`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 513`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 514`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
+- **Thin community `Community 515`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 516`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
+- **Thin community `Community 517`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 518`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 519`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 520`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 521`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 522`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 523`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
+- **Thin community `Community 524`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 525`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 526`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 527`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 528`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 529`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 530`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 531`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `LoginLayout()`, `_layout.tsx`
+- **Thin community `Community 532`** (2 nodes): `LoginLayout()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 533`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 534`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 535`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 536`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 537`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 538`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 539`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 540`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 541`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 542`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 543`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 544`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 545`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 546`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 547`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 548`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 549`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 550`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 551`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 552`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 553`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 554`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 555`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 556`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 557`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 558`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 559`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 560`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 561`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 562`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 563`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 564`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 565`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 566`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 567`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 568`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 569`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 570`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 571`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 572`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 573`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 574`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 575`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 576`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 577`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 578`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 579`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 580`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 581`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 582`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 583`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 584`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 585`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 586`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 587`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 588`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 589`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 590`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 591`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 592`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 593`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 594`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 595`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 596`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 597`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 598`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 599`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 600`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 601`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 602`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 603`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 604`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 605`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 606`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 607`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 608`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 609`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 610`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 611`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 612`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 613`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 614`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 615`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 616`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 617`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 618`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 619`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 620`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 621`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 622`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 623`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 624`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 625`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 626`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 627`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 628`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 629`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 630`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 631`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 632`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 633`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 634`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 635`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 636`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 637`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 638`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 639`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 640`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 641`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 642`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 643`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 644`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 645`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 646`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 647`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 648`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 649`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 650`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 651`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 652`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 653`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 654`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 655`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 656`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 657`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 658`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 659`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 660`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 661`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (1 nodes): `api.d.ts`
+- **Thin community `Community 662`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (1 nodes): `api.js`
+- **Thin community `Community 663`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 664`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (1 nodes): `server.d.ts`
+- **Thin community `Community 665`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (1 nodes): `server.js`
+- **Thin community `Community 666`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (1 nodes): `app.ts`
+- **Thin community `Community 667`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (1 nodes): `auth.config.js`
+- **Thin community `Community 668`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (1 nodes): `auth.ts`
+- **Thin community `Community 669`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 670`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (1 nodes): `countries.ts`
+- **Thin community `Community 671`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (1 nodes): `email.ts`
+- **Thin community `Community 672`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `ghana.ts`
+- **Thin community `Community 673`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `payment.ts`
+- **Thin community `Community 674`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `crons.ts`
+- **Thin community `Community 675`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 676`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 677`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 678`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 679`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `env.ts`
+- **Thin community `Community 680`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `analytics.ts`
+- **Thin community `Community 681`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `auth.ts`
+- **Thin community `Community 682`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 683`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `categories.ts`
+- **Thin community `Community 684`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `colors.ts`
+- **Thin community `Community 685`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `index.ts`
+- **Thin community `Community 686`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `organizations.ts`
+- **Thin community `Community 687`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `products.ts`
+- **Thin community `Community 688`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `stores.ts`
+- **Thin community `Community 689`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `subcategories.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `index.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `bag.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `guest.ts`
+- **Thin community `Community 690`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 691`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `me.ts`
+- **Thin community `Community 692`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `offers.ts`
+- **Thin community `Community 693`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 694`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `paystack.ts`
+- **Thin community `Community 695`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `reviews.ts`
+- **Thin community `Community 696`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `rewards.ts`
+- **Thin community `Community 697`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 698`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `security.test.ts`
+- **Thin community `Community 699`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `storefront.ts`
+- **Thin community `Community 700`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `upsells.ts`
+- **Thin community `Community 701`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `user.ts`
+- **Thin community `Community 702`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 703`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `health.test.ts`
+- **Thin community `Community 704`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `http.ts`
+- **Thin community `Community 705`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 706`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `auth.ts`
+- **Thin community `Community 707`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 708`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 709`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `categories.ts`
+- **Thin community `Community 710`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `colors.ts`
+- **Thin community `Community 711`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 712`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 713`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 714`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 715`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 716`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 717`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `organizations.ts`
+- **Thin community `Community 718`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 719`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 720`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 721`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `productSku.ts`
+- **Thin community `Community 722`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 723`** (1 nodes): `posSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 724`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 725`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 726`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 727`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 728`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 729`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 730`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 731`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `client.test.ts`
+- **Thin community `Community 732`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `config.test.ts`
+- **Thin community `Community 733`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 734`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `types.ts`
+- **Thin community `Community 735`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 736`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 737`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 738`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `staffProfiles.test.ts`
+- **Thin community `Community 739`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `ResendOTP.ts`
+- **Thin community `Community 740`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `schema.ts`
+- **Thin community `Community 741`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 742`** (1 nodes): `staffProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 743`** (1 nodes): `ResendOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 744`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 745`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `cashier.ts`
+- **Thin community `Community 746`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `category.ts`
+- **Thin community `Community 747`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `color.ts`
+- **Thin community `Community 748`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 749`** (1 nodes): `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 750`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `index.ts`
+- **Thin community `Community 751`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 752`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `organization.ts`
+- **Thin community `Community 753`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 754`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `product.ts`
+- **Thin community `Community 755`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 756`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 757`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `store.ts`
+- **Thin community `Community 758`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 759`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 760`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 761`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `index.ts`
+- **Thin community `Community 762`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 763`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 764`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 765`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 766`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 767`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 768`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 769`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 770`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `customer.ts`
+- **Thin community `Community 771`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 772`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 773`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 774`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 775`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `index.ts`
+- **Thin community `Community 776`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `posSession.ts`
+- **Thin community `Community 777`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 778`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 779`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 780`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 781`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `index.ts`
+- **Thin community `Community 782`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 783`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 784`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 785`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 786`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 787`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `index.ts`
+- **Thin community `Community 788`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 789`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 790`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 791`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 792`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `vendor.ts`
+- **Thin community `Community 793`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `analytics.ts`
+- **Thin community `Community 794`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `bag.ts`
+- **Thin community `Community 795`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 796`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 797`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 798`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `customer.ts`
+- **Thin community `Community 799`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `guest.ts`
+- **Thin community `Community 800`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `index.ts`
+- **Thin community `Community 801`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `offer.ts`
+- **Thin community `Community 802`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 803`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 804`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `review.ts`
+- **Thin community `Community 805`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `rewards.ts`
+- **Thin community `Community 806`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 807`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 808`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 809`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 810`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 811`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 812`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 813`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `bag.ts`
+- **Thin community `Community 814`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 815`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `customer.ts`
+- **Thin community `Community 816`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `guest.ts`
+- **Thin community `Community 817`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 818`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 819`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `payment.ts`
+- **Thin community `Community 820`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 821`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 822`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 823`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `users.ts`
+- **Thin community `Community 824`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `payment.ts`
+- **Thin community `Community 825`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 826`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `index.ts`
+- **Thin community `Community 827`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 828`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 829`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 830`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 831`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 832`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 833`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 834`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `constants.ts`
+- **Thin community `Community 835`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 836`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 837`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 838`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `types.ts`
+- **Thin community `Community 839`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 840`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 841`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 842`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 843`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 844`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 845`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 846`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 847`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `columns.tsx`
+- **Thin community `Community 848`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 849`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 850`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 851`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 852`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `columns.tsx`
+- **Thin community `Community 853`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 854`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 855`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `chart.tsx`
+- **Thin community `Community 856`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `columns.tsx`
+- **Thin community `Community 857`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 858`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 859`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 860`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `constants.ts`
+- **Thin community `Community 861`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 862`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 863`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 864`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `data.ts`
+- **Thin community `Community 865`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `columns.tsx`
+- **Thin community `Community 866`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 867`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 868`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 869`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 870`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 871`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 872`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 873`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 874`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 875`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 876`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `constants.ts`
+- **Thin community `Community 877`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 878`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 879`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 880`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `data.ts`
+- **Thin community `Community 881`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 882`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 883`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 884`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 885`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `columns.tsx`
+- **Thin community `Community 886`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 887`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 888`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 889`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 890`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 891`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `columns.tsx`
+- **Thin community `Community 892`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `constants.ts`
+- **Thin community `Community 893`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 894`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 895`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 896`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 897`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 898`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `RegisterCloseoutView.test.tsx`
+- **Thin community `Community 899`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 900`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `index.tsx`
+- **Thin community `Community 901`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `columns.tsx`
+- **Thin community `Community 902`** (1 nodes): `RegisterCloseoutView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 903`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 904`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 905`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 906`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 907`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 908`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 909`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 910`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 911`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 912`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 913`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `constants.ts`
+- **Thin community `Community 914`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 915`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 916`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 917`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `data.ts`
+- **Thin community `Community 918`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 919`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `constants.ts`
+- **Thin community `Community 920`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 921`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 922`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 923`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 924`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `data.ts`
+- **Thin community `Community 925`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 926`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `constants.ts`
+- **Thin community `Community 927`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 928`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 929`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 930`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 931`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `data.ts`
+- **Thin community `Community 932`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 933`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 934`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 935`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 936`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 937`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 938`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 939`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 940`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 941`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 942`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 943`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `types.ts`
+- **Thin community `Community 944`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 945`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 946`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 947`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 948`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 949`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 950`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 951`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 952`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 953`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `Products.tsx`
+- **Thin community `Community 954`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 955`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 956`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 957`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 958`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 959`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 960`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 961`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 962`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 963`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `data.ts`
+- **Thin community `Community 964`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 965`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `PromoCodePreview.tsx`
+- **Thin community `Community 966`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 967`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 968`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 969`** (1 nodes): `PromoCodePreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `columns.tsx`
+- **Thin community `Community 970`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 971`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 972`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 973`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 974`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 975`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `columns.tsx`
+- **Thin community `Community 976`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `constants.ts`
+- **Thin community `Community 977`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 978`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 979`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 980`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `data.ts`
+- **Thin community `Community 981`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `types.ts`
+- **Thin community `Community 982`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 983`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 984`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 985`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 986`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `ServiceAppointmentsView.test.tsx`
+- **Thin community `Community 987`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `ServiceCasesView.test.tsx`
+- **Thin community `Community 988`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `ServiceCatalogView.test.tsx`
+- **Thin community `Community 989`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `ServiceIntakeView.test.tsx`
+- **Thin community `Community 990`** (1 nodes): `ServiceAppointmentsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 991`** (1 nodes): `ServiceCasesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `index.tsx`
+- **Thin community `Community 992`** (1 nodes): `ServiceCatalogView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 993`** (1 nodes): `ServiceIntakeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 994`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `button.tsx`
+- **Thin community `Community 995`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 996`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `card.tsx`
+- **Thin community `Community 997`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 998`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 999`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `command.tsx`
+- **Thin community `Community 1000`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1001`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1002`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1003`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `form.tsx`
+- **Thin community `Community 1004`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1005`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1006`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `input.tsx`
+- **Thin community `Community 1007`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1008`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1009`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1010`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1011`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1012`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `select.tsx`
+- **Thin community `Community 1013`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1014`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1015`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1016`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `table.tsx`
+- **Thin community `Community 1017`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1018`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1019`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1020`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1021`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1022`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1023`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1024`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1025`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `constants.ts`
+- **Thin community `Community 1026`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1027`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1028`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1029`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `data.ts`
+- **Thin community `Community 1030`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1031`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1032`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1033`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1034`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1035`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1036`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1037`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1038`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1039`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1040`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1041`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1042`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1043`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `index.ts`
+- **Thin community `Community 1044`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `config.ts`
+- **Thin community `Community 1045`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1046`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1047`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1048`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `aws.ts`
+- **Thin community `Community 1049`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `constants.ts`
+- **Thin community `Community 1050`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `countries.ts`
+- **Thin community `Community 1051`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1052`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1053`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `constants.ts`
+- **Thin community `Community 1054`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1055`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1056`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `category.ts`
+- **Thin community `Community 1057`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `product.ts`
+- **Thin community `Community 1058`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `store.ts`
+- **Thin community `Community 1059`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1060`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `user.ts`
+- **Thin community `Community 1061`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1062`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1063`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1064`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1065`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `index.tsx`
+- **Thin community `Community 1066`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `index.tsx`
+- **Thin community `Community 1067`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `index.tsx`
+- **Thin community `Community 1068`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1069`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1070`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1071`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1072`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1073`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1074`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1075`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1076`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1077`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `home.tsx`
+- **Thin community `Community 1078`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1079`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1080`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1081`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `index.tsx`
+- **Thin community `Community 1082`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `index.tsx`
+- **Thin community `Community 1083`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1084`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1085`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1086`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `index.tsx`
+- **Thin community `Community 1087`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1088`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1089`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1090`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1091`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1092`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1093`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1094`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `index.tsx`
+- **Thin community `Community 1095`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1096`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1097`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1098`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1099`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1100`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1101`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1102`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `index.tsx`
+- **Thin community `Community 1103`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `new.tsx`
+- **Thin community `Community 1104`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `index.tsx`
+- **Thin community `Community 1105`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `new.tsx`
+- **Thin community `Community 1106`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1107`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1108`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1109`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `new.tsx`
+- **Thin community `Community 1110`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `index.tsx`
+- **Thin community `Community 1111`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1112`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1113`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1114`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1115`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1116`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1117`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1118`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1119`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1120`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1121`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1122`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `posStore.ts`
+- **Thin community `Community 1123`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1124`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1125`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1126`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1127`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1128`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1129`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1130`** (1 nodes): `posStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1131`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1132`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1133`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1134`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1135`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `setup.ts`
+- **Thin community `Community 1136`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1137`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1138`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `types.ts`
+- **Thin community `Community 1139`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1140`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1141`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1142`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1143`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1144`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1145`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1146`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1147`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1148`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1149`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1150`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1151`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1152`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1153`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1154`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1155`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `schema.ts`
+- **Thin community `Community 1156`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1157`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1158`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1159`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1160`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1161`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1162`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1163`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1164`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1165`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `types.ts`
+- **Thin community `Community 1166`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1167`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1168`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1169`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1170`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1171`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1172`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1173`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `constants.ts`
+- **Thin community `Community 1174`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1175`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `About.tsx`
+- **Thin community `Community 1176`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1177`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1178`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1179`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1180`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1181`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1182`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1183`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1184`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1185`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `types.ts`
+- **Thin community `Community 1186`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1187`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1188`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1189`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1190`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1191`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1192`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1193`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1194`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1195`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1196`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `button.tsx`
+- **Thin community `Community 1197`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `card.tsx`
+- **Thin community `Community 1198`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1199`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `command.tsx`
+- **Thin community `Community 1200`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1201`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1202`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1203`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `form.tsx`
+- **Thin community `Community 1204`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1205`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1206`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1207`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1208`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `input.tsx`
+- **Thin community `Community 1209`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `label.tsx`
+- **Thin community `Community 1210`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1211`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1212`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1213`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `index.ts`
+- **Thin community `Community 1214`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `types.ts`
+- **Thin community `Community 1215`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1216`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1217`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1218`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1219`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `select.tsx`
+- **Thin community `Community 1220`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1221`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1222`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `table.tsx`
+- **Thin community `Community 1223`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1224`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1225`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1226`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1227`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1228`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `config.ts`
+- **Thin community `Community 1229`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1230`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1231`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1232`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `constants.ts`
+- **Thin community `Community 1233`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `countries.ts`
+- **Thin community `Community 1234`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1235`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1236`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1237`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1238`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `index.ts`
+- **Thin community `Community 1239`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `store.ts`
+- **Thin community `Community 1240`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `bag.ts`
+- **Thin community `Community 1241`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1242`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `category.ts`
+- **Thin community `Community 1243`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `organization.ts`
+- **Thin community `Community 1244`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `product.ts`
+- **Thin community `Community 1245`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `store.ts`
+- **Thin community `Community 1246`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1247`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `user.ts`
+- **Thin community `Community 1248`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `states.ts`
+- **Thin community `Community 1249`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1250`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1251`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1252`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1253`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1254`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1255`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1256`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `index.tsx`
+- **Thin community `Community 1257`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1258`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `index.tsx`
+- **Thin community `Community 1259`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1260`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1261`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1262`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1263`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1264`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `index.tsx`
+- **Thin community `Community 1265`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1266`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1267`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1268`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1269`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `index.js`
+- **Thin community `Community 1270`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1271`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1272`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1273`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1274`** (1 nodes): `tailwind.config.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1275`** (1 nodes): `vitest.config.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1276`** (1 nodes): `vitest.setup.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1277`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1278`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1279`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1280`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1281`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -532,6 +532,30 @@
       "weight": 1
     },
     {
+      "_src": "cart_calculateposcarttotals",
+      "_tgt": "cart_roundposamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cart_calculateposcarttotals",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L23",
+      "target": "cart_roundposamount",
+      "weight": 1
+    },
+    {
+      "_src": "cart_calculatepositemtotal",
+      "_tgt": "cart_roundposamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "cart_calculatepositemtotal",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L30",
+      "target": "cart_roundposamount",
+      "weight": 1
+    },
+    {
       "_src": "cashcontrolsdashboard_summarystrip",
       "_tgt": "cashcontrolsdashboard_formatcurrency",
       "confidence": "EXTRACTED",
@@ -19204,6 +19228,186 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
+      "_tgt": "cart_calculateposcarttotals",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L3",
+      "target": "cart_calculateposcarttotals",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
+      "_tgt": "cart_calculatepositemtotal",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L29",
+      "target": "cart_calculatepositemtotal",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
+      "_tgt": "cart_getposeffectiveprice",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L33",
+      "target": "cart_getposeffectiveprice",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
+      "_tgt": "cart_roundposamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L40",
+      "target": "cart_roundposamount",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "_tgt": "payments_calculateposchange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3",
+      "target": "payments_calculateposchange",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "_tgt": "payments_calculateposremainingdue",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20",
+      "target": "payments_calculateposremainingdue",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "_tgt": "payments_calculatepostotalpaid",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14",
+      "target": "payments_calculatepostotalpaid",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "_tgt": "payments_ispospaymentsufficient",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7",
+      "target": "payments_ispospaymentsufficient",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "_tgt": "payments_roundposamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L27",
+      "target": "payments_roundposamount",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "_tgt": "session_deriveregisterphase",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3",
+      "target": "session_deriveregisterphase",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "_tgt": "session_hasactiveregistersession",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33",
+      "target": "session_hasactiveregistersession",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "_tgt": "session_hasresumableregistersession",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39",
+      "target": "session_hasresumableregistersession",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "_tgt": "session_isregisterreadytostart",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45",
+      "target": "session_isregisterreadytostart",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "_tgt": "session_requirescashier",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29",
+      "target": "session_requirescashier",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "_tgt": "session_requiresterminal",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25",
+      "target": "session_requiresterminal",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
       "_tgt": "calculationservice_calculatecarttotals",
       "confidence": "EXTRACTED",
@@ -19211,7 +19415,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L30",
+      "source_location": "L28",
       "target": "calculationservice_calculatecarttotals",
       "weight": 1
     },
@@ -19223,7 +19427,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L68",
+      "source_location": "L42",
       "target": "calculationservice_calculatechange",
       "weight": 1
     },
@@ -19235,7 +19439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L61",
+      "source_location": "L35",
       "target": "calculationservice_calculateitemtotal",
       "weight": 1
     },
@@ -19247,7 +19451,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L75",
+      "source_location": "L49",
       "target": "calculationservice_formatcurrency",
       "weight": 1
     },
@@ -19259,7 +19463,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L96",
+      "source_location": "L70",
       "target": "calculationservice_geteffectiveprice",
       "weight": 1
     },
@@ -19271,7 +19475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L85",
+      "source_location": "L59",
       "target": "calculationservice_ispaymentsufficient",
       "weight": 1
     },
@@ -26512,6 +26716,42 @@
       "weight": 1
     },
     {
+      "_src": "payments_calculateposchange",
+      "_tgt": "payments_roundposamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "payments_calculateposchange",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L4",
+      "target": "payments_roundposamount",
+      "weight": 1
+    },
+    {
+      "_src": "payments_calculateposremainingdue",
+      "_tgt": "payments_roundposamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "payments_calculateposremainingdue",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L24",
+      "target": "payments_roundposamount",
+      "weight": 1
+    },
+    {
+      "_src": "payments_calculatepostotalpaid",
+      "_tgt": "payments_roundposamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "payments_calculatepostotalpaid",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L15",
+      "target": "payments_roundposamount",
+      "weight": 1
+    },
+    {
       "_src": "paystackservice_initializetransaction",
       "_tgt": "paystackservice_getpaystackheaders",
       "confidence": "EXTRACTED",
@@ -31972,6 +32212,66 @@
       "weight": 1
     },
     {
+      "_src": "session_hasactiveregistersession",
+      "_tgt": "session_deriveregisterphase",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "session_deriveregisterphase",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L36",
+      "target": "session_hasactiveregistersession",
+      "weight": 1
+    },
+    {
+      "_src": "session_hasresumableregistersession",
+      "_tgt": "session_deriveregisterphase",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "session_deriveregisterphase",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L42",
+      "target": "session_hasresumableregistersession",
+      "weight": 1
+    },
+    {
+      "_src": "session_isregisterreadytostart",
+      "_tgt": "session_deriveregisterphase",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "session_deriveregisterphase",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L46",
+      "target": "session_isregisterreadytostart",
+      "weight": 1
+    },
+    {
+      "_src": "session_requirescashier",
+      "_tgt": "session_deriveregisterphase",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "session_deriveregisterphase",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L30",
+      "target": "session_requirescashier",
+      "weight": 1
+    },
+    {
+      "_src": "session_requiresterminal",
+      "_tgt": "session_deriveregisterphase",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "session_deriveregisterphase",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L26",
+      "target": "session_requiresterminal",
+      "weight": 1
+    },
+    {
       "_src": "sessionvalidation_validatecustomerinfo",
       "_tgt": "sessionvalidation_isvalidemail",
       "confidence": "EXTRACTED",
@@ -34926,59 +35226,86 @@
     {
       "community": 100,
       "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
+      "label": "usePOSCustomers.ts",
+      "norm_label": "useposcustomers.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L1"
     },
     {
+      "community": 100,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomer",
+      "label": "usePOSCustomer()",
+      "norm_label": "useposcustomer()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomercreate",
+      "label": "usePOSCustomerCreate()",
+      "norm_label": "useposcustomercreate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomersearch",
+      "label": "usePOSCustomerSearch()",
+      "norm_label": "useposcustomersearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomertransactions",
+      "label": "usePOSCustomerTransactions()",
+      "norm_label": "useposcustomertransactions()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomerupdate",
+      "label": "usePOSCustomerUpdate()",
+      "norm_label": "useposcustomerupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L57"
+    },
+    {
       "community": 1000,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_card_tsx",
+      "label": "card.tsx",
+      "norm_label": "card.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
+      "label": "collapsible.tsx",
+      "norm_label": "collapsible.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -34987,7 +35314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -34996,7 +35323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -35005,7 +35332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -35014,7 +35341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -35023,7 +35350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -35032,7 +35359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -35041,7 +35368,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 101,
+      "file_type": "code",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1010,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -35050,7 +35431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1011,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -35059,7 +35440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1009,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -35068,61 +35449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 101,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
-    },
-    {
-      "community": 1010,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -35131,7 +35458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -35140,7 +35467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -35149,7 +35476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -35158,7 +35485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -35167,7 +35494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -35176,7 +35503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -35185,7 +35512,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 102,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 1020,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -35194,7 +35575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1021,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -35203,7 +35584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1019,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -35212,61 +35593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 102,
-      "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L198"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L71"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1020,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -35275,7 +35602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -35284,7 +35611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -35293,7 +35620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -35302,7 +35629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -35311,7 +35638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -35320,7 +35647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -35329,7 +35656,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 103,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 1030,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -35338,7 +35719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1031,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -35347,7 +35728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1029,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -35356,61 +35737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 103,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L232"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "storesettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 1030,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -35419,7 +35746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -35428,7 +35755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -35437,7 +35764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -35446,7 +35773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -35455,7 +35782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -35464,7 +35791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -35473,7 +35800,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 104,
+      "file_type": "code",
+      "id": "organizationsettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L198"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L71"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1040,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -35482,7 +35863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1041,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -35491,7 +35872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1039,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -35500,61 +35881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 104,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 1040,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -35563,7 +35890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -35572,7 +35899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -35581,7 +35908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -35590,7 +35917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -35599,7 +35926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -35608,7 +35935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -35617,7 +35944,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 105,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L232"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 1050,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -35626,7 +36007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1051,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -35635,7 +36016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1049,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
@@ -35644,61 +36025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 105,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 1050,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -35707,7 +36034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -35716,7 +36043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -35725,7 +36052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -35734,7 +36061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -35743,7 +36070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -35752,7 +36079,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1059,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
+      "label": "cart.test.ts",
+      "norm_label": "cart.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 1060,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
+      "label": "session.test.ts",
+      "norm_label": "session.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1062,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -35761,7 +36178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -35770,7 +36187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -35779,7 +36196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1059,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -35788,61 +36205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 106,
-      "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1060,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -35851,7 +36214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -35860,7 +36223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -35869,7 +36232,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 107,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 1070,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -35878,7 +36295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1071,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -35887,7 +36304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -35896,7 +36313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -35905,7 +36322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -35914,7 +36331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -35923,7 +36340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1069,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -35932,61 +36349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 107,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1070,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -35995,7 +36358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -36004,7 +36367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -36013,7 +36376,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 108,
+      "file_type": "code",
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1080,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -36022,7 +36439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1081,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -36031,7 +36448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -36040,7 +36457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -36049,7 +36466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -36058,7 +36475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -36067,7 +36484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1079,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -36076,61 +36493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 108,
-      "file_type": "code",
-      "id": "feeutils_getremainingforfreedelivery",
-      "label": "getRemainingForFreeDelivery()",
-      "norm_label": "getremainingforfreedelivery()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "feeutils_haswaiverconfigured",
-      "label": "hasWaiverConfigured()",
-      "norm_label": "haswaiverconfigured()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "feeutils_isanyfeewaived",
-      "label": "isAnyFeeWaived()",
-      "norm_label": "isanyfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "feeutils_isfeewaived",
-      "label": "isFeeWaived()",
-      "norm_label": "isfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "feeutils_meetsthreshold",
-      "label": "meetsThreshold()",
-      "norm_label": "meetsthreshold()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
-      "label": "feeUtils.ts",
-      "norm_label": "feeutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1080,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -36139,7 +36502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -36148,7 +36511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
@@ -36157,7 +36520,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 109,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1090,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -36166,7 +36583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1091,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -36175,7 +36592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -36184,7 +36601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -36193,7 +36610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -36202,7 +36619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -36211,7 +36628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1089,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -36220,61 +36637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 109,
-      "file_type": "code",
-      "id": "auth_verify_formattime",
-      "label": "formatTime()",
-      "norm_label": "formattime()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L149"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "auth_verify_handlecodechange",
-      "label": "handleCodeChange()",
-      "norm_label": "handlecodechange()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "auth_verify_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "auth_verify_reportauthfailure",
-      "label": "reportAuthFailure()",
-      "norm_label": "reportauthfailure()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "auth_verify_resendverificationcode",
-      "label": "resendVerificationCode()",
-      "norm_label": "resendverificationcode()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L282"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
-      "label": "auth.verify.tsx",
-      "norm_label": "auth.verify.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1090,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -36283,7 +36646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -36292,75 +36655,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
       "norm_label": "$reportid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1093,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
-      "label": "expense-reports.index.tsx",
-      "norm_label": "expense-reports.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1094,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
-      "label": "expense.index.tsx",
-      "norm_label": "expense.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1095,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1096,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
-      "label": "register.index.tsx",
-      "norm_label": "register.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1097,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
-      "label": "settings.index.tsx",
-      "norm_label": "settings.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1098,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
-      "label": "$transactionId.tsx",
-      "norm_label": "$transactionid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
-      "label": "transactions.index.tsx",
-      "norm_label": "transactions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
       "source_location": "L1"
     },
     {
@@ -36546,59 +36846,122 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "graphify_check_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L72"
+      "id": "feeutils_getremainingforfreedelivery",
+      "label": "getRemainingForFreeDelivery()",
+      "norm_label": "getremainingforfreedelivery()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L138"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "graphify_check_collectstalegraphifyartifacts",
-      "label": "collectStaleGraphifyArtifacts()",
-      "norm_label": "collectstalegraphifyartifacts()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L124"
+      "id": "feeutils_haswaiverconfigured",
+      "label": "hasWaiverConfigured()",
+      "norm_label": "haswaiverconfigured()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L100"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "graphify_check_copygraphifycheckinputs",
-      "label": "copyGraphifyCheckInputs()",
-      "norm_label": "copygraphifycheckinputs()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L106"
+      "id": "feeutils_isanyfeewaived",
+      "label": "isAnyFeeWaived()",
+      "norm_label": "isanyfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L74"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "graphify_check_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L63"
+      "id": "feeutils_isfeewaived",
+      "label": "isFeeWaived()",
+      "norm_label": "isfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L34"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "graphify_check_rungraphifycheck",
-      "label": "runGraphifyCheck()",
-      "norm_label": "rungraphifycheck()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L151"
+      "id": "feeutils_meetsthreshold",
+      "label": "meetsThreshold()",
+      "norm_label": "meetsthreshold()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L17"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "scripts_graphify_check_ts",
-      "label": "graphify-check.ts",
-      "norm_label": "graphify-check.ts",
-      "source_file": "scripts/graphify-check.ts",
+      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
+      "label": "feeUtils.ts",
+      "norm_label": "feeutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 1100,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
+      "label": "expense-reports.index.tsx",
+      "norm_label": "expense-reports.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
+      "label": "expense.index.tsx",
+      "norm_label": "expense.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1102,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1103,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
+      "label": "register.index.tsx",
+      "norm_label": "register.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1104,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
+      "label": "settings.index.tsx",
+      "norm_label": "settings.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1105,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
+      "label": "$transactionId.tsx",
+      "norm_label": "$transactionid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1106,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
+      "label": "transactions.index.tsx",
+      "norm_label": "transactions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -36607,7 +36970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -36616,7 +36979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -36625,7 +36988,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 111,
+      "file_type": "code",
+      "id": "auth_verify_formattime",
+      "label": "formatTime()",
+      "norm_label": "formattime()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L149"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "auth_verify_handlecodechange",
+      "label": "handleCodeChange()",
+      "norm_label": "handlecodechange()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "auth_verify_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "auth_verify_reportauthfailure",
+      "label": "reportAuthFailure()",
+      "norm_label": "reportauthfailure()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L93"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "auth_verify_resendverificationcode",
+      "label": "resendVerificationCode()",
+      "norm_label": "resendverificationcode()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L282"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
+      "label": "auth.verify.tsx",
+      "norm_label": "auth.verify.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1110,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -36634,7 +37051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1111,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -36643,7 +37060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -36652,7 +37069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -36661,7 +37078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -36670,7 +37087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -36679,7 +37096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1109,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -36688,61 +37105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 111,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
-      "label": "buildAthenaRuntimeUrl()",
-      "norm_label": "buildathenaruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
-      "label": "buildValkeyRuntimeUrl()",
-      "norm_label": "buildvalkeyruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
-      "label": "createAthenaRuntimeProcess()",
-      "norm_label": "createathenaruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
-      "label": "createStorefrontRuntimeProcesses()",
-      "norm_label": "createstorefrontruntimeprocesses()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
-      "label": "createValkeyRuntimeProcess()",
-      "norm_label": "createvalkeyruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_scenarios_ts",
-      "label": "harness-behavior-scenarios.ts",
-      "norm_label": "harness-behavior-scenarios.ts",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1110,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -36751,7 +37114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -36760,7 +37123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -36769,7 +37132,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 112,
+      "file_type": "code",
+      "id": "graphify_check_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "graphify_check_collectstalegraphifyartifacts",
+      "label": "collectStaleGraphifyArtifacts()",
+      "norm_label": "collectstalegraphifyartifacts()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "graphify_check_copygraphifycheckinputs",
+      "label": "copyGraphifyCheckInputs()",
+      "norm_label": "copygraphifycheckinputs()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "graphify_check_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "graphify_check_rungraphifycheck",
+      "label": "runGraphifyCheck()",
+      "norm_label": "rungraphifycheck()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "scripts_graphify_check_ts",
+      "label": "graphify-check.ts",
+      "norm_label": "graphify-check.ts",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1120,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -36778,7 +37195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1121,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -36787,7 +37204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -36796,7 +37213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -36805,7 +37222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -36814,7 +37231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -36823,7 +37240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1119,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -36832,52 +37249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 112,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "label": "r2.ts",
-      "norm_label": "r2.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "r2_deletedirectoryinr2",
-      "label": "deleteDirectoryInR2()",
-      "norm_label": "deletedirectoryinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "r2_deletefileinr2",
-      "label": "deleteFileInR2()",
-      "norm_label": "deletefileinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "r2_listitemsinr2directory",
-      "label": "listItemsInR2Directory()",
-      "norm_label": "listitemsinr2directory()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "r2_uploadfiletor2",
-      "label": "uploadFileToR2()",
-      "norm_label": "uploadfiletor2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 1120,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -36886,7 +37258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -36895,7 +37267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -36904,7 +37276,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 113,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
+      "label": "buildAthenaRuntimeUrl()",
+      "norm_label": "buildathenaruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
+      "label": "buildValkeyRuntimeUrl()",
+      "norm_label": "buildvalkeyruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
+      "label": "createAthenaRuntimeProcess()",
+      "norm_label": "createathenaruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
+      "label": "createStorefrontRuntimeProcesses()",
+      "norm_label": "createstorefrontruntimeprocesses()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
+      "label": "createValkeyRuntimeProcess()",
+      "norm_label": "createvalkeyruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_scenarios_ts",
+      "label": "harness-behavior-scenarios.ts",
+      "norm_label": "harness-behavior-scenarios.ts",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1130,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_posstore_ts",
       "label": "posStore.ts",
@@ -36913,7 +37339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1131,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -36922,7 +37348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -36931,7 +37357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -36940,7 +37366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -36949,7 +37375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -36958,7 +37384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1129,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -36967,52 +37393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 113,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
-      "label": "validateExpenseItemBelongsToSession()",
-      "norm_label": "validateexpenseitembelongstosession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionactive",
-      "label": "validateExpenseSessionActive()",
-      "norm_label": "validateexpensesessionactive()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionexists",
-      "label": "validateExpenseSessionExists()",
-      "norm_label": "validateexpensesessionexists()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
-      "label": "validateExpenseSessionModifiable()",
-      "norm_label": "validateexpensesessionmodifiable()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
-      "label": "expenseSessionValidation.ts",
-      "norm_label": "expensesessionvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1130,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -37021,7 +37402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -37030,7 +37411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -37039,7 +37420,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 114,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
+      "label": "r2.ts",
+      "norm_label": "r2.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "r2_deletedirectoryinr2",
+      "label": "deleteDirectoryInR2()",
+      "norm_label": "deletedirectoryinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "r2_deletefileinr2",
+      "label": "deleteFileInR2()",
+      "norm_label": "deletefileinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "r2_listitemsinr2directory",
+      "label": "listItemsInR2Directory()",
+      "norm_label": "listitemsinr2directory()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "r2_uploadfiletor2",
+      "label": "uploadFileToR2()",
+      "norm_label": "uploadfiletor2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 1140,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -37048,7 +37474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1141,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -37057,7 +37483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -37066,7 +37492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -37075,7 +37501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -37084,7 +37510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -37093,7 +37519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1139,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -37102,52 +37528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 114,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "label": "posSessions.ts",
-      "norm_label": "possessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "possessions_buildnextsessionnumber",
-      "label": "buildNextSessionNumber()",
-      "norm_label": "buildnextsessionnumber()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "possessions_listpossessionsbystatusbefore",
-      "label": "listPosSessionsByStatusBefore()",
-      "norm_label": "listpossessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "possessions_listpossessionsforstorestatus",
-      "label": "listPosSessionsForStoreStatus()",
-      "norm_label": "listpossessionsforstorestatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "possessions_loadpossessionitems",
-      "label": "loadPosSessionItems()",
-      "norm_label": "loadpossessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 1140,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -37156,7 +37537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -37165,7 +37546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -37174,7 +37555,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 115,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
+      "label": "validateExpenseItemBelongsToSession()",
+      "norm_label": "validateexpenseitembelongstosession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionactive",
+      "label": "validateExpenseSessionActive()",
+      "norm_label": "validateexpensesessionactive()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionexists",
+      "label": "validateExpenseSessionExists()",
+      "norm_label": "validateexpensesessionexists()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
+      "label": "validateExpenseSessionModifiable()",
+      "norm_label": "validateexpensesessionmodifiable()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
+      "label": "expenseSessionValidation.ts",
+      "norm_label": "expensesessionvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1150,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -37183,7 +37609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1151,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -37192,7 +37618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -37201,7 +37627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -37210,7 +37636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -37219,7 +37645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -37228,7 +37654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1149,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -37237,52 +37663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 115,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_products_ts",
-      "label": "products.ts",
-      "norm_label": "products.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "products_calculatetotalavailablecount",
-      "label": "calculateTotalAvailableCount()",
-      "norm_label": "calculatetotalavailablecount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "products_calculatetotalinventorycount",
-      "label": "calculateTotalInventoryCount()",
-      "norm_label": "calculatetotalinventorycount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "products_generatebarcode",
-      "label": "generateBarcode()",
-      "norm_label": "generatebarcode()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "products_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 1150,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -37291,7 +37672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -37300,7 +37681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -37309,7 +37690,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 116,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "label": "posSessions.ts",
+      "norm_label": "possessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "possessions_buildnextsessionnumber",
+      "label": "buildNextSessionNumber()",
+      "norm_label": "buildnextsessionnumber()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "possessions_listpossessionsbystatusbefore",
+      "label": "listPosSessionsByStatusBefore()",
+      "norm_label": "listpossessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "possessions_listpossessionsforstorestatus",
+      "label": "listPosSessionsForStoreStatus()",
+      "norm_label": "listpossessionsforstorestatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "possessions_loadpossessionitems",
+      "label": "loadPosSessionItems()",
+      "norm_label": "loadpossessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 1160,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -37318,7 +37744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1161,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -37327,7 +37753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -37336,7 +37762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -37345,7 +37771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -37354,7 +37780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -37363,7 +37789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1159,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -37372,52 +37798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 116,
-      "file_type": "code",
-      "id": "customerprofiles_compactrecord",
-      "label": "compactRecord()",
-      "norm_label": "compactrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
-      "label": "ensureCustomerProfileFromSourcesWithCtx()",
-      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "customerprofiles_findexistingprofile",
-      "label": "findExistingProfile()",
-      "norm_label": "findexistingprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "customerprofiles_loadcustomersources",
-      "label": "loadCustomerSources()",
-      "norm_label": "loadcustomersources()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
-      "label": "customerProfiles.ts",
-      "norm_label": "customerprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1160,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -37426,7 +37807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -37435,7 +37816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -37444,7 +37825,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 117,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_products_ts",
+      "label": "products.ts",
+      "norm_label": "products.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "products_calculatetotalavailablecount",
+      "label": "calculateTotalAvailableCount()",
+      "norm_label": "calculatetotalavailablecount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "products_calculatetotalinventorycount",
+      "label": "calculateTotalInventoryCount()",
+      "norm_label": "calculatetotalinventorycount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "products_generatebarcode",
+      "label": "generateBarcode()",
+      "norm_label": "generatebarcode()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "products_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 1170,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -37453,7 +37879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1171,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -37462,7 +37888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -37471,7 +37897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -37480,7 +37906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -37489,7 +37915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -37498,7 +37924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1169,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -37507,52 +37933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 117,
-      "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1170,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -37561,7 +37942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -37570,7 +37951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -37579,7 +37960,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 118,
+      "file_type": "code",
+      "id": "customerprofiles_compactrecord",
+      "label": "compactRecord()",
+      "norm_label": "compactrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
+      "label": "ensureCustomerProfileFromSourcesWithCtx()",
+      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "customerprofiles_findexistingprofile",
+      "label": "findExistingProfile()",
+      "norm_label": "findexistingprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "customerprofiles_loadcustomersources",
+      "label": "loadCustomerSources()",
+      "norm_label": "loadcustomersources()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
+      "label": "customerProfiles.ts",
+      "norm_label": "customerprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1180,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -37588,7 +38014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1181,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -37597,7 +38023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -37606,7 +38032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -37615,7 +38041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -37624,7 +38050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -37633,7 +38059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1179,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -37642,52 +38068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 118,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 1180,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -37696,7 +38077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -37705,7 +38086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -37714,7 +38095,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 119,
+      "file_type": "code",
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1190,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -37723,7 +38149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1191,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -37732,7 +38158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -37741,7 +38167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -37750,7 +38176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -37759,7 +38185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -37768,7 +38194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1189,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -37777,52 +38203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
-      "label": "serviceIntake.ts",
-      "norm_label": "serviceintake.ts",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "serviceintake_resolveserviceintakecustomerprofile",
-      "label": "resolveServiceIntakeCustomerProfile()",
-      "norm_label": "resolveserviceintakecustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "serviceintake_splitfullname",
-      "label": "splitFullName()",
-      "norm_label": "splitfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "serviceintake_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "serviceintake_validateserviceintakeinput",
-      "label": "validateServiceIntakeInput()",
-      "norm_label": "validateserviceintakeinput()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 1190,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -37831,7 +38212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -37840,75 +38221,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
       "norm_label": "maintenance.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1193,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
-      "label": "AnimatedCard.tsx",
-      "norm_label": "animatedcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1194,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
-      "label": "accordion.tsx",
-      "norm_label": "accordion.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1195,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
-      "label": "alert.tsx",
-      "norm_label": "alert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1196,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
-      "label": "breadcrumb.tsx",
-      "norm_label": "breadcrumb.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1197,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
-      "label": "button.tsx",
-      "norm_label": "button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1198,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_card_tsx",
-      "label": "card.tsx",
-      "norm_label": "card.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1"
     },
     {
@@ -38076,50 +38394,113 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_paystackservice_ts",
-      "label": "paystackService.ts",
-      "norm_label": "paystackservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
       "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "paystackservice_getpaystackheaders",
-      "label": "getPaystackHeaders()",
-      "norm_label": "getpaystackheaders()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L11"
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "paystackservice_initializetransaction",
-      "label": "initializeTransaction()",
-      "norm_label": "initializetransaction()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L21"
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "paystackservice_initiaterefund",
-      "label": "initiateRefund()",
-      "norm_label": "initiaterefund()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L87"
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L78"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "paystackservice_verifytransaction",
-      "label": "verifyTransaction()",
-      "norm_label": "verifytransaction()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L65"
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
     },
     {
       "community": 1200,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
+      "label": "AnimatedCard.tsx",
+      "norm_label": "animatedcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
+      "label": "accordion.tsx",
+      "norm_label": "accordion.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1202,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
+      "label": "alert.tsx",
+      "norm_label": "alert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1203,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
+      "label": "breadcrumb.tsx",
+      "norm_label": "breadcrumb.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1204,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
+      "label": "button.tsx",
+      "norm_label": "button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1205,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_card_tsx",
+      "label": "card.tsx",
+      "norm_label": "card.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1206,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1207,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -38128,7 +38509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -38137,7 +38518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -38146,7 +38527,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
+      "label": "serviceIntake.ts",
+      "norm_label": "serviceintake.ts",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "serviceintake_resolveserviceintakecustomerprofile",
+      "label": "resolveServiceIntakeCustomerProfile()",
+      "norm_label": "resolveserviceintakecustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "serviceintake_splitfullname",
+      "label": "splitFullName()",
+      "norm_label": "splitfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "serviceintake_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "serviceintake_validateserviceintakeinput",
+      "label": "validateServiceIntakeInput()",
+      "norm_label": "validateserviceintakeinput()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 1210,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -38155,7 +38581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1211,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -38164,7 +38590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -38173,7 +38599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -38182,7 +38608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -38191,7 +38617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -38200,7 +38626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1209,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -38209,52 +38635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 121,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
-      "label": "returnExchangeOperations.ts",
-      "norm_label": "returnexchangeoperations.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
-      "label": "buildOnlineOrderReturnExchangePlan()",
-      "norm_label": "buildonlineorderreturnexchangeplan()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "returnexchangeoperations_getapprovalreason",
-      "label": "getApprovalReason()",
-      "norm_label": "getapprovalreason()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "returnexchangeoperations_getkind",
-      "label": "getKind()",
-      "norm_label": "getkind()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "returnexchangeoperations_getlinerefundamount",
-      "label": "getLineRefundAmount()",
-      "norm_label": "getlinerefundamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 1210,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -38263,7 +38644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -38272,7 +38653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -38281,7 +38662,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_paystackservice_ts",
+      "label": "paystackService.ts",
+      "norm_label": "paystackservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "paystackservice_getpaystackheaders",
+      "label": "getPaystackHeaders()",
+      "norm_label": "getpaystackheaders()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "paystackservice_initializetransaction",
+      "label": "initializeTransaction()",
+      "norm_label": "initializetransaction()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "paystackservice_initiaterefund",
+      "label": "initiateRefund()",
+      "norm_label": "initiaterefund()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "paystackservice_verifytransaction",
+      "label": "verifyTransaction()",
+      "norm_label": "verifytransaction()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 1220,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -38290,7 +38716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1221,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -38299,7 +38725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -38308,7 +38734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -38317,7 +38743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -38326,7 +38752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -38335,7 +38761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1219,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -38344,52 +38770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 122,
-      "file_type": "code",
-      "id": "offers_createoffer",
-      "label": "createOffer()",
-      "norm_label": "createoffer()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "offers_getupsellproducts",
-      "label": "getUpsellProducts()",
-      "norm_label": "getupsellproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L765"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "offers_isduplicate",
-      "label": "isDuplicate()",
-      "norm_label": "isduplicate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "offers_updatestorefrontactoremail",
-      "label": "updateStoreFrontActorEmail()",
-      "norm_label": "updatestorefrontactoremail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1220,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -38398,7 +38779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -38407,7 +38788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -38416,7 +38797,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 123,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
+      "label": "returnExchangeOperations.ts",
+      "norm_label": "returnexchangeoperations.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
+      "label": "buildOnlineOrderReturnExchangePlan()",
+      "norm_label": "buildonlineorderreturnexchangeplan()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getapprovalreason",
+      "label": "getApprovalReason()",
+      "norm_label": "getapprovalreason()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getkind",
+      "label": "getKind()",
+      "norm_label": "getkind()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getlinerefundamount",
+      "label": "getLineRefundAmount()",
+      "norm_label": "getlinerefundamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 1230,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -38425,7 +38851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1231,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -38434,7 +38860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1232,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -38443,7 +38869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -38452,7 +38878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -38461,7 +38887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1228,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -38470,7 +38896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1229,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -38479,52 +38905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 123,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
-      "label": "storefrontObservabilityReport.ts",
-      "norm_label": "storefrontobservabilityreport.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
-      "label": "buildStorefrontObservabilityReport()",
-      "norm_label": "buildstorefrontobservabilityreport()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_getnonemptystring",
-      "label": "getNonEmptyString()",
-      "norm_label": "getnonemptystring()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_gettrafficsource",
-      "label": "getTrafficSource()",
-      "norm_label": "gettrafficsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
-      "label": "normalizeStorefrontObservabilityEvent()",
-      "norm_label": "normalizestorefrontobservabilityevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 1230,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -38533,7 +38914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -38542,7 +38923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -38551,7 +38932,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 124,
+      "file_type": "code",
+      "id": "offers_createoffer",
+      "label": "createOffer()",
+      "norm_label": "createoffer()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L89"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "offers_getupsellproducts",
+      "label": "getUpsellProducts()",
+      "norm_label": "getupsellproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L765"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "offers_isduplicate",
+      "label": "isDuplicate()",
+      "norm_label": "isduplicate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "offers_updatestorefrontactoremail",
+      "label": "updateStoreFrontActorEmail()",
+      "norm_label": "updatestorefrontactoremail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1240,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -38560,7 +38986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1241,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -38569,7 +38995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -38578,7 +39004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -38587,7 +39013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -38596,7 +39022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -38605,7 +39031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1239,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -38614,52 +39040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 124,
-      "file_type": "code",
-      "id": "navbar_appheader",
-      "label": "AppHeader()",
-      "norm_label": "appheader()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "navbar_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "navbar_navbar",
-      "label": "Navbar()",
-      "norm_label": "navbar()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "navbar_settingsheader",
-      "label": "SettingsHeader()",
-      "norm_label": "settingsheader()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_navbar_tsx",
-      "label": "Navbar.tsx",
-      "norm_label": "navbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1240,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -38668,7 +39049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -38677,7 +39058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -38686,7 +39067,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 125,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
+      "label": "storefrontObservabilityReport.ts",
+      "norm_label": "storefrontobservabilityreport.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
+      "label": "buildStorefrontObservabilityReport()",
+      "norm_label": "buildstorefrontobservabilityreport()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_getnonemptystring",
+      "label": "getNonEmptyString()",
+      "norm_label": "getnonemptystring()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_gettrafficsource",
+      "label": "getTrafficSource()",
+      "norm_label": "gettrafficsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
+      "label": "normalizeStorefrontObservabilityEvent()",
+      "norm_label": "normalizestorefrontobservabilityevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 1250,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -38695,7 +39121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1251,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -38704,7 +39130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -38713,7 +39139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -38722,7 +39148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -38731,7 +39157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -38740,7 +39166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1249,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -38749,52 +39175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 125,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
-      "label": "ProductCategorization.tsx",
-      "norm_label": "productcategorization.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "productcategorization_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L286"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "productcategorization_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L203"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "productcategorization_handleproductvisibility",
-      "label": "handleProductVisibility()",
-      "norm_label": "handleproductvisibility()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L243"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "productcategorization_setinitialselectedoption",
-      "label": "setInitialSelectedOption()",
-      "norm_label": "setinitialselectedoption()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L230"
-    },
-    {
-      "community": 1250,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -38803,7 +39184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -38812,7 +39193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -38821,7 +39202,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 126,
+      "file_type": "code",
+      "id": "navbar_appheader",
+      "label": "AppHeader()",
+      "norm_label": "appheader()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "navbar_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "navbar_navbar",
+      "label": "Navbar()",
+      "norm_label": "navbar()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "navbar_settingsheader",
+      "label": "SettingsHeader()",
+      "norm_label": "settingsheader()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_navbar_tsx",
+      "label": "Navbar.tsx",
+      "norm_label": "navbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1260,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -38830,7 +39256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1261,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -38839,7 +39265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1262,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -38848,7 +39274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -38857,7 +39283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -38866,7 +39292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -38875,7 +39301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1259,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -38884,52 +39310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 126,
-      "file_type": "code",
-      "id": "dashboard_getperiodrange",
-      "label": "getPeriodRange()",
-      "norm_label": "getperiodrange()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "dashboard_loadingsection",
-      "label": "LoadingSection()",
-      "norm_label": "loadingsection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "dashboard_renderproductssection",
-      "label": "renderProductsSection()",
-      "norm_label": "renderproductssection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "dashboard_rendersalessection",
-      "label": "renderSalesSection()",
-      "norm_label": "rendersalessection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L322"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "label": "Dashboard.tsx",
-      "norm_label": "dashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1260,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -38938,7 +39319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -38947,7 +39328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -38956,7 +39337,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 127,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
+      "label": "ProductCategorization.tsx",
+      "norm_label": "productcategorization.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "productcategorization_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L286"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "productcategorization_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L203"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "productcategorization_handleproductvisibility",
+      "label": "handleProductVisibility()",
+      "norm_label": "handleproductvisibility()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L243"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "productcategorization_setinitialselectedoption",
+      "label": "setInitialSelectedOption()",
+      "norm_label": "setinitialselectedoption()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L230"
+    },
+    {
+      "community": 1270,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -38965,7 +39391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1271,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -38974,7 +39400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1272,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -38983,7 +39409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -38992,7 +39418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -39001,7 +39427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -39010,7 +39436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1269,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -39019,52 +39445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 127,
-      "file_type": "code",
-      "id": "herosectiontabs_handledisplaytypechange",
-      "label": "handleDisplayTypeChange()",
-      "norm_label": "handledisplaytypechange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "herosectiontabs_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L57"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "herosectiontabs_handleoverlaytoggle",
-      "label": "handleOverlayToggle()",
-      "norm_label": "handleoverlaytoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "herosectiontabs_handletexttoggle",
-      "label": "handleTextToggle()",
-      "norm_label": "handletexttoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L134"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
-      "label": "HeroSectionTabs.tsx",
-      "norm_label": "herosectiontabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1270,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -39073,7 +39454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1278,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -39082,7 +39463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1279,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -39091,7 +39472,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 128,
+      "file_type": "code",
+      "id": "dashboard_getperiodrange",
+      "label": "getPeriodRange()",
+      "norm_label": "getperiodrange()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "dashboard_loadingsection",
+      "label": "LoadingSection()",
+      "norm_label": "loadingsection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "dashboard_renderproductssection",
+      "label": "renderProductsSection()",
+      "norm_label": "renderproductssection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "dashboard_rendersalessection",
+      "label": "renderSalesSection()",
+      "norm_label": "rendersalessection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
+      "label": "Dashboard.tsx",
+      "norm_label": "dashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1280,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -39100,7 +39526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1281,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -39109,93 +39535,48 @@
       "source_location": "L1"
     },
     {
-      "community": 128,
+      "community": 129,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
-      "label": "ReelUploader.tsx",
-      "norm_label": "reeluploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "reeluploader_formatfilesize",
-      "label": "formatFileSize()",
-      "norm_label": "formatfilesize()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "reeluploader_handlefileselect",
-      "label": "handleFileSelect()",
-      "norm_label": "handlefileselect()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "reeluploader_handleupload",
-      "label": "handleUpload()",
-      "norm_label": "handleupload()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L135"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "reeluploader_validatefile",
-      "label": "validateFile()",
-      "norm_label": "validatefile()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L43"
+      "id": "herosectiontabs_handledisplaytypechange",
+      "label": "handleDisplayTypeChange()",
+      "norm_label": "handledisplaytypechange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L61"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "activityview_iscreatedaction",
-      "label": "isCreatedAction()",
-      "norm_label": "iscreatedaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L58"
+      "id": "herosectiontabs_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L57"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "activityview_isfeedbackrequestaction",
-      "label": "isFeedbackRequestAction()",
-      "norm_label": "isfeedbackrequestaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L63"
+      "id": "herosectiontabs_handleoverlaytoggle",
+      "label": "handleOverlayToggle()",
+      "norm_label": "handleoverlaytoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L98"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "activityview_isrefundaction",
-      "label": "isRefundAction()",
-      "norm_label": "isrefundaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L50"
+      "id": "herosectiontabs_handletexttoggle",
+      "label": "handleTextToggle()",
+      "norm_label": "handletexttoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L134"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "activityview_istransitionaction",
-      "label": "isTransitionAction()",
-      "norm_label": "istransitionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
-      "label": "ActivityView.tsx",
-      "norm_label": "activityview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
+      "label": "HeroSectionTabs.tsx",
+      "norm_label": "herosectiontabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L1"
     },
     {
@@ -39363,6 +39744,96 @@
     {
       "community": 130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
+      "label": "ReelUploader.tsx",
+      "norm_label": "reeluploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "reeluploader_formatfilesize",
+      "label": "formatFileSize()",
+      "norm_label": "formatfilesize()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "reeluploader_handlefileselect",
+      "label": "handleFileSelect()",
+      "norm_label": "handlefileselect()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "reeluploader_handleupload",
+      "label": "handleUpload()",
+      "norm_label": "handleupload()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L135"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "reeluploader_validatefile",
+      "label": "validateFile()",
+      "norm_label": "validatefile()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "activityview_iscreatedaction",
+      "label": "isCreatedAction()",
+      "norm_label": "iscreatedaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "activityview_isfeedbackrequestaction",
+      "label": "isFeedbackRequestAction()",
+      "norm_label": "isfeedbackrequestaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "activityview_isrefundaction",
+      "label": "isRefundAction()",
+      "norm_label": "isrefundaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "activityview_istransitionaction",
+      "label": "isTransitionAction()",
+      "norm_label": "istransitionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
+      "label": "ActivityView.tsx",
+      "norm_label": "activityview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
       "norm_label": "fetchtransactions()",
@@ -39370,7 +39841,7 @@
       "source_location": "L138"
     },
     {
-      "community": 130,
+      "community": 132,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -39379,7 +39850,7 @@
       "source_location": "L175"
     },
     {
-      "community": 130,
+      "community": 132,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -39388,7 +39859,7 @@
       "source_location": "L189"
     },
     {
-      "community": 130,
+      "community": 132,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -39397,7 +39868,7 @@
       "source_location": "L43"
     },
     {
-      "community": 130,
+      "community": 132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -39406,7 +39877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -39415,7 +39886,7 @@
       "source_location": "L77"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -39424,7 +39895,7 @@
       "source_location": "L295"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -39433,7 +39904,7 @@
       "source_location": "L61"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -39442,7 +39913,7 @@
       "source_location": "L47"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
@@ -39451,7 +39922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "index_feesview",
       "label": "FeesView()",
@@ -39460,7 +39931,7 @@
       "source_location": "L29"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -39469,7 +39940,7 @@
       "source_location": "L42"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "index_onsubmit",
       "label": "onSubmit()",
@@ -39478,7 +39949,7 @@
       "source_location": "L105"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -39487,7 +39958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "label": "index.tsx",
@@ -39496,7 +39967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "ordersummary_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -39505,7 +39976,7 @@
       "source_location": "L320"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "ordersummary_handlecompletetransaction",
       "label": "handleCompleteTransaction()",
@@ -39514,7 +39985,7 @@
       "source_location": "L130"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "ordersummary_handlenewtransaction",
       "label": "handleNewTransaction()",
@@ -39523,7 +39994,7 @@
       "source_location": "L164"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "ordersummary_handleselectedpaymentmethod",
       "label": "handleSelectedPaymentMethod()",
@@ -39532,7 +40003,7 @@
       "source_location": "L152"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -39541,7 +40012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
       "label": "PaymentView.tsx",
@@ -39550,7 +40021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "paymentview_handleaddpayment",
       "label": "handleAddPayment()",
@@ -39559,7 +40030,7 @@
       "source_location": "L182"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "paymentview_handleamountblur",
       "label": "handleAmountBlur()",
@@ -39568,7 +40039,7 @@
       "source_location": "L246"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "paymentview_handleamountchange",
       "label": "handleAmountChange()",
@@ -39577,7 +40048,7 @@
       "source_location": "L228"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "paymentview_handleclearall",
       "label": "handleClearAll()",
@@ -39586,7 +40057,7 @@
       "source_location": "L223"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -39595,7 +40066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "sessionmanager_onholdconfirm",
       "label": "onHoldConfirm()",
@@ -39604,7 +40075,7 @@
       "source_location": "L72"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "sessionmanager_onnewsessionclick",
       "label": "onNewSessionClick()",
@@ -39613,7 +40084,7 @@
       "source_location": "L96"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "sessionmanager_onresumesession",
       "label": "onResumeSession()",
@@ -39622,7 +40093,7 @@
       "source_location": "L77"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "sessionmanager_onvoidconfirm",
       "label": "onVoidConfirm()",
@@ -39631,7 +40102,7 @@
       "source_location": "L90"
     },
     {
-      "community": 136,
+      "community": 138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
       "label": "ReceivingView.tsx",
@@ -39640,7 +40111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 136,
+      "community": 138,
       "file_type": "code",
       "id": "receivingview_builddefaultreceivedquantities",
       "label": "buildDefaultReceivedQuantities()",
@@ -39649,7 +40120,7 @@
       "source_location": "L35"
     },
     {
-      "community": 136,
+      "community": 138,
       "file_type": "code",
       "id": "receivingview_buildreceivedquantitiesaftersubmission",
       "label": "buildReceivedQuantitiesAfterSubmission()",
@@ -39658,7 +40129,7 @@
       "source_location": "L44"
     },
     {
-      "community": 136,
+      "community": 138,
       "file_type": "code",
       "id": "receivingview_buildsubmissionkey",
       "label": "buildSubmissionKey()",
@@ -39667,7 +40138,7 @@
       "source_location": "L31"
     },
     {
-      "community": 136,
+      "community": 138,
       "file_type": "code",
       "id": "receivingview_receivingview",
       "label": "ReceivingView()",
@@ -39676,7 +40147,7 @@
       "source_location": "L70"
     },
     {
-      "community": 137,
+      "community": 139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -39685,7 +40156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 137,
+      "community": 139,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -39694,7 +40165,7 @@
       "source_location": "L146"
     },
     {
-      "community": 137,
+      "community": 139,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -39703,7 +40174,7 @@
       "source_location": "L213"
     },
     {
-      "community": 137,
+      "community": 139,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -39712,103 +40183,13 @@
       "source_location": "L299"
     },
     {
-      "community": 137,
+      "community": 139,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
       "norm_label": "updateleaveareviewdiscountcode()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L351"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "custom_modal_example_basicmodalexample",
-      "label": "BasicModalExample()",
-      "norm_label": "basicmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "custom_modal_example_customclosebuttonexample",
-      "label": "CustomCloseButtonExample()",
-      "norm_label": "customclosebuttonexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L69"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "custom_modal_example_custompositionmodalexample",
-      "label": "CustomPositionModalExample()",
-      "norm_label": "custompositionmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "custom_modal_example_fullscreenmodalexample",
-      "label": "FullScreenModalExample()",
-      "norm_label": "fullscreenmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L103"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
-      "label": "custom-modal-example.tsx",
-      "norm_label": "custom-modal-example.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "label": "usePOSProducts.ts",
-      "norm_label": "useposproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "useposproducts_useposbarcodesearch",
-      "label": "usePOSBarcodeSearch()",
-      "norm_label": "useposbarcodesearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "useposproducts_useposproductidsearch",
-      "label": "usePOSProductIdSearch()",
-      "norm_label": "useposproductidsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "useposproducts_useposproductsearch",
-      "label": "usePOSProductSearch()",
-      "norm_label": "useposproductsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "useposproducts_usepostransactioncomplete",
-      "label": "usePOSTransactionComplete()",
-      "norm_label": "usepostransactioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L100"
     },
     {
       "community": 14,
@@ -39966,6 +40347,96 @@
     {
       "community": 140,
       "file_type": "code",
+      "id": "custom_modal_example_basicmodalexample",
+      "label": "BasicModalExample()",
+      "norm_label": "basicmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "custom_modal_example_customclosebuttonexample",
+      "label": "CustomCloseButtonExample()",
+      "norm_label": "customclosebuttonexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L69"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "custom_modal_example_custompositionmodalexample",
+      "label": "CustomPositionModalExample()",
+      "norm_label": "custompositionmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "custom_modal_example_fullscreenmodalexample",
+      "label": "FullScreenModalExample()",
+      "norm_label": "fullscreenmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L103"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
+      "label": "custom-modal-example.tsx",
+      "norm_label": "custom-modal-example.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
+      "label": "usePOSProducts.ts",
+      "norm_label": "useposproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "useposproducts_useposbarcodesearch",
+      "label": "usePOSBarcodeSearch()",
+      "norm_label": "useposbarcodesearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "useposproducts_useposproductidsearch",
+      "label": "usePOSProductIdSearch()",
+      "norm_label": "useposproductidsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "useposproducts_useposproductsearch",
+      "label": "usePOSProductSearch()",
+      "norm_label": "useposproductsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "useposproducts_usepostransactioncomplete",
+      "label": "usePOSTransactionComplete()",
+      "norm_label": "usepostransactioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
       "norm_label": "buffertohex()",
@@ -39973,7 +40444,7 @@
       "source_location": "L18"
     },
     {
-      "community": 140,
+      "community": 142,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -39982,7 +40453,7 @@
       "source_location": "L23"
     },
     {
-      "community": 140,
+      "community": 142,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -39991,7 +40462,7 @@
       "source_location": "L65"
     },
     {
-      "community": 140,
+      "community": 142,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -40000,7 +40471,7 @@
       "source_location": "L45"
     },
     {
-      "community": 140,
+      "community": 142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -40009,7 +40480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 141,
+      "community": 143,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -40018,7 +40489,7 @@
       "source_location": "L78"
     },
     {
-      "community": 141,
+      "community": 143,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -40027,7 +40498,7 @@
       "source_location": "L74"
     },
     {
-      "community": 141,
+      "community": 143,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -40036,7 +40507,7 @@
       "source_location": "L103"
     },
     {
-      "community": 141,
+      "community": 143,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -40045,7 +40516,7 @@
       "source_location": "L109"
     },
     {
-      "community": 141,
+      "community": 143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -40054,7 +40525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 142,
+      "community": 144,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -40063,7 +40534,7 @@
       "source_location": "L75"
     },
     {
-      "community": 142,
+      "community": 144,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -40072,7 +40543,7 @@
       "source_location": "L26"
     },
     {
-      "community": 142,
+      "community": 144,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -40081,7 +40552,7 @@
       "source_location": "L38"
     },
     {
-      "community": 142,
+      "community": 144,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -40090,7 +40561,7 @@
       "source_location": "L4"
     },
     {
-      "community": 142,
+      "community": 144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -40099,7 +40570,52 @@
       "source_location": "L1"
     },
     {
-      "community": 143,
+      "community": 145,
+      "file_type": "code",
+      "id": "cart_calculateposcarttotals",
+      "label": "calculatePosCartTotals()",
+      "norm_label": "calculateposcarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "cart_calculatepositemtotal",
+      "label": "calculatePosItemTotal()",
+      "norm_label": "calculatepositemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "cart_getposeffectiveprice",
+      "label": "getPosEffectivePrice()",
+      "norm_label": "getposeffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "cart_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
+      "label": "cart.ts",
+      "norm_label": "cart.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -40108,7 +40624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 143,
+      "community": 146,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -40117,7 +40633,7 @@
       "source_location": "L42"
     },
     {
-      "community": 143,
+      "community": 146,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -40126,7 +40642,7 @@
       "source_location": "L29"
     },
     {
-      "community": 143,
+      "community": 146,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -40135,7 +40651,7 @@
       "source_location": "L49"
     },
     {
-      "community": 143,
+      "community": 146,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -40144,7 +40660,7 @@
       "source_location": "L14"
     },
     {
-      "community": 144,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -40153,7 +40669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 144,
+      "community": 147,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -40162,7 +40678,7 @@
       "source_location": "L184"
     },
     {
-      "community": 144,
+      "community": 147,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -40171,7 +40687,7 @@
       "source_location": "L200"
     },
     {
-      "community": 144,
+      "community": 147,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -40180,7 +40696,7 @@
       "source_location": "L244"
     },
     {
-      "community": 144,
+      "community": 147,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -40189,7 +40705,7 @@
       "source_location": "L206"
     },
     {
-      "community": 145,
+      "community": 148,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -40198,7 +40714,7 @@
       "source_location": "L93"
     },
     {
-      "community": 145,
+      "community": 148,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -40207,7 +40723,7 @@
       "source_location": "L75"
     },
     {
-      "community": 145,
+      "community": 148,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -40216,7 +40732,7 @@
       "source_location": "L4"
     },
     {
-      "community": 145,
+      "community": 148,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -40225,7 +40741,7 @@
       "source_location": "L47"
     },
     {
-      "community": 145,
+      "community": 148,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -40234,7 +40750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 149,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -40243,7 +40759,7 @@
       "source_location": "L11"
     },
     {
-      "community": 146,
+      "community": 149,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -40252,7 +40768,7 @@
       "source_location": "L25"
     },
     {
-      "community": 146,
+      "community": 149,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -40261,7 +40777,7 @@
       "source_location": "L9"
     },
     {
-      "community": 146,
+      "community": 149,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -40270,147 +40786,12 @@
       "source_location": "L39"
     },
     {
-      "community": 146,
+      "community": 149,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "onlineorder_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "onlineorder_getorder",
-      "label": "getOrder()",
-      "norm_label": "getorder()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "onlineorder_getorders",
-      "label": "getOrders()",
-      "norm_label": "getorders()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "onlineorder_updateordersowner",
-      "label": "updateOrdersOwner()",
-      "norm_label": "updateordersowner()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
-      "label": "storeFrontUser.ts",
-      "norm_label": "storefrontuser.ts",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "storefrontuser_getactiveuser",
-      "label": "getActiveUser()",
-      "norm_label": "getactiveuser()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "storefrontuser_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "storefrontuser_getguest",
-      "label": "getGuest()",
-      "norm_label": "getguest()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "storefrontuser_updateuser",
-      "label": "updateUser()",
-      "norm_label": "updateuser()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "homepage_enableprompts",
-      "label": "enablePrompts()",
-      "norm_label": "enableprompts()",
-      "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "homepage_handleclickonleavereviewbutton",
-      "label": "handleClickOnLeaveReviewButton()",
-      "norm_label": "handleclickonleavereviewbutton()",
-      "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
-      "source_location": "L185"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "homepage_handlescroll",
-      "label": "handleScroll()",
-      "norm_label": "handlescroll()",
-      "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
-      "source_location": "L115"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "homepage_homepagereadyshell",
-      "label": "HomePageReadyShell()",
-      "norm_label": "homepagereadyshell()",
-      "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_homepage_tsx",
-      "label": "HomePage.tsx",
-      "norm_label": "homepage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L1"
     },
     {
@@ -40569,6 +40950,141 @@
     {
       "community": 150,
       "file_type": "code",
+      "id": "onlineorder_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "onlineorder_getorder",
+      "label": "getOrder()",
+      "norm_label": "getorder()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "onlineorder_getorders",
+      "label": "getOrders()",
+      "norm_label": "getorders()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "onlineorder_updateordersowner",
+      "label": "updateOrdersOwner()",
+      "norm_label": "updateordersowner()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
+      "label": "storeFrontUser.ts",
+      "norm_label": "storefrontuser.ts",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "storefrontuser_getactiveuser",
+      "label": "getActiveUser()",
+      "norm_label": "getactiveuser()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "storefrontuser_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "storefrontuser_getguest",
+      "label": "getGuest()",
+      "norm_label": "getguest()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "storefrontuser_updateuser",
+      "label": "updateUser()",
+      "norm_label": "updateuser()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "homepage_enableprompts",
+      "label": "enablePrompts()",
+      "norm_label": "enableprompts()",
+      "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "homepage_handleclickonleavereviewbutton",
+      "label": "handleClickOnLeaveReviewButton()",
+      "norm_label": "handleclickonleavereviewbutton()",
+      "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
+      "source_location": "L185"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "homepage_handlescroll",
+      "label": "handleScroll()",
+      "norm_label": "handlescroll()",
+      "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
+      "source_location": "L115"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "homepage_homepagereadyshell",
+      "label": "HomePageReadyShell()",
+      "norm_label": "homepagereadyshell()",
+      "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_homepage_tsx",
+      "label": "HomePage.tsx",
+      "norm_label": "homepage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
       "norm_label": "lowstockbadge()",
@@ -40576,7 +41092,7 @@
       "source_location": "L14"
     },
     {
-      "community": 150,
+      "community": 153,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -40585,7 +41101,7 @@
       "source_location": "L22"
     },
     {
-      "community": 150,
+      "community": 153,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -40594,7 +41110,7 @@
       "source_location": "L30"
     },
     {
-      "community": 150,
+      "community": 153,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -40603,7 +41119,7 @@
       "source_location": "L3"
     },
     {
-      "community": 150,
+      "community": 153,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -40612,7 +41128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 154,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -40621,7 +41137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 154,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -40630,7 +41146,7 @@
       "source_location": "L136"
     },
     {
-      "community": 151,
+      "community": 154,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -40639,7 +41155,7 @@
       "source_location": "L154"
     },
     {
-      "community": 151,
+      "community": 154,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -40648,7 +41164,7 @@
       "source_location": "L25"
     },
     {
-      "community": 151,
+      "community": 154,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -40657,7 +41173,7 @@
       "source_location": "L47"
     },
     {
-      "community": 152,
+      "community": 155,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -40666,7 +41182,7 @@
       "source_location": "L44"
     },
     {
-      "community": 152,
+      "community": 155,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -40675,7 +41191,7 @@
       "source_location": "L36"
     },
     {
-      "community": 152,
+      "community": 155,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -40684,7 +41200,7 @@
       "source_location": "L26"
     },
     {
-      "community": 152,
+      "community": 155,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -40693,7 +41209,7 @@
       "source_location": "L30"
     },
     {
-      "community": 152,
+      "community": 155,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
@@ -40702,7 +41218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 156,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -40711,7 +41227,7 @@
       "source_location": "L109"
     },
     {
-      "community": 153,
+      "community": 156,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -40720,7 +41236,7 @@
       "source_location": "L84"
     },
     {
-      "community": 153,
+      "community": 156,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -40729,7 +41245,7 @@
       "source_location": "L95"
     },
     {
-      "community": 153,
+      "community": 156,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
       "label": "checkout.ts",
@@ -40738,7 +41254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 157,
       "file_type": "code",
       "id": "expensesessions_buildnextexpensesessionnumber",
       "label": "buildNextExpenseSessionNumber()",
@@ -40747,7 +41263,7 @@
       "source_location": "L33"
     },
     {
-      "community": 154,
+      "community": 157,
       "file_type": "code",
       "id": "expensesessions_listexpensesessionsbystatusbefore",
       "label": "listExpenseSessionsByStatusBefore()",
@@ -40756,7 +41272,7 @@
       "source_location": "L66"
     },
     {
-      "community": 154,
+      "community": 157,
       "file_type": "code",
       "id": "expensesessions_loadexpensesessionitems",
       "label": "loadExpenseSessionItems()",
@@ -40765,7 +41281,7 @@
       "source_location": "L41"
     },
     {
-      "community": 154,
+      "community": 157,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
       "label": "expenseSessions.ts",
@@ -40774,7 +41290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 158,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -40783,7 +41299,7 @@
       "source_location": "L21"
     },
     {
-      "community": 155,
+      "community": 158,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -40792,7 +41308,7 @@
       "source_location": "L35"
     },
     {
-      "community": 155,
+      "community": 158,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -40801,7 +41317,7 @@
       "source_location": "L45"
     },
     {
-      "community": 155,
+      "community": 158,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -40810,7 +41326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 159,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -40819,7 +41335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 159,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -40828,7 +41344,7 @@
       "source_location": "L21"
     },
     {
-      "community": 156,
+      "community": 159,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -40837,121 +41353,13 @@
       "source_location": "L35"
     },
     {
-      "community": 156,
+      "community": 159,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
       "norm_label": "getsessionexpirydurationminutes()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L45"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "collections_getcachedtokenrecord",
-      "label": "getCachedTokenRecord()",
-      "norm_label": "getcachedtokenrecord()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "collections_resolveaccesstokenforstore",
-      "label": "resolveAccessTokenForStore()",
-      "norm_label": "resolveaccesstokenforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "collections_resolveconfigforstore",
-      "label": "resolveConfigForStore()",
-      "norm_label": "resolveconfigforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_collections_ts",
-      "label": "collections.ts",
-      "norm_label": "collections.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "normalize_maskmtnpartyid",
-      "label": "maskMtnPartyId()",
-      "norm_label": "maskmtnpartyid()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "normalize_normalizecollectionstransaction",
-      "label": "normalizeCollectionsTransaction()",
-      "norm_label": "normalizecollectionstransaction()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "normalize_parsecollectionsnotificationrequest",
-      "label": "parseCollectionsNotificationRequest()",
-      "norm_label": "parsecollectionsnotificationrequest()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_normalize_ts",
-      "label": "normalize.ts",
-      "norm_label": "normalize.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L1"
     },
     {
       "community": 16,
@@ -41109,6 +41517,114 @@
     {
       "community": 160,
       "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "collections_getcachedtokenrecord",
+      "label": "getCachedTokenRecord()",
+      "norm_label": "getcachedtokenrecord()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "collections_resolveaccesstokenforstore",
+      "label": "resolveAccessTokenForStore()",
+      "norm_label": "resolveaccesstokenforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "collections_resolveconfigforstore",
+      "label": "resolveConfigForStore()",
+      "norm_label": "resolveconfigforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_collections_ts",
+      "label": "collections.ts",
+      "norm_label": "collections.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "normalize_maskmtnpartyid",
+      "label": "maskMtnPartyId()",
+      "norm_label": "maskmtnpartyid()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "normalize_normalizecollectionstransaction",
+      "label": "normalizeCollectionsTransaction()",
+      "norm_label": "normalizecollectionstransaction()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "normalize_parsecollectionsnotificationrequest",
+      "label": "parseCollectionsNotificationRequest()",
+      "norm_label": "parsecollectionsnotificationrequest()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_normalize_ts",
+      "label": "normalize.ts",
+      "norm_label": "normalize.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
       "norm_label": "buildoperationalevent()",
@@ -41116,7 +41632,7 @@
       "source_location": "L28"
     },
     {
-      "community": 160,
+      "community": 163,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -41125,7 +41641,7 @@
       "source_location": "L42"
     },
     {
-      "community": 160,
+      "community": 163,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -41134,7 +41650,7 @@
       "source_location": "L73"
     },
     {
-      "community": 160,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -41143,7 +41659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 164,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -41152,7 +41668,7 @@
       "source_location": "L8"
     },
     {
-      "community": 161,
+      "community": 164,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -41161,7 +41677,7 @@
       "source_location": "L32"
     },
     {
-      "community": 161,
+      "community": 164,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -41170,7 +41686,7 @@
       "source_location": "L64"
     },
     {
-      "community": 161,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -41179,7 +41695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 165,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -41188,7 +41704,7 @@
       "source_location": "L18"
     },
     {
-      "community": 162,
+      "community": 165,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -41197,7 +41713,7 @@
       "source_location": "L25"
     },
     {
-      "community": 162,
+      "community": 165,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -41206,7 +41722,7 @@
       "source_location": "L11"
     },
     {
-      "community": 162,
+      "community": 165,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -41215,7 +41731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 166,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -41224,7 +41740,7 @@
       "source_location": "L30"
     },
     {
-      "community": 163,
+      "community": 166,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -41233,7 +41749,7 @@
       "source_location": "L175"
     },
     {
-      "community": 163,
+      "community": 166,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -41242,7 +41758,7 @@
       "source_location": "L26"
     },
     {
-      "community": 163,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -41251,7 +41767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -41260,7 +41776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 167,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -41269,7 +41785,7 @@
       "source_location": "L23"
     },
     {
-      "community": 164,
+      "community": 167,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -41278,7 +41794,7 @@
       "source_location": "L9"
     },
     {
-      "community": 164,
+      "community": 167,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -41287,7 +41803,7 @@
       "source_location": "L13"
     },
     {
-      "community": 165,
+      "community": 168,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -41296,7 +41812,7 @@
       "source_location": "L19"
     },
     {
-      "community": 165,
+      "community": 168,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -41305,7 +41821,7 @@
       "source_location": "L26"
     },
     {
-      "community": 165,
+      "community": 168,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -41314,7 +41830,7 @@
       "source_location": "L12"
     },
     {
-      "community": 165,
+      "community": 168,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -41323,7 +41839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 169,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -41332,7 +41848,7 @@
       "source_location": "L21"
     },
     {
-      "community": 166,
+      "community": 169,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -41341,7 +41857,7 @@
       "source_location": "L63"
     },
     {
-      "community": 166,
+      "community": 169,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -41350,120 +41866,12 @@
       "source_location": "L71"
     },
     {
-      "community": 166,
+      "community": 169,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
       "norm_label": "customerengagementevents.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
-      "label": "returnExchangeOperations.test.ts",
-      "norm_label": "returnexchangeoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createorderitem",
-      "label": "createOrderItem()",
-      "norm_label": "createorderitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createreplacement",
-      "label": "createReplacement()",
-      "norm_label": "createreplacement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "attributesmanager_attributesmanager",
-      "label": "AttributesManager()",
-      "norm_label": "attributesmanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "attributesmanager_colormanager",
-      "label": "ColorManager()",
-      "norm_label": "colormanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "attributesmanager_sidebar",
-      "label": "Sidebar()",
-      "norm_label": "sidebar()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L26"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
-      "label": "AttributesManager.tsx",
-      "norm_label": "attributesmanager.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "attributestable_getproductattribute",
-      "label": "getProductAttribute()",
-      "norm_label": "getproductattribute()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "attributestable_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L32"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "attributestable_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L210"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
-      "label": "AttributesTable.tsx",
-      "norm_label": "attributestable.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L1"
     },
     {
@@ -41613,6 +42021,114 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "label": "returnExchangeOperations.test.ts",
+      "norm_label": "returnexchangeoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createorderitem",
+      "label": "createOrderItem()",
+      "norm_label": "createorderitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createreplacement",
+      "label": "createReplacement()",
+      "norm_label": "createreplacement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "attributesmanager_attributesmanager",
+      "label": "AttributesManager()",
+      "norm_label": "attributesmanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "attributesmanager_colormanager",
+      "label": "ColorManager()",
+      "norm_label": "colormanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "attributesmanager_sidebar",
+      "label": "Sidebar()",
+      "norm_label": "sidebar()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
+      "label": "AttributesManager.tsx",
+      "norm_label": "attributesmanager.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "attributestable_getproductattribute",
+      "label": "getProductAttribute()",
+      "norm_label": "getproductattribute()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "attributestable_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L32"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "attributestable_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L210"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
+      "label": "AttributesTable.tsx",
+      "norm_label": "attributestable.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
       "norm_label": "categorymanager()",
@@ -41620,7 +42136,7 @@
       "source_location": "L51"
     },
     {
-      "community": 170,
+      "community": 173,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -41629,7 +42145,7 @@
       "source_location": "L26"
     },
     {
-      "community": 170,
+      "community": 173,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -41638,7 +42154,7 @@
       "source_location": "L290"
     },
     {
-      "community": 170,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -41647,7 +42163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 174,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -41656,7 +42172,7 @@
       "source_location": "L48"
     },
     {
-      "community": 171,
+      "community": 174,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -41665,7 +42181,7 @@
       "source_location": "L88"
     },
     {
-      "community": 171,
+      "community": 174,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -41674,7 +42190,7 @@
       "source_location": "L14"
     },
     {
-      "community": 171,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -41683,7 +42199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -41692,7 +42208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 175,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -41701,7 +42217,7 @@
       "source_location": "L15"
     },
     {
-      "community": 172,
+      "community": 175,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -41710,7 +42226,7 @@
       "source_location": "L28"
     },
     {
-      "community": 172,
+      "community": 175,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -41719,7 +42235,7 @@
       "source_location": "L19"
     },
     {
-      "community": 173,
+      "community": 176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -41728,7 +42244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 176,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -41737,7 +42253,7 @@
       "source_location": "L52"
     },
     {
-      "community": 173,
+      "community": 176,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -41746,7 +42262,7 @@
       "source_location": "L3"
     },
     {
-      "community": 173,
+      "community": 176,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -41755,7 +42271,7 @@
       "source_location": "L90"
     },
     {
-      "community": 174,
+      "community": 177,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -41764,7 +42280,7 @@
       "source_location": "L86"
     },
     {
-      "community": 174,
+      "community": 177,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -41773,7 +42289,7 @@
       "source_location": "L76"
     },
     {
-      "community": 174,
+      "community": 177,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -41782,7 +42298,7 @@
       "source_location": "L52"
     },
     {
-      "community": 174,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -41791,7 +42307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -41800,7 +42316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 178,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -41809,7 +42325,7 @@
       "source_location": "L67"
     },
     {
-      "community": 175,
+      "community": 178,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -41818,7 +42334,7 @@
       "source_location": "L90"
     },
     {
-      "community": 175,
+      "community": 178,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -41827,7 +42343,7 @@
       "source_location": "L73"
     },
     {
-      "community": 176,
+      "community": 179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -41836,7 +42352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 179,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -41845,7 +42361,7 @@
       "source_location": "L103"
     },
     {
-      "community": 176,
+      "community": 179,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -41854,121 +42370,13 @@
       "source_location": "L95"
     },
     {
-      "community": 176,
+      "community": 179,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
       "norm_label": "toggleitem()",
       "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
       "source_location": "L81"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "newtransactionview_handlequickstart",
-      "label": "handleQuickStart()",
-      "norm_label": "handlequickstart()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "newtransactionview_handlestarttransaction",
-      "label": "handleStartTransaction()",
-      "norm_label": "handlestarttransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L68"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "newtransactionview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
-      "label": "NewTransactionView.tsx",
-      "norm_label": "newtransactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
-      "label": "POSSettingsView.tsx",
-      "norm_label": "possettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "possettingsview_handleregisterterminal",
-      "label": "handleRegisterTerminal()",
-      "norm_label": "handleregisterterminal()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L247"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "possettingsview_handleupdateexistingterminal",
-      "label": "handleUpdateExistingTerminal()",
-      "norm_label": "handleupdateexistingterminal()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L284"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "possettingsview_loadfingerprint",
-      "label": "loadFingerprint()",
-      "norm_label": "loadfingerprint()",
-      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
-      "source_location": "L166"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
-      "label": "ProcurementView.tsx",
-      "norm_label": "procurementview.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "procurementview_formatoptionaldate",
-      "label": "formatOptionalDate()",
-      "norm_label": "formatoptionaldate()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L78"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "procurementview_getfilteremptystatecopy",
-      "label": "getFilterEmptyStateCopy()",
-      "norm_label": "getfilteremptystatecopy()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L118"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "procurementview_getrecommendationstatuscopy",
-      "label": "getRecommendationStatusCopy()",
-      "norm_label": "getrecommendationstatuscopy()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L89"
     },
     {
       "community": 18,
@@ -42117,6 +42525,114 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "newtransactionview_handlequickstart",
+      "label": "handleQuickStart()",
+      "norm_label": "handlequickstart()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "newtransactionview_handlestarttransaction",
+      "label": "handleStartTransaction()",
+      "norm_label": "handlestarttransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L68"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "newtransactionview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
+      "label": "NewTransactionView.tsx",
+      "norm_label": "newtransactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
+      "label": "POSSettingsView.tsx",
+      "norm_label": "possettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "possettingsview_handleregisterterminal",
+      "label": "handleRegisterTerminal()",
+      "norm_label": "handleregisterterminal()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L247"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "possettingsview_handleupdateexistingterminal",
+      "label": "handleUpdateExistingTerminal()",
+      "norm_label": "handleupdateexistingterminal()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L284"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "possettingsview_loadfingerprint",
+      "label": "loadFingerprint()",
+      "norm_label": "loadfingerprint()",
+      "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+      "source_location": "L166"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
+      "label": "ProcurementView.tsx",
+      "norm_label": "procurementview.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "procurementview_formatoptionaldate",
+      "label": "formatOptionalDate()",
+      "norm_label": "formatoptionaldate()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L78"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "procurementview_getfilteremptystatecopy",
+      "label": "getFilterEmptyStateCopy()",
+      "norm_label": "getfilteremptystatecopy()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L118"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
+      "id": "procurementview_getrecommendationstatuscopy",
+      "label": "getRecommendationStatusCopy()",
+      "norm_label": "getrecommendationstatuscopy()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
       "norm_label": "productstock.tsx",
@@ -42124,7 +42640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 180,
+      "community": 183,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -42133,7 +42649,7 @@
       "source_location": "L63"
     },
     {
-      "community": 180,
+      "community": 183,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -42142,7 +42658,7 @@
       "source_location": "L54"
     },
     {
-      "community": 180,
+      "community": 183,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -42151,7 +42667,7 @@
       "source_location": "L11"
     },
     {
-      "community": 181,
+      "community": 184,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -42160,7 +42676,7 @@
       "source_location": "L16"
     },
     {
-      "community": 181,
+      "community": 184,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -42169,7 +42685,7 @@
       "source_location": "L35"
     },
     {
-      "community": 181,
+      "community": 184,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -42178,7 +42694,7 @@
       "source_location": "L6"
     },
     {
-      "community": 181,
+      "community": 184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -42187,7 +42703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "label": "ServiceAppointmentsView.tsx",
@@ -42196,7 +42712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 185,
       "file_type": "code",
       "id": "serviceappointmentsview_handlesubmit",
       "label": "handleSubmit()",
@@ -42205,7 +42721,7 @@
       "source_location": "L115"
     },
     {
-      "community": 182,
+      "community": 185,
       "file_type": "code",
       "id": "serviceappointmentsview_parsedatetimelocal",
       "label": "parseDateTimeLocal()",
@@ -42214,7 +42730,7 @@
       "source_location": "L77"
     },
     {
-      "community": 182,
+      "community": 185,
       "file_type": "code",
       "id": "serviceappointmentsview_withsavestate",
       "label": "withSaveState()",
@@ -42223,7 +42739,7 @@
       "source_location": "L441"
     },
     {
-      "community": 183,
+      "community": 186,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -42232,7 +42748,7 @@
       "source_location": "L75"
     },
     {
-      "community": 183,
+      "community": 186,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -42241,7 +42757,7 @@
       "source_location": "L82"
     },
     {
-      "community": 183,
+      "community": 186,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -42250,7 +42766,7 @@
       "source_location": "L93"
     },
     {
-      "community": 183,
+      "community": 186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -42259,7 +42775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -42268,7 +42784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 187,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -42277,7 +42793,7 @@
       "source_location": "L15"
     },
     {
-      "community": 184,
+      "community": 187,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -42286,7 +42802,7 @@
       "source_location": "L28"
     },
     {
-      "community": 184,
+      "community": 187,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -42295,7 +42811,7 @@
       "source_location": "L54"
     },
     {
-      "community": 185,
+      "community": 188,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -42304,7 +42820,7 @@
       "source_location": "L66"
     },
     {
-      "community": 185,
+      "community": 188,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -42313,7 +42829,7 @@
       "source_location": "L121"
     },
     {
-      "community": 185,
+      "community": 188,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -42322,7 +42838,7 @@
       "source_location": "L74"
     },
     {
-      "community": 185,
+      "community": 188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -42331,7 +42847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 189,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -42340,7 +42856,7 @@
       "source_location": "L51"
     },
     {
-      "community": 186,
+      "community": 189,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -42349,7 +42865,7 @@
       "source_location": "L92"
     },
     {
-      "community": 186,
+      "community": 189,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -42358,121 +42874,13 @@
       "source_location": "L16"
     },
     {
-      "community": 186,
+      "community": 189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
       "norm_label": "barcodeutils.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "offers_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "offers_getuserredeemedoffers",
-      "label": "getUserRedeemedOffers()",
-      "norm_label": "getuserredeemedoffers()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "offers_submitoffer",
-      "label": "submitOffer()",
-      "norm_label": "submitoffer()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "stores_getallstores",
-      "label": "getAllStores()",
-      "norm_label": "getallstores()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "stores_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "stores_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "subcategory_getallsubcategories",
-      "label": "getAllSubcategories()",
-      "norm_label": "getallsubcategories()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "subcategory_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "subcategory_getsubategory",
-      "label": "getSubategory()",
-      "norm_label": "getsubategory()",
-      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
-      "source_location": "L25"
     },
     {
       "community": 19,
@@ -42621,6 +43029,114 @@
     {
       "community": 190,
       "file_type": "code",
+      "id": "offers_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "offers_getuserredeemedoffers",
+      "label": "getUserRedeemedOffers()",
+      "norm_label": "getuserredeemedoffers()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "offers_submitoffer",
+      "label": "submitOffer()",
+      "norm_label": "submitoffer()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "stores_getallstores",
+      "label": "getAllStores()",
+      "norm_label": "getallstores()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "stores_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "stores_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "subcategory_getallsubcategories",
+      "label": "getAllSubcategories()",
+      "norm_label": "getallsubcategories()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "subcategory_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "subcategory_getsubategory",
+      "label": "getSubategory()",
+      "norm_label": "getsubategory()",
+      "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
       "norm_label": "productactionbar.tsx",
@@ -42628,7 +43144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 190,
+      "community": 193,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -42637,7 +43153,7 @@
       "source_location": "L50"
     },
     {
-      "community": 190,
+      "community": 193,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -42646,7 +43162,7 @@
       "source_location": "L92"
     },
     {
-      "community": 190,
+      "community": 193,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -42655,7 +43171,7 @@
       "source_location": "L74"
     },
     {
-      "community": 191,
+      "community": 194,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -42664,7 +43180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 194,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -42673,7 +43189,7 @@
       "source_location": "L62"
     },
     {
-      "community": 191,
+      "community": 194,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -42682,7 +43198,7 @@
       "source_location": "L109"
     },
     {
-      "community": 191,
+      "community": 194,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -42691,7 +43207,7 @@
       "source_location": "L177"
     },
     {
-      "community": 192,
+      "community": 195,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -42700,7 +43216,7 @@
       "source_location": "L18"
     },
     {
-      "community": 192,
+      "community": 195,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -42709,7 +43225,7 @@
       "source_location": "L52"
     },
     {
-      "community": 192,
+      "community": 195,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -42718,7 +43234,7 @@
       "source_location": "L68"
     },
     {
-      "community": 192,
+      "community": 195,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -42727,7 +43243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 196,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -42736,7 +43252,7 @@
       "source_location": "L68"
     },
     {
-      "community": 193,
+      "community": 196,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -42745,7 +43261,7 @@
       "source_location": "L26"
     },
     {
-      "community": 193,
+      "community": 196,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -42754,7 +43270,7 @@
       "source_location": "L7"
     },
     {
-      "community": 193,
+      "community": 196,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -42763,7 +43279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 197,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -42772,7 +43288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 197,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -42781,7 +43297,7 @@
       "source_location": "L43"
     },
     {
-      "community": 194,
+      "community": 197,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -42790,7 +43306,7 @@
       "source_location": "L13"
     },
     {
-      "community": 194,
+      "community": 197,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -42799,7 +43315,7 @@
       "source_location": "L88"
     },
     {
-      "community": 195,
+      "community": 198,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -42808,7 +43324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 198,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -42817,7 +43333,7 @@
       "source_location": "L111"
     },
     {
-      "community": 195,
+      "community": 198,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -42826,7 +43342,7 @@
       "source_location": "L66"
     },
     {
-      "community": 195,
+      "community": 198,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -42835,7 +43351,7 @@
       "source_location": "L127"
     },
     {
-      "community": 196,
+      "community": 199,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -42844,7 +43360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 199,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -42853,7 +43369,7 @@
       "source_location": "L115"
     },
     {
-      "community": 196,
+      "community": 199,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -42862,121 +43378,13 @@
       "source_location": "L105"
     },
     {
-      "community": 196,
+      "community": 199,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
       "norm_label": "onmobilefilterscloseclick()",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L110"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "index_cancelorder",
-      "label": "cancelOrder()",
-      "norm_label": "cancelorder()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L121"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "index_geterrormessage",
-      "label": "getErrorMessage()",
-      "norm_label": "geterrormessage()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L26"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "index_placeorder",
-      "label": "placeOrder()",
-      "norm_label": "placeorder()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L71"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "bootstrap_bootstrapcheckout",
-      "label": "bootstrapCheckout()",
-      "norm_label": "bootstrapcheckout()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "bootstrap_createbootstraptoken",
-      "label": "createBootstrapToken()",
-      "norm_label": "createbootstraptoken()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "bootstrap_createmarker",
-      "label": "createMarker()",
-      "norm_label": "createmarker()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
-      "label": "bootstrap.ts",
-      "norm_label": "bootstrap.ts",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "app_test_createinmemoryredis",
-      "label": "createInMemoryRedis()",
-      "norm_label": "createinmemoryredis()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L33"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "app_test_createresponserecorder",
-      "label": "createResponseRecorder()",
-      "norm_label": "createresponserecorder()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L6"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "app_test_createsilentlogger",
-      "label": "createSilentLogger()",
-      "norm_label": "createsilentlogger()",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L25"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_app_test_js",
-      "label": "app.test.js",
-      "norm_label": "app.test.js",
-      "source_file": "packages/valkey-proxy-server/app.test.js",
-      "source_location": "L1"
     },
     {
       "community": 2,
@@ -43413,6 +43821,114 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "index_cancelorder",
+      "label": "cancelOrder()",
+      "norm_label": "cancelorder()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L121"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "index_geterrormessage",
+      "label": "getErrorMessage()",
+      "norm_label": "geterrormessage()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "index_placeorder",
+      "label": "placeOrder()",
+      "norm_label": "placeorder()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L71"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "bootstrap_bootstrapcheckout",
+      "label": "bootstrapCheckout()",
+      "norm_label": "bootstrapcheckout()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "bootstrap_createbootstraptoken",
+      "label": "createBootstrapToken()",
+      "norm_label": "createbootstraptoken()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "bootstrap_createmarker",
+      "label": "createMarker()",
+      "norm_label": "createmarker()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
+      "label": "bootstrap.ts",
+      "norm_label": "bootstrap.ts",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "app_test_createinmemoryredis",
+      "label": "createInMemoryRedis()",
+      "norm_label": "createinmemoryredis()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L33"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "app_test_createresponserecorder",
+      "label": "createResponseRecorder()",
+      "norm_label": "createresponserecorder()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L6"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "app_test_createsilentlogger",
+      "label": "createSilentLogger()",
+      "norm_label": "createsilentlogger()",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L25"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "packages_valkey_proxy_server_app_test_js",
+      "label": "app.test.js",
+      "norm_label": "app.test.js",
+      "source_file": "packages/valkey-proxy-server/app.test.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -43420,7 +43936,7 @@
       "source_location": "L17"
     },
     {
-      "community": 200,
+      "community": 203,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -43429,7 +43945,7 @@
       "source_location": "L11"
     },
     {
-      "community": 200,
+      "community": 203,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -43438,7 +43954,7 @@
       "source_location": "L24"
     },
     {
-      "community": 200,
+      "community": 203,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -43447,7 +43963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 204,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -43456,7 +43972,7 @@
       "source_location": "L20"
     },
     {
-      "community": 201,
+      "community": 204,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -43465,7 +43981,7 @@
       "source_location": "L65"
     },
     {
-      "community": 201,
+      "community": 204,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -43474,7 +43990,7 @@
       "source_location": "L14"
     },
     {
-      "community": 201,
+      "community": 204,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -43483,7 +43999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 205,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -43492,7 +44008,7 @@
       "source_location": "L126"
     },
     {
-      "community": 202,
+      "community": 205,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -43501,7 +44017,7 @@
       "source_location": "L130"
     },
     {
-      "community": 202,
+      "community": 205,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -43510,7 +44026,7 @@
       "source_location": "L615"
     },
     {
-      "community": 202,
+      "community": 205,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -43519,7 +44035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 206,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -43528,7 +44044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 206,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -43537,7 +44053,7 @@
       "source_location": "L8"
     },
     {
-      "community": 203,
+      "community": 206,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -43546,7 +44062,7 @@
       "source_location": "L79"
     },
     {
-      "community": 203,
+      "community": 206,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -43555,7 +44071,7 @@
       "source_location": "L61"
     },
     {
-      "community": 204,
+      "community": 207,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -43564,7 +44080,7 @@
       "source_location": "L49"
     },
     {
-      "community": 204,
+      "community": 207,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -43573,7 +44089,7 @@
       "source_location": "L17"
     },
     {
-      "community": 204,
+      "community": 207,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -43582,7 +44098,7 @@
       "source_location": "L11"
     },
     {
-      "community": 204,
+      "community": 207,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -43591,7 +44107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 208,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -43600,7 +44116,7 @@
       "source_location": "L26"
     },
     {
-      "community": 205,
+      "community": 208,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -43609,7 +44125,7 @@
       "source_location": "L72"
     },
     {
-      "community": 205,
+      "community": 208,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -43618,7 +44134,7 @@
       "source_location": "L36"
     },
     {
-      "community": 205,
+      "community": 208,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -43627,7 +44143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 209,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -43636,7 +44152,7 @@
       "source_location": "L90"
     },
     {
-      "community": 206,
+      "community": 209,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -43645,7 +44161,7 @@
       "source_location": "L88"
     },
     {
-      "community": 206,
+      "community": 209,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -43654,94 +44170,13 @@
       "source_location": "L89"
     },
     {
-      "community": 206,
+      "community": 209,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
       "norm_label": "pre-push-review.test.ts",
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 207,
-      "file_type": "code",
-      "id": "discountcode_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 207,
-      "file_type": "code",
-      "id": "discountcode_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 207,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
-      "label": "DiscountCode.tsx",
-      "norm_label": "discountcode.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "discountreminder_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "discountreminder_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
-      "label": "DiscountReminder.tsx",
-      "norm_label": "discountreminder.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "utils_getstoredatafromrequest",
-      "label": "getStoreDataFromRequest()",
-      "norm_label": "getstoredatafromrequest()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "utils_getstorefrontuserfromrequest",
-      "label": "getStorefrontUserFromRequest()",
-      "norm_label": "getstorefrontuserfromrequest()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L12"
     },
     {
       "community": 21,
@@ -43881,6 +44316,87 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "discountcode_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "discountcode_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
+      "label": "DiscountCode.tsx",
+      "norm_label": "discountcode.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "discountreminder_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "discountreminder_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
+      "label": "DiscountReminder.tsx",
+      "norm_label": "discountreminder.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 212,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 212,
+      "file_type": "code",
+      "id": "utils_getstoredatafromrequest",
+      "label": "getStoreDataFromRequest()",
+      "norm_label": "getstoredatafromrequest()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 212,
+      "file_type": "code",
+      "id": "utils_getstorefrontuserfromrequest",
+      "label": "getStorefrontUserFromRequest()",
+      "norm_label": "getstorefrontuserfromrequest()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 213,
+      "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
       "norm_label": "calculateactivitytrend()",
@@ -43888,7 +44404,7 @@
       "source_location": "L43"
     },
     {
-      "community": 210,
+      "community": 213,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -43897,7 +44413,7 @@
       "source_location": "L11"
     },
     {
-      "community": 210,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -43906,7 +44422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 214,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
       "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
@@ -43915,7 +44431,7 @@
       "source_location": "L75"
     },
     {
-      "community": 211,
+      "community": 214,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestwithctx",
       "label": "decideApprovalRequestWithCtx()",
@@ -43924,7 +44440,7 @@
       "source_location": "L25"
     },
     {
-      "community": 211,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "label": "approvalRequests.ts",
@@ -43933,7 +44449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
       "label": "staffProfiles.ts",
@@ -43942,7 +44458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 215,
       "file_type": "code",
       "id": "staffprofiles_buildfullname",
       "label": "buildFullName()",
@@ -43951,7 +44467,7 @@
       "source_location": "L12"
     },
     {
-      "community": 212,
+      "community": 215,
       "file_type": "code",
       "id": "staffprofiles_buildroleassignmentdrafts",
       "label": "buildRoleAssignmentDrafts()",
@@ -43960,7 +44476,7 @@
       "source_location": "L17"
     },
     {
-      "community": 213,
+      "community": 216,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -43969,7 +44485,7 @@
       "source_location": "L7"
     },
     {
-      "community": 213,
+      "community": 216,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -43978,7 +44494,7 @@
       "source_location": "L109"
     },
     {
-      "community": 213,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -43987,7 +44503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 217,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -43996,7 +44512,7 @@
       "source_location": "L16"
     },
     {
-      "community": 214,
+      "community": 217,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -44005,7 +44521,7 @@
       "source_location": "L42"
     },
     {
-      "community": 214,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -44014,7 +44530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -44023,7 +44539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 218,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -44032,7 +44548,7 @@
       "source_location": "L23"
     },
     {
-      "community": 215,
+      "community": 218,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -44041,7 +44557,7 @@
       "source_location": "L16"
     },
     {
-      "community": 216,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -44050,7 +44566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 219,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -44059,94 +44575,13 @@
       "source_location": "L12"
     },
     {
-      "community": 216,
+      "community": 219,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
       "source_location": "L7"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "bag_listbagitems",
-      "label": "listBagItems()",
-      "norm_label": "listbagitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "bag_loadbagwithitems",
-      "label": "loadBagWithItems()",
-      "norm_label": "loadbagwithitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_view_tsx",
-      "label": "View.tsx",
-      "norm_label": "view.tsx",
-      "source_file": "packages/athena-webapp/src/components/View.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_view_tsx",
-      "label": "View.tsx",
-      "norm_label": "view.tsx",
-      "source_file": "packages/storefront-webapp/src/components/View.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 218,
-      "file_type": "code",
-      "id": "view_view",
-      "label": "View()",
-      "norm_label": "view()",
-      "source_file": "packages/storefront-webapp/src/components/View.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
-      "label": "ProductAvailability.tsx",
-      "norm_label": "productavailability.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "productavailability_productavailability",
-      "label": "ProductAvailability()",
-      "norm_label": "productavailability()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "productavailability_productavailabilityview",
-      "label": "ProductAvailabilityView()",
-      "norm_label": "productavailabilityview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L5"
     },
     {
       "community": 22,
@@ -44277,6 +44712,87 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "bag_listbagitems",
+      "label": "listBagItems()",
+      "norm_label": "listbagitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "bag_loadbagwithitems",
+      "label": "loadBagWithItems()",
+      "norm_label": "loadbagwithitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_view_tsx",
+      "label": "View.tsx",
+      "norm_label": "view.tsx",
+      "source_file": "packages/athena-webapp/src/components/View.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_view_tsx",
+      "label": "View.tsx",
+      "norm_label": "view.tsx",
+      "source_file": "packages/storefront-webapp/src/components/View.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
+      "id": "view_view",
+      "label": "View()",
+      "norm_label": "view()",
+      "source_file": "packages/storefront-webapp/src/components/View.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
+      "label": "ProductAvailability.tsx",
+      "norm_label": "productavailability.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "productavailability_productavailability",
+      "label": "ProductAvailability()",
+      "norm_label": "productavailability()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "productavailability_productavailabilityview",
+      "label": "ProductAvailabilityView()",
+      "norm_label": "productavailabilityview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
       "norm_label": "sheetprovider.tsx",
@@ -44284,7 +44800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 220,
+      "community": 223,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -44293,7 +44809,7 @@
       "source_location": "L19"
     },
     {
-      "community": 220,
+      "community": 223,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -44302,7 +44818,7 @@
       "source_location": "L11"
     },
     {
-      "community": 221,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -44311,7 +44827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 224,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -44320,7 +44836,7 @@
       "source_location": "L21"
     },
     {
-      "community": 221,
+      "community": 224,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -44329,7 +44845,7 @@
       "source_location": "L8"
     },
     {
-      "community": 222,
+      "community": 225,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -44338,7 +44854,7 @@
       "source_location": "L21"
     },
     {
-      "community": 222,
+      "community": 225,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -44347,7 +44863,7 @@
       "source_location": "L13"
     },
     {
-      "community": 222,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -44356,7 +44872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 226,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -44365,7 +44881,7 @@
       "source_location": "L100"
     },
     {
-      "community": 223,
+      "community": 226,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -44374,7 +44890,7 @@
       "source_location": "L10"
     },
     {
-      "community": 223,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -44383,7 +44899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 227,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -44392,7 +44908,7 @@
       "source_location": "L100"
     },
     {
-      "community": 224,
+      "community": 227,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -44401,7 +44917,7 @@
       "source_location": "L10"
     },
     {
-      "community": 224,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -44410,7 +44926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 228,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -44419,7 +44935,7 @@
       "source_location": "L15"
     },
     {
-      "community": 225,
+      "community": 228,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -44428,7 +44944,7 @@
       "source_location": "L39"
     },
     {
-      "community": 225,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -44437,7 +44953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 229,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -44446,7 +44962,7 @@
       "source_location": "L51"
     },
     {
-      "community": 226,
+      "community": 229,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -44455,93 +44971,12 @@
       "source_location": "L59"
     },
     {
-      "community": 226,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
       "norm_label": "inputotp.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "fadein_fadein",
-      "label": "FadeIn()",
-      "norm_label": "fadein()",
-      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_fadein_tsx",
-      "label": "FadeIn.tsx",
-      "norm_label": "fadein.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/FadeIn.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
-      "label": "FadeIn.tsx",
-      "norm_label": "fadein.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "bestsellers_handleremovebestseller",
-      "label": "handleRemoveBestSeller()",
-      "norm_label": "handleremovebestseller()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "bestsellers_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
-      "label": "BestSellers.tsx",
-      "norm_label": "bestsellers.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "featuredsection_handlehighlighteditem",
-      "label": "handleHighlightedItem()",
-      "norm_label": "handlehighlighteditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "featuredsection_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
-      "label": "FeaturedSection.tsx",
-      "norm_label": "featuredsection.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1"
     },
     {
@@ -44673,6 +45108,87 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "fadein_fadein",
+      "label": "FadeIn()",
+      "norm_label": "fadein()",
+      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_fadein_tsx",
+      "label": "FadeIn.tsx",
+      "norm_label": "fadein.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/FadeIn.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
+      "label": "FadeIn.tsx",
+      "norm_label": "fadein.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "bestsellers_handleremovebestseller",
+      "label": "handleRemoveBestSeller()",
+      "norm_label": "handleremovebestseller()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "bestsellers_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
+      "label": "BestSellers.tsx",
+      "norm_label": "bestsellers.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "featuredsection_handlehighlighteditem",
+      "label": "handleHighlightedItem()",
+      "norm_label": "handlehighlighteditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "featuredsection_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
+      "label": "FeaturedSection.tsx",
+      "norm_label": "featuredsection.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
       "norm_label": "videoplayer.tsx",
@@ -44680,7 +45196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 230,
+      "community": 233,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -44689,7 +45205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 230,
+      "community": 233,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
@@ -44698,7 +45214,7 @@
       "source_location": "L9"
     },
     {
-      "community": 231,
+      "community": 234,
       "file_type": "code",
       "id": "operationsqueueview_handledecideapprovalrequest",
       "label": "handleDecideApprovalRequest()",
@@ -44707,7 +45223,7 @@
       "source_location": "L289"
     },
     {
-      "community": 231,
+      "community": 234,
       "file_type": "code",
       "id": "operationsqueueview_handlesubmitstockbatch",
       "label": "handleSubmitStockBatch()",
@@ -44716,7 +45232,7 @@
       "source_location": "L279"
     },
     {
-      "community": 231,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -44725,7 +45241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -44734,7 +45250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 235,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -44743,7 +45259,7 @@
       "source_location": "L67"
     },
     {
-      "community": 232,
+      "community": 235,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -44752,7 +45268,7 @@
       "source_location": "L9"
     },
     {
-      "community": 233,
+      "community": 236,
       "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
@@ -44761,7 +45277,7 @@
       "source_location": "L100"
     },
     {
-      "community": 233,
+      "community": 236,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -44770,7 +45286,7 @@
       "source_location": "L95"
     },
     {
-      "community": 233,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -44779,7 +45295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 237,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -44788,7 +45304,7 @@
       "source_location": "L59"
     },
     {
-      "community": 234,
+      "community": 237,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -44797,7 +45313,7 @@
       "source_location": "L55"
     },
     {
-      "community": 234,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -44806,7 +45322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -44815,7 +45331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 238,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -44824,7 +45340,7 @@
       "source_location": "L20"
     },
     {
-      "community": 235,
+      "community": 238,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -44833,7 +45349,7 @@
       "source_location": "L26"
     },
     {
-      "community": 236,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -44842,7 +45358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 239,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -44851,94 +45367,13 @@
       "source_location": "L65"
     },
     {
-      "community": 236,
+      "community": 239,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
       "norm_label": "productactionstogglegroup()",
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L20"
-    },
-    {
-      "community": 237,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
-      "label": "ProductsTableContext.tsx",
-      "norm_label": "productstablecontext.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 237,
-      "file_type": "code",
-      "id": "productstablecontext_productstableprovider",
-      "label": "ProductsTableProvider()",
-      "norm_label": "productstableprovider()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 237,
-      "file_type": "code",
-      "id": "productstablecontext_useproductstablestate",
-      "label": "useProductsTableState()",
-      "norm_label": "useproductstablestate()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
-      "source_location": "L60"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
-      "label": "StoreProductsView.tsx",
-      "norm_label": "storeproductsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "storeproductsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "storeproductsview_productactionstogglegroup",
-      "label": "ProductActionsToggleGroup()",
-      "norm_label": "productactionstogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "addcomplimentaryproduct_addcomplimentaryproduct",
-      "label": "AddComplimentaryProduct()",
-      "norm_label": "addcomplimentaryproduct()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
-      "source_location": "L128"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
-      "label": "handleAddComplimentaryProducts()",
-      "norm_label": "handleaddcomplimentaryproducts()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
-      "source_location": "L40"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
-      "label": "AddComplimentaryProduct.tsx",
-      "norm_label": "addcomplimentaryproduct.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
-      "source_location": "L1"
     },
     {
       "community": 24,
@@ -45060,6 +45495,87 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
+      "label": "ProductsTableContext.tsx",
+      "norm_label": "productstablecontext.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "productstablecontext_productstableprovider",
+      "label": "ProductsTableProvider()",
+      "norm_label": "productstableprovider()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "productstablecontext_useproductstablestate",
+      "label": "useProductsTableState()",
+      "norm_label": "useproductstablestate()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
+      "source_location": "L60"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
+      "label": "StoreProductsView.tsx",
+      "norm_label": "storeproductsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "storeproductsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "storeproductsview_productactionstogglegroup",
+      "label": "ProductActionsToggleGroup()",
+      "norm_label": "productactionstogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "addcomplimentaryproduct_addcomplimentaryproduct",
+      "label": "AddComplimentaryProduct()",
+      "norm_label": "addcomplimentaryproduct()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
+      "source_location": "L128"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
+      "label": "handleAddComplimentaryProducts()",
+      "norm_label": "handleaddcomplimentaryproducts()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
+      "label": "AddComplimentaryProduct.tsx",
+      "norm_label": "addcomplimentaryproduct.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
       "norm_label": "handleblur()",
@@ -45067,7 +45583,7 @@
       "source_location": "L24"
     },
     {
-      "community": 240,
+      "community": 243,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -45076,7 +45592,7 @@
       "source_location": "L20"
     },
     {
-      "community": 240,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -45085,7 +45601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 244,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -45094,7 +45610,7 @@
       "source_location": "L25"
     },
     {
-      "community": 241,
+      "community": 244,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -45103,7 +45619,7 @@
       "source_location": "L17"
     },
     {
-      "community": 241,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -45112,7 +45628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -45121,7 +45637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 245,
       "file_type": "code",
       "id": "serviceintakeview_handlecreateintake",
       "label": "handleCreateIntake()",
@@ -45130,7 +45646,7 @@
       "source_location": "L238"
     },
     {
-      "community": 242,
+      "community": 245,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -45139,7 +45655,7 @@
       "source_location": "L69"
     },
     {
-      "community": 243,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -45148,7 +45664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 246,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -45157,7 +45673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 246,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -45166,7 +45682,7 @@
       "source_location": "L3"
     },
     {
-      "community": 244,
+      "community": 247,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -45175,7 +45691,7 @@
       "source_location": "L9"
     },
     {
-      "community": 244,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -45184,7 +45700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 247,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -45193,7 +45709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 248,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -45202,7 +45718,7 @@
       "source_location": "L3"
     },
     {
-      "community": 245,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -45211,7 +45727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 248,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -45220,7 +45736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 249,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -45229,7 +45745,7 @@
       "source_location": "L3"
     },
     {
-      "community": 246,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -45238,93 +45754,12 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 249,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
       "norm_label": "dashboard-skeleton.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
-      "label": "table-skeleton.tsx",
-      "norm_label": "table-skeleton.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/loading/table-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
-      "label": "table-skeleton.tsx",
-      "norm_label": "table-skeleton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "table_skeleton_tableskeleton",
-      "label": "TableSkeleton()",
-      "norm_label": "tableskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
-      "label": "transactions-skeleton.tsx",
-      "norm_label": "transactions-skeleton.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/loading/transactions-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
-      "label": "transactions-skeleton.tsx",
-      "norm_label": "transactions-skeleton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "transactions_skeleton_transactionsskeleton",
-      "label": "TransactionsSkeleton()",
-      "norm_label": "transactionsskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "notfound_notfound",
-      "label": "NotFound()",
-      "norm_label": "notfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
-      "label": "NotFound.tsx",
-      "norm_label": "notfound.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFound.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
-      "label": "NotFound.tsx",
-      "norm_label": "notfound.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1"
     },
     {
@@ -45447,6 +45882,87 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
+      "label": "table-skeleton.tsx",
+      "norm_label": "table-skeleton.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/loading/table-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
+      "label": "table-skeleton.tsx",
+      "norm_label": "table-skeleton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "table_skeleton_tableskeleton",
+      "label": "TableSkeleton()",
+      "norm_label": "tableskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
+      "label": "transactions-skeleton.tsx",
+      "norm_label": "transactions-skeleton.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/loading/transactions-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
+      "label": "transactions-skeleton.tsx",
+      "norm_label": "transactions-skeleton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "transactions_skeleton_transactionsskeleton",
+      "label": "TransactionsSkeleton()",
+      "norm_label": "transactionsskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "notfound_notfound",
+      "label": "NotFound()",
+      "norm_label": "notfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
+      "label": "NotFound.tsx",
+      "norm_label": "notfound.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFound.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
+      "label": "NotFound.tsx",
+      "norm_label": "notfound.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
       "norm_label": "handletoggleallfees()",
@@ -45454,7 +45970,7 @@
       "source_location": "L104"
     },
     {
-      "community": 250,
+      "community": 253,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -45463,7 +45979,7 @@
       "source_location": "L36"
     },
     {
-      "community": 250,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -45472,7 +45988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 254,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -45481,7 +45997,7 @@
       "source_location": "L20"
     },
     {
-      "community": 251,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -45490,7 +46006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 254,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -45499,7 +46015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 255,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -45508,7 +46024,7 @@
       "source_location": "L30"
     },
     {
-      "community": 252,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -45517,7 +46033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 255,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -45526,7 +46042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 256,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -45535,7 +46051,7 @@
       "source_location": "L9"
     },
     {
-      "community": 253,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -45544,7 +46060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 256,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -45553,7 +46069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 257,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -45562,7 +46078,7 @@
       "source_location": "L38"
     },
     {
-      "community": 254,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -45571,7 +46087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 257,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -45580,7 +46096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 258,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -45589,7 +46105,7 @@
       "source_location": "L20"
     },
     {
-      "community": 255,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -45598,7 +46114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 258,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -45607,7 +46123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 259,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -45616,7 +46132,7 @@
       "source_location": "L12"
     },
     {
-      "community": 256,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -45625,94 +46141,13 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 259,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
       "norm_label": "overlay-modal.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
-      "label": "skeleton.tsx",
-      "norm_label": "skeleton.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
-      "label": "skeleton.tsx",
-      "norm_label": "skeleton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "skeleton_skeleton",
-      "label": "Skeleton()",
-      "norm_label": "skeleton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
-      "label": "sonner.tsx",
-      "norm_label": "sonner.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sonner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
-      "label": "sonner.tsx",
-      "norm_label": "sonner.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "sonner_toaster",
-      "label": "Toaster()",
-      "norm_label": "toaster()",
-      "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
-      "label": "spinner.tsx",
-      "norm_label": "spinner.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/spinner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
-      "label": "spinner.tsx",
-      "norm_label": "spinner.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "spinner_spinner",
-      "label": "Spinner()",
-      "norm_label": "spinner()",
-      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
-      "source_location": "L3"
     },
     {
       "community": 26,
@@ -45834,6 +46269,87 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
+      "label": "skeleton.tsx",
+      "norm_label": "skeleton.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
+      "label": "skeleton.tsx",
+      "norm_label": "skeleton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "skeleton_skeleton",
+      "label": "Skeleton()",
+      "norm_label": "skeleton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
+      "label": "sonner.tsx",
+      "norm_label": "sonner.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sonner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
+      "label": "sonner.tsx",
+      "norm_label": "sonner.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "sonner_toaster",
+      "label": "Toaster()",
+      "norm_label": "toaster()",
+      "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
+      "label": "spinner.tsx",
+      "norm_label": "spinner.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/spinner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
+      "label": "spinner.tsx",
+      "norm_label": "spinner.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "spinner_spinner",
+      "label": "Spinner()",
+      "norm_label": "spinner()",
+      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 263,
+      "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
       "norm_label": "activitysummarycards()",
@@ -45841,7 +46357,7 @@
       "source_location": "L44"
     },
     {
-      "community": 260,
+      "community": 263,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -45850,7 +46366,7 @@
       "source_location": "L19"
     },
     {
-      "community": 260,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -45859,7 +46375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -45868,7 +46384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 264,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -45877,7 +46393,7 @@
       "source_location": "L159"
     },
     {
-      "community": 261,
+      "community": 264,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -45886,7 +46402,7 @@
       "source_location": "L195"
     },
     {
-      "community": 262,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -45895,7 +46411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 265,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -45904,7 +46420,7 @@
       "source_location": "L22"
     },
     {
-      "community": 262,
+      "community": 265,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -45913,7 +46429,7 @@
       "source_location": "L45"
     },
     {
-      "community": 263,
+      "community": 266,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -45922,7 +46438,7 @@
       "source_location": "L24"
     },
     {
-      "community": 263,
+      "community": 266,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -45931,7 +46447,7 @@
       "source_location": "L38"
     },
     {
-      "community": 263,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -45940,7 +46456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -45949,7 +46465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 267,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -45958,7 +46474,7 @@
       "source_location": "L23"
     },
     {
-      "community": 264,
+      "community": 267,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -45967,7 +46483,7 @@
       "source_location": "L51"
     },
     {
-      "community": 265,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -45976,7 +46492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 268,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -45985,7 +46501,7 @@
       "source_location": "L54"
     },
     {
-      "community": 265,
+      "community": 268,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -45994,7 +46510,7 @@
       "source_location": "L282"
     },
     {
-      "community": 266,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -46003,7 +46519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 269,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -46012,94 +46528,13 @@
       "source_location": "L12"
     },
     {
-      "community": 266,
+      "community": 269,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
       "norm_label": "useusercontext()",
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L37"
-    },
-    {
-      "community": 267,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useauth_ts",
-      "label": "useAuth.ts",
-      "norm_label": "useauth.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useAuth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 267,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useauth_ts",
-      "label": "useAuth.ts",
-      "norm_label": "useauth.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 267,
-      "file_type": "code",
-      "id": "useauth_useauth",
-      "label": "useAuth()",
-      "norm_label": "useauth()",
-      "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
-      "label": "useGetActiveStore.ts",
-      "norm_label": "usegetactivestore.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "usegetactivestore_usegetactivestore",
-      "label": "useGetActiveStore()",
-      "norm_label": "usegetactivestore()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "usegetactivestore_usegetstores",
-      "label": "useGetStores()",
-      "norm_label": "usegetstores()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
-      "label": "useGetOrganizations.ts",
-      "norm_label": "usegetorganizations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "usegetorganizations_usegetactiveorganization",
-      "label": "useGetActiveOrganization()",
-      "norm_label": "usegetactiveorganization()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "usegetorganizations_usegetorganizations",
-      "label": "useGetOrganizations()",
-      "norm_label": "usegetorganizations()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L31"
     },
     {
       "community": 27,
@@ -46221,6 +46656,87 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useauth_ts",
+      "label": "useAuth.ts",
+      "norm_label": "useauth.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useAuth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useauth_ts",
+      "label": "useAuth.ts",
+      "norm_label": "useauth.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "useauth_useauth",
+      "label": "useAuth()",
+      "norm_label": "useauth()",
+      "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
+      "label": "useGetActiveStore.ts",
+      "norm_label": "usegetactivestore.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
+      "id": "usegetactivestore_usegetactivestore",
+      "label": "useGetActiveStore()",
+      "norm_label": "usegetactivestore()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
+      "id": "usegetactivestore_usegetstores",
+      "label": "useGetStores()",
+      "norm_label": "usegetstores()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 272,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
+      "label": "useGetOrganizations.ts",
+      "norm_label": "usegetorganizations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 272,
+      "file_type": "code",
+      "id": "usegetorganizations_usegetactiveorganization",
+      "label": "useGetActiveOrganization()",
+      "norm_label": "usegetactiveorganization()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 272,
+      "file_type": "code",
+      "id": "usegetorganizations_usegetorganizations",
+      "label": "useGetOrganizations()",
+      "norm_label": "usegetorganizations()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
       "norm_label": "usegetproducts.ts",
@@ -46228,7 +46744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 273,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -46237,7 +46753,7 @@
       "source_location": "L5"
     },
     {
-      "community": 270,
+      "community": 273,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -46246,7 +46762,7 @@
       "source_location": "L31"
     },
     {
-      "community": 271,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposoperations_ts",
       "label": "usePOSOperations.ts",
@@ -46255,7 +46771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 274,
       "file_type": "code",
       "id": "useposoperations_useposoperations",
       "label": "usePOSOperations()",
@@ -46264,7 +46780,7 @@
       "source_location": "L30"
     },
     {
-      "community": 271,
+      "community": 274,
       "file_type": "code",
       "id": "useposoperations_useposstate",
       "label": "usePOSState()",
@@ -46273,7 +46789,7 @@
       "source_location": "L580"
     },
     {
-      "community": 272,
+      "community": 275,
       "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
@@ -46282,7 +46798,7 @@
       "source_location": "L7"
     },
     {
-      "community": 272,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -46291,7 +46807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 275,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -46300,7 +46816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 276,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -46309,7 +46825,7 @@
       "source_location": "L3"
     },
     {
-      "community": 273,
+      "community": 276,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -46318,7 +46834,7 @@
       "source_location": "L10"
     },
     {
-      "community": 273,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -46327,7 +46843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 277,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -46336,7 +46852,7 @@
       "source_location": "L31"
     },
     {
-      "community": 274,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -46345,7 +46861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 277,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -46354,7 +46870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 278,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -46363,7 +46879,7 @@
       "source_location": "L18"
     },
     {
-      "community": 275,
+      "community": 278,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -46372,7 +46888,7 @@
       "source_location": "L38"
     },
     {
-      "community": 275,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -46381,7 +46897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 279,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -46390,7 +46906,7 @@
       "source_location": "L127"
     },
     {
-      "community": 276,
+      "community": 279,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -46399,94 +46915,13 @@
       "source_location": "L106"
     },
     {
-      "community": 276,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
       "norm_label": "admin-shell-patterns.tsx",
       "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "inventoryvalidationlogic_test_mockgetsku",
-      "label": "mockGetSku()",
-      "norm_label": "mockgetsku()",
-      "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
-      "label": "validateInventoryForTransaction()",
-      "norm_label": "validateinventoryfortransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
-      "label": "inventoryValidationLogic.test.ts",
-      "norm_label": "inventoryvalidationlogic.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "index_hashpassword",
-      "label": "hashPassword()",
-      "norm_label": "hashpassword()",
-      "source_file": "packages/storefront-webapp/src/utils/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_utils_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/utils/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_utils_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/storefront-webapp/src/utils/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "versionchecker_createversionchecker",
-      "label": "createVersionChecker()",
-      "norm_label": "createversionchecker()",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L16"
     },
     {
       "community": 28,
@@ -46599,6 +47034,87 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "inventoryvalidationlogic_test_mockgetsku",
+      "label": "mockGetSku()",
+      "norm_label": "mockgetsku()",
+      "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
+      "label": "validateInventoryForTransaction()",
+      "norm_label": "validateinventoryfortransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
+      "label": "inventoryValidationLogic.test.ts",
+      "norm_label": "inventoryvalidationlogic.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "index_hashpassword",
+      "label": "hashPassword()",
+      "norm_label": "hashpassword()",
+      "source_file": "packages/storefront-webapp/src/utils/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_utils_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/utils/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_utils_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/storefront-webapp/src/utils/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "versionchecker_createversionchecker",
+      "label": "createVersionChecker()",
+      "norm_label": "createversionchecker()",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 283,
+      "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
       "norm_label": "vite.config.ts",
@@ -46606,7 +47122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 283,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -46615,7 +47131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 283,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -46624,7 +47140,7 @@
       "source_location": "L19"
     },
     {
-      "community": 281,
+      "community": 284,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -46633,7 +47149,7 @@
       "source_location": "L32"
     },
     {
-      "community": 281,
+      "community": 284,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -46642,7 +47158,7 @@
       "source_location": "L3"
     },
     {
-      "community": 281,
+      "community": 284,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -46651,7 +47167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 285,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -46660,7 +47176,7 @@
       "source_location": "L7"
     },
     {
-      "community": 282,
+      "community": 285,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -46669,7 +47185,7 @@
       "source_location": "L5"
     },
     {
-      "community": 282,
+      "community": 285,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -46678,7 +47194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 286,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -46687,7 +47203,7 @@
       "source_location": "L6"
     },
     {
-      "community": 283,
+      "community": 286,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -46696,7 +47212,7 @@
       "source_location": "L18"
     },
     {
-      "community": 283,
+      "community": 286,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -46705,7 +47221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 287,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -46714,7 +47230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 287,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -46723,7 +47239,7 @@
       "source_location": "L3"
     },
     {
-      "community": 284,
+      "community": 287,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -46732,7 +47248,7 @@
       "source_location": "L5"
     },
     {
-      "community": 285,
+      "community": 288,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -46741,7 +47257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 288,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -46750,7 +47266,7 @@
       "source_location": "L18"
     },
     {
-      "community": 285,
+      "community": 288,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -46759,7 +47275,7 @@
       "source_location": "L23"
     },
     {
-      "community": 286,
+      "community": 289,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -46768,7 +47284,7 @@
       "source_location": "L22"
     },
     {
-      "community": 286,
+      "community": 289,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -46777,93 +47293,12 @@
       "source_location": "L55"
     },
     {
-      "community": 286,
+      "community": 289,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
       "norm_label": "customerdetails.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "deliveryoptionsselector_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "deliveryoptionsselector_storeselector",
-      "label": "StoreSelector()",
-      "norm_label": "storeselector()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
-      "label": "DeliveryOptionsSelector.tsx",
-      "norm_label": "deliveryoptionsselector.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "deliverysection_deliverydetails",
-      "label": "DeliveryDetails()",
-      "norm_label": "deliverydetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "deliverysection_deliveryoptions",
-      "label": "DeliveryOptions()",
-      "norm_label": "deliveryoptions()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
-      "label": "DeliverySection.tsx",
-      "norm_label": "deliverysection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "mobilebagsummary_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "mobilebagsummary_handleredeempromocode",
-      "label": "handleRedeemPromoCode()",
-      "norm_label": "handleredeempromocode()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
-      "label": "MobileBagSummary.tsx",
-      "norm_label": "mobilebagsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L1"
     },
     {
@@ -46968,6 +47403,87 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "deliveryoptionsselector_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "deliveryoptionsselector_storeselector",
+      "label": "StoreSelector()",
+      "norm_label": "storeselector()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
+      "label": "DeliveryOptionsSelector.tsx",
+      "norm_label": "deliveryoptionsselector.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "deliverysection_deliverydetails",
+      "label": "DeliveryDetails()",
+      "norm_label": "deliverydetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "deliverysection_deliveryoptions",
+      "label": "DeliveryOptions()",
+      "norm_label": "deliveryoptions()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
+      "label": "DeliverySection.tsx",
+      "norm_label": "deliverysection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 292,
+      "file_type": "code",
+      "id": "mobilebagsummary_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 292,
+      "file_type": "code",
+      "id": "mobilebagsummary_handleredeempromocode",
+      "label": "handleRedeemPromoCode()",
+      "norm_label": "handleredeempromocode()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 292,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
+      "label": "MobileBagSummary.tsx",
+      "norm_label": "mobilebagsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
       "norm_label": "loadcheckoutstate()",
@@ -46975,7 +47491,7 @@
       "source_location": "L4"
     },
     {
-      "community": 290,
+      "community": 293,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -46984,7 +47500,7 @@
       "source_location": "L24"
     },
     {
-      "community": 290,
+      "community": 293,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -46993,7 +47509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 294,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -47002,7 +47518,7 @@
       "source_location": "L131"
     },
     {
-      "community": 291,
+      "community": 294,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -47011,7 +47527,7 @@
       "source_location": "L12"
     },
     {
-      "community": 291,
+      "community": 294,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -47020,7 +47536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 295,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -47029,7 +47545,7 @@
       "source_location": "L20"
     },
     {
-      "community": 292,
+      "community": 295,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -47038,7 +47554,7 @@
       "source_location": "L46"
     },
     {
-      "community": 292,
+      "community": 295,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -47047,7 +47563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -47056,7 +47572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 296,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -47065,7 +47581,7 @@
       "source_location": "L20"
     },
     {
-      "community": 293,
+      "community": 296,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -47074,7 +47590,7 @@
       "source_location": "L59"
     },
     {
-      "community": 294,
+      "community": 297,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -47083,7 +47599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 297,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -47092,7 +47608,7 @@
       "source_location": "L25"
     },
     {
-      "community": 294,
+      "community": 297,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -47101,7 +47617,7 @@
       "source_location": "L20"
     },
     {
-      "community": 295,
+      "community": 298,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -47110,7 +47626,7 @@
       "source_location": "L30"
     },
     {
-      "community": 295,
+      "community": 298,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -47119,7 +47635,7 @@
       "source_location": "L95"
     },
     {
-      "community": 295,
+      "community": 298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -47128,7 +47644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 299,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -47137,7 +47653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 299,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -47146,94 +47662,13 @@
       "source_location": "L61"
     },
     {
-      "community": 296,
+      "community": 299,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
       "norm_label": "handleclick()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L65"
-    },
-    {
-      "community": 297,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
-      "label": "ReviewEditor.tsx",
-      "norm_label": "revieweditor.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 297,
-      "file_type": "code",
-      "id": "revieweditor_handleformdatachange",
-      "label": "handleFormDataChange()",
-      "norm_label": "handleformdatachange()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 297,
-      "file_type": "code",
-      "id": "revieweditor_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L157"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
-      "label": "UpsellModalForm.tsx",
-      "norm_label": "upsellmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "upsellmodalform_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "upsellmodalform_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
-      "label": "WelcomeBackModal.tsx",
-      "norm_label": "welcomebackmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "welcomebackmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "welcomebackmodal_handlesuccess",
-      "label": "handleSuccess()",
-      "norm_label": "handlesuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L76"
     },
     {
       "community": 3,
@@ -47616,6 +48051,87 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
+      "label": "ReviewEditor.tsx",
+      "norm_label": "revieweditor.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "revieweditor_handleformdatachange",
+      "label": "handleFormDataChange()",
+      "norm_label": "handleformdatachange()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "revieweditor_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L157"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
+      "label": "UpsellModalForm.tsx",
+      "norm_label": "upsellmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "upsellmodalform_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "upsellmodalform_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
+      "label": "WelcomeBackModal.tsx",
+      "norm_label": "welcomebackmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
+      "id": "welcomebackmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
+      "id": "welcomebackmodal_handlesuccess",
+      "label": "handleSuccess()",
+      "norm_label": "handlesuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 303,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
       "norm_label": "welcomebackmodalform.tsx",
@@ -47623,7 +48139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 303,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -47632,7 +48148,7 @@
       "source_location": "L51"
     },
     {
-      "community": 300,
+      "community": 303,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -47641,7 +48157,7 @@
       "source_location": "L36"
     },
     {
-      "community": 301,
+      "community": 304,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -47650,7 +48166,7 @@
       "source_location": "L16"
     },
     {
-      "community": 301,
+      "community": 304,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -47659,7 +48175,7 @@
       "source_location": "L39"
     },
     {
-      "community": 301,
+      "community": 304,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -47668,7 +48184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -47677,7 +48193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 305,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -47686,7 +48202,7 @@
       "source_location": "L25"
     },
     {
-      "community": 302,
+      "community": 305,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -47695,7 +48211,7 @@
       "source_location": "L82"
     },
     {
-      "community": 303,
+      "community": 306,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -47704,7 +48220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 306,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -47713,7 +48229,7 @@
       "source_location": "L20"
     },
     {
-      "community": 303,
+      "community": 306,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -47722,7 +48238,7 @@
       "source_location": "L55"
     },
     {
-      "community": 304,
+      "community": 307,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -47731,7 +48247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 307,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -47740,7 +48256,7 @@
       "source_location": "L107"
     },
     {
-      "community": 304,
+      "community": 307,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -47749,7 +48265,7 @@
       "source_location": "L25"
     },
     {
-      "community": 305,
+      "community": 308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -47758,7 +48274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 308,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -47767,7 +48283,7 @@
       "source_location": "L556"
     },
     {
-      "community": 305,
+      "community": 308,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -47776,7 +48292,7 @@
       "source_location": "L52"
     },
     {
-      "community": 306,
+      "community": 309,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -47785,7 +48301,7 @@
       "source_location": "L429"
     },
     {
-      "community": 306,
+      "community": 309,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -47794,93 +48310,12 @@
       "source_location": "L102"
     },
     {
-      "community": 306,
+      "community": 309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 307,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
-      "label": "review.tsx",
-      "norm_label": "review.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 307,
-      "file_type": "code",
-      "id": "review_getordermessage",
-      "label": "getOrderMessage()",
-      "norm_label": "getordermessage()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L250"
-    },
-    {
-      "community": 307,
-      "file_type": "code",
-      "id": "review_ordernavigation",
-      "label": "OrderNavigation()",
-      "norm_label": "ordernavigation()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "account_accountbeforeload",
-      "label": "accountBeforeLoad()",
-      "norm_label": "accountbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "account_handleonsubmitform",
-      "label": "handleOnSubmitForm()",
-      "norm_label": "handleonsubmitform()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
-      "label": "account.tsx",
-      "norm_label": "account.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "login_loginbeforeload",
-      "label": "loginBeforeLoad()",
-      "norm_label": "loginbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "login_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "label": "login.tsx",
-      "norm_label": "login.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1"
     },
     {
@@ -47985,6 +48420,87 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
+      "label": "review.tsx",
+      "norm_label": "review.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "review_getordermessage",
+      "label": "getOrderMessage()",
+      "norm_label": "getordermessage()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L250"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "review_ordernavigation",
+      "label": "OrderNavigation()",
+      "norm_label": "ordernavigation()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "account_accountbeforeload",
+      "label": "accountBeforeLoad()",
+      "norm_label": "accountbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "account_handleonsubmitform",
+      "label": "handleOnSubmitForm()",
+      "norm_label": "handleonsubmitform()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
+      "label": "account.tsx",
+      "norm_label": "account.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "login_loginbeforeload",
+      "label": "loginBeforeLoad()",
+      "norm_label": "loginbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "login_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_login_tsx",
+      "label": "login.tsx",
+      "norm_label": "login.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 313,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
       "norm_label": "verify.index.tsx",
@@ -47992,7 +48508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 313,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -48001,7 +48517,7 @@
       "source_location": "L21"
     },
     {
-      "community": 310,
+      "community": 313,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -48010,7 +48526,7 @@
       "source_location": "L107"
     },
     {
-      "community": 311,
+      "community": 314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -48019,7 +48535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 314,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -48028,7 +48544,7 @@
       "source_location": "L161"
     },
     {
-      "community": 311,
+      "community": 314,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -48037,7 +48553,7 @@
       "source_location": "L66"
     },
     {
-      "community": 312,
+      "community": 315,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -48046,7 +48562,7 @@
       "source_location": "L11"
     },
     {
-      "community": 312,
+      "community": 315,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -48055,7 +48571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 315,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -48064,7 +48580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 316,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -48073,7 +48589,7 @@
       "source_location": "L16"
     },
     {
-      "community": 313,
+      "community": 316,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -48082,7 +48598,7 @@
       "source_location": "L10"
     },
     {
-      "community": 313,
+      "community": 316,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -48091,7 +48607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 317,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -48100,7 +48616,7 @@
       "source_location": "L17"
     },
     {
-      "community": 314,
+      "community": 317,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -48109,7 +48625,7 @@
       "source_location": "L11"
     },
     {
-      "community": 314,
+      "community": 317,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -48118,7 +48634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 318,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -48127,7 +48643,7 @@
       "source_location": "L21"
     },
     {
-      "community": 315,
+      "community": 318,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -48136,7 +48652,7 @@
       "source_location": "L15"
     },
     {
-      "community": 315,
+      "community": 318,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -48145,7 +48661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 319,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -48154,7 +48670,7 @@
       "source_location": "L48"
     },
     {
-      "community": 316,
+      "community": 319,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -48163,93 +48679,12 @@
       "source_location": "L42"
     },
     {
-      "community": 316,
+      "community": 319,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
       "norm_label": "harness-check.test.ts",
       "source_file": "scripts/harness-check.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "harness_generate_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-generate.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "harness_generate_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-generate.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "scripts_harness_generate_test_ts",
-      "label": "harness-generate.test.ts",
-      "norm_label": "harness-generate.test.ts",
-      "source_file": "scripts/harness-generate.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "harness_inferential_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "harness_inferential_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "scripts_harness_inferential_review_test_ts",
-      "label": "harness-inferential-review.test.ts",
-      "norm_label": "harness-inferential-review.test.ts",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "harness_self_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "harness_self_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "scripts_harness_self_review_test_ts",
-      "label": "harness-self-review.test.ts",
-      "norm_label": "harness-self-review.test.ts",
-      "source_file": "scripts/harness-self-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -48354,6 +48789,87 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "harness_generate_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "harness_generate_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "scripts_harness_generate_test_ts",
+      "label": "harness-generate.test.ts",
+      "norm_label": "harness-generate.test.ts",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "harness_inferential_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "harness_inferential_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "scripts_harness_inferential_review_test_ts",
+      "label": "harness-inferential-review.test.ts",
+      "norm_label": "harness-inferential-review.test.ts",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "harness_self_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "harness_self_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "scripts_harness_self_review_test_ts",
+      "label": "harness-self-review.test.ts",
+      "norm_label": "harness-self-review.test.ts",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -48361,7 +48877,7 @@
       "source_location": "L20"
     },
     {
-      "community": 320,
+      "community": 323,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -48370,7 +48886,7 @@
       "source_location": "L14"
     },
     {
-      "community": 320,
+      "community": 323,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
@@ -48379,7 +48895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 324,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -48388,7 +48904,7 @@
       "source_location": "L26"
     },
     {
-      "community": 321,
+      "community": 324,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -48397,7 +48913,7 @@
       "source_location": "L18"
     },
     {
-      "community": 321,
+      "community": 324,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -48406,7 +48922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 325,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
@@ -48415,7 +48931,7 @@
       "source_location": "L45"
     },
     {
-      "community": 322,
+      "community": 325,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
       "label": "stageTrackedGraphifyArtifacts()",
@@ -48424,7 +48940,7 @@
       "source_location": "L20"
     },
     {
-      "community": 322,
+      "community": 325,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -48433,7 +48949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 326,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -48442,7 +48958,7 @@
       "source_location": "L8"
     },
     {
-      "community": 323,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -48451,7 +48967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 327,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -48460,7 +48976,7 @@
       "source_location": "L9"
     },
     {
-      "community": 324,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -48469,7 +48985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -48478,7 +48994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 328,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -48487,7 +49003,7 @@
       "source_location": "L12"
     },
     {
-      "community": 326,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -48496,67 +49012,13 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 329,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
       "norm_label": "getcloudflareconfig()",
       "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
       "source_location": "L8"
-    },
-    {
-      "community": 327,
-      "file_type": "code",
-      "id": "convexauditscript_test_createcommandshimbin",
-      "label": "createCommandShimBin()",
-      "norm_label": "createcommandshimbin()",
-      "source_file": "packages/athena-webapp/convex/convexAuditScript.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 327,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
-      "label": "convexAuditScript.test.ts",
-      "norm_label": "convexauditscript.test.ts",
-      "source_file": "packages/athena-webapp/convex/convexAuditScript.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
-      "label": "VerificationCode.tsx",
-      "norm_label": "verificationcode.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "verificationcode_verificationcode",
-      "label": "VerificationCode()",
-      "norm_label": "verificationcode()",
-      "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "mtnmomo_handlecollectionnotification",
-      "label": "handleCollectionNotification()",
-      "norm_label": "handlecollectionnotification()",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
-      "label": "mtnMomo.ts",
-      "norm_label": "mtnmomo.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
-      "source_location": "L1"
     },
     {
       "community": 33,
@@ -48660,6 +49122,60 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "convexauditscript_test_createcommandshimbin",
+      "label": "createCommandShimBin()",
+      "norm_label": "createcommandshimbin()",
+      "source_file": "packages/athena-webapp/convex/convexAuditScript.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
+      "label": "convexAuditScript.test.ts",
+      "norm_label": "convexauditscript.test.ts",
+      "source_file": "packages/athena-webapp/convex/convexAuditScript.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
+      "label": "VerificationCode.tsx",
+      "norm_label": "verificationcode.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "verificationcode_verificationcode",
+      "label": "VerificationCode()",
+      "norm_label": "verificationcode()",
+      "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "mtnmomo_handlecollectionnotification",
+      "label": "handleCollectionNotification()",
+      "norm_label": "handlecollectionnotification()",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
+      "label": "mtnMomo.ts",
+      "norm_label": "mtnmomo.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 333,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
       "norm_label": "routercomposition.test.ts",
@@ -48667,7 +49183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 333,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -48676,7 +49192,7 @@
       "source_location": "L6"
     },
     {
-      "community": 331,
+      "community": 334,
       "file_type": "code",
       "id": "cashier_authenticatehandler",
       "label": "authenticateHandler()",
@@ -48685,7 +49201,7 @@
       "source_location": "L239"
     },
     {
-      "community": 331,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -48694,7 +49210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -48703,7 +49219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 335,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -48712,7 +49228,7 @@
       "source_location": "L8"
     },
     {
-      "community": 333,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -48721,7 +49237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 336,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -48730,7 +49246,7 @@
       "source_location": "L6"
     },
     {
-      "community": 334,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -48739,7 +49255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 337,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -48748,7 +49264,7 @@
       "source_location": "L27"
     },
     {
-      "community": 335,
+      "community": 338,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -48757,7 +49273,7 @@
       "source_location": "L4"
     },
     {
-      "community": 335,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -48766,7 +49282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 339,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -48775,66 +49291,12 @@
       "source_location": "L3"
     },
     {
-      "community": 336,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
       "norm_label": "anthropic.ts",
       "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 337,
-      "file_type": "code",
-      "id": "openai_callopenai",
-      "label": "callOpenAi()",
-      "norm_label": "callopenai()",
-      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 337,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
-      "label": "openai.ts",
-      "norm_label": "openai.ts",
-      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "foundation_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
-      "label": "foundation.test.ts",
-      "norm_label": "foundation.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "approvalrequesthelpers_buildapprovalrequest",
-      "label": "buildApprovalRequest()",
-      "norm_label": "buildapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
-      "label": "approvalRequestHelpers.ts",
-      "norm_label": "approvalrequesthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
       "source_location": "L1"
     },
     {
@@ -48930,6 +49392,60 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "openai_callopenai",
+      "label": "callOpenAi()",
+      "norm_label": "callopenai()",
+      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
+      "label": "openai.ts",
+      "norm_label": "openai.ts",
+      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "foundation_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
+      "label": "foundation.test.ts",
+      "norm_label": "foundation.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
+      "id": "approvalrequesthelpers_buildapprovalrequest",
+      "label": "buildApprovalRequest()",
+      "norm_label": "buildapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
+      "label": "approvalRequestHelpers.ts",
+      "norm_label": "approvalrequesthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 343,
+      "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
       "norm_label": "createapprovalrequestmutationctx()",
@@ -48937,7 +49453,7 @@
       "source_location": "L18"
     },
     {
-      "community": 340,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -48946,7 +49462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 344,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -48955,7 +49471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -48964,7 +49480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
@@ -48973,7 +49489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 345,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -48982,7 +49498,7 @@
       "source_location": "L7"
     },
     {
-      "community": 343,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_verificationcodeemail_tsx",
       "label": "VerificationCodeEmail.tsx",
@@ -48991,7 +49507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 346,
       "file_type": "code",
       "id": "verificationcodeemail_verificationcodeemail",
       "label": "VerificationCodeEmail()",
@@ -49000,7 +49516,7 @@
       "source_location": "L11"
     },
     {
-      "community": 344,
+      "community": 347,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -49009,7 +49525,7 @@
       "source_location": "L8"
     },
     {
-      "community": 344,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -49018,7 +49534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 348,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -49027,7 +49543,7 @@
       "source_location": "L4"
     },
     {
-      "community": 345,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -49036,7 +49552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 349,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -49045,67 +49561,13 @@
       "source_location": "L6"
     },
     {
-      "community": 346,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
       "norm_label": "access.test.ts",
       "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 347,
-      "file_type": "code",
-      "id": "access_requirestorefulladminaccess",
-      "label": "requireStoreFullAdminAccess()",
-      "norm_label": "requirestorefulladminaccess()",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 347,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_access_ts",
-      "label": "access.ts",
-      "norm_label": "access.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
-      "label": "purchaseOrders.test.ts",
-      "norm_label": "purchaseorders.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "purchaseorders_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
-      "label": "receiving.test.ts",
-      "norm_label": "receiving.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "receiving_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
-      "source_location": "L13"
     },
     {
       "community": 35,
@@ -49200,6 +49662,60 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "access_requirestorefulladminaccess",
+      "label": "requireStoreFullAdminAccess()",
+      "norm_label": "requirestorefulladminaccess()",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_access_ts",
+      "label": "access.ts",
+      "norm_label": "access.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
+      "label": "purchaseOrders.test.ts",
+      "norm_label": "purchaseorders.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "purchaseorders_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
+      "label": "receiving.test.ts",
+      "norm_label": "receiving.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
+      "id": "receiving_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 353,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
       "norm_label": "vendors.test.ts",
@@ -49207,7 +49723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 350,
+      "community": 353,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -49216,7 +49732,7 @@
       "source_location": "L5"
     },
     {
-      "community": 351,
+      "community": 354,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -49225,7 +49741,7 @@
       "source_location": "L15"
     },
     {
-      "community": 351,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -49234,7 +49750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 355,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -49243,7 +49759,7 @@
       "source_location": "L8"
     },
     {
-      "community": 352,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -49252,7 +49768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 356,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -49261,7 +49777,7 @@
       "source_location": "L17"
     },
     {
-      "community": 353,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -49270,7 +49786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 357,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -49279,7 +49795,7 @@
       "source_location": "L6"
     },
     {
-      "community": 354,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -49288,7 +49804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 358,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -49297,7 +49813,7 @@
       "source_location": "L5"
     },
     {
-      "community": 355,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -49306,7 +49822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 359,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -49315,67 +49831,13 @@
       "source_location": "L25"
     },
     {
-      "community": 356,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
       "norm_label": "onlineorderitem.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 357,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 357,
-      "file_type": "code",
-      "id": "reviews_getstorefrontactorbyid",
-      "label": "getStoreFrontActorById()",
-      "norm_label": "getstorefrontactorbyid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "rewards_formatpointslabel",
-      "label": "formatPointsLabel()",
-      "norm_label": "formatpointslabel()",
-      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "savedbag_listsavedbagitems",
-      "label": "listSavedBagItems()",
-      "norm_label": "listsavedbagitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
-      "source_location": "L14"
     },
     {
       "community": 36,
@@ -49470,6 +49932,60 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "reviews_getstorefrontactorbyid",
+      "label": "getStoreFrontActorById()",
+      "norm_label": "getstorefrontactorbyid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "rewards_formatpointslabel",
+      "label": "formatPointsLabel()",
+      "norm_label": "formatpointslabel()",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
+      "id": "savedbag_listsavedbagitems",
+      "label": "listSavedBagItems()",
+      "norm_label": "listsavedbagitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 363,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
       "norm_label": "storefrontobservabilityreport.test.ts",
@@ -49477,7 +49993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 363,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -49486,7 +50002,7 @@
       "source_location": "L8"
     },
     {
-      "community": 361,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -49495,7 +50011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 364,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -49504,7 +50020,7 @@
       "source_location": "L3"
     },
     {
-      "community": 362,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -49513,7 +50029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 365,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -49522,7 +50038,7 @@
       "source_location": "L5"
     },
     {
-      "community": 363,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -49531,7 +50047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 366,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -49540,7 +50056,7 @@
       "source_location": "L16"
     },
     {
-      "community": 364,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -49549,7 +50065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 367,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -49558,7 +50074,7 @@
       "source_location": "L30"
     },
     {
-      "community": 365,
+      "community": 368,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -49567,7 +50083,7 @@
       "source_location": "L7"
     },
     {
-      "community": 365,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -49576,7 +50092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 369,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -49585,67 +50101,13 @@
       "source_location": "L12"
     },
     {
-      "community": 366,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
       "norm_label": "organizationsview.tsx",
       "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 367,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_permissiongate_tsx",
-      "label": "PermissionGate.tsx",
-      "norm_label": "permissiongate.tsx",
-      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 367,
-      "file_type": "code",
-      "id": "permissiongate_permissiongate",
-      "label": "PermissionGate()",
-      "norm_label": "permissiongate()",
-      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_protectedroute_tsx",
-      "label": "ProtectedRoute.tsx",
-      "norm_label": "protectedroute.tsx",
-      "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "protectedroute_protectedroute",
-      "label": "ProtectedRoute()",
-      "norm_label": "protectedroute()",
-      "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_settingsview_tsx",
-      "label": "SettingsView.tsx",
-      "norm_label": "settingsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "settingsview_settingsview",
-      "label": "SettingsView()",
-      "norm_label": "settingsview()",
-      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
-      "source_location": "L3"
     },
     {
       "community": 37,
@@ -49740,6 +50202,60 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_permissiongate_tsx",
+      "label": "PermissionGate.tsx",
+      "norm_label": "permissiongate.tsx",
+      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "permissiongate_permissiongate",
+      "label": "PermissionGate()",
+      "norm_label": "permissiongate()",
+      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_protectedroute_tsx",
+      "label": "ProtectedRoute.tsx",
+      "norm_label": "protectedroute.tsx",
+      "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "protectedroute_protectedroute",
+      "label": "ProtectedRoute()",
+      "norm_label": "protectedroute()",
+      "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_settingsview_tsx",
+      "label": "SettingsView.tsx",
+      "norm_label": "settingsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
+      "id": "settingsview_settingsview",
+      "label": "SettingsView()",
+      "norm_label": "settingsview()",
+      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 373,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
       "norm_label": "storeactions.tsx",
@@ -49747,7 +50263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 373,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -49756,7 +50272,7 @@
       "source_location": "L12"
     },
     {
-      "community": 371,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -49765,7 +50281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 374,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -49774,7 +50290,7 @@
       "source_location": "L42"
     },
     {
-      "community": 372,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -49783,7 +50299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 375,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -49792,7 +50308,7 @@
       "source_location": "L13"
     },
     {
-      "community": 373,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -49801,7 +50317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 376,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -49810,7 +50326,7 @@
       "source_location": "L42"
     },
     {
-      "community": 374,
+      "community": 377,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -49819,7 +50335,7 @@
       "source_location": "L31"
     },
     {
-      "community": 374,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -49828,7 +50344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -49837,7 +50353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 378,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -49846,7 +50362,7 @@
       "source_location": "L10"
     },
     {
-      "community": 376,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -49855,67 +50371,13 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 379,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
       "norm_label": "isallowedattribute()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 377,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
-      "label": "ProductAvailabilityToggleGroup.tsx",
-      "norm_label": "productavailabilitytogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 377,
-      "file_type": "code",
-      "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
-      "label": "ProductAvailabilityToggleGroup()",
-      "norm_label": "productavailabilitytogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
-      "label": "ProductDetails.tsx",
-      "norm_label": "productdetails.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "productdetails_handlenamechange",
-      "label": "handleNameChange()",
-      "norm_label": "handlenamechange()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
-      "label": "ProductImages.tsx",
-      "norm_label": "productimages.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "productimages_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
-      "source_location": "L15"
     },
     {
       "community": 38,
@@ -50010,6 +50472,60 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
+      "label": "ProductAvailabilityToggleGroup.tsx",
+      "norm_label": "productavailabilitytogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
+      "label": "ProductAvailabilityToggleGroup()",
+      "norm_label": "productavailabilitytogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
+      "label": "ProductDetails.tsx",
+      "norm_label": "productdetails.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "productdetails_handlenamechange",
+      "label": "handleNameChange()",
+      "norm_label": "handlenamechange()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
+      "label": "ProductImages.tsx",
+      "norm_label": "productimages.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
+      "id": "productimages_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 383,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
       "norm_label": "productpage.tsx",
@@ -50017,7 +50533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 383,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -50026,7 +50542,7 @@
       "source_location": "L13"
     },
     {
-      "community": 381,
+      "community": 384,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -50035,7 +50551,7 @@
       "source_location": "L116"
     },
     {
-      "community": 381,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -50044,7 +50560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -50053,7 +50569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 385,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -50062,7 +50578,7 @@
       "source_location": "L47"
     },
     {
-      "community": 383,
+      "community": 386,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -50071,7 +50587,7 @@
       "source_location": "L151"
     },
     {
-      "community": 383,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -50080,7 +50596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 387,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -50089,7 +50605,7 @@
       "source_location": "L6"
     },
     {
-      "community": 384,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -50098,7 +50614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 388,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -50107,7 +50623,7 @@
       "source_location": "L19"
     },
     {
-      "community": 385,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -50116,7 +50632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 389,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -50125,67 +50641,13 @@
       "source_location": "L7"
     },
     {
-      "community": 386,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
       "norm_label": "analyticsusers.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 387,
-      "file_type": "code",
-      "id": "enhancedanalyticsview_getdaterangemilliseconds",
-      "label": "getDateRangeMilliseconds()",
-      "norm_label": "getdaterangemilliseconds()",
-      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 387,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
-      "label": "EnhancedAnalyticsView.tsx",
-      "norm_label": "enhancedanalyticsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
-      "label": "StoreInsights.tsx",
-      "norm_label": "storeinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "storeinsights_gettrendicon",
-      "label": "getTrendIcon()",
-      "norm_label": "gettrendicon()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
-      "label": "VisitorChart.tsx",
-      "norm_label": "visitorchart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "visitorchart_formathour",
-      "label": "formatHour()",
-      "norm_label": "formathour()",
-      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
-      "source_location": "L18"
     },
     {
       "community": 39,
@@ -50280,6 +50742,60 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "enhancedanalyticsview_getdaterangemilliseconds",
+      "label": "getDateRangeMilliseconds()",
+      "norm_label": "getdaterangemilliseconds()",
+      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
+      "label": "EnhancedAnalyticsView.tsx",
+      "norm_label": "enhancedanalyticsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
+      "label": "StoreInsights.tsx",
+      "norm_label": "storeinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "storeinsights_gettrendicon",
+      "label": "getTrendIcon()",
+      "norm_label": "gettrendicon()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 392,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
+      "label": "VisitorChart.tsx",
+      "norm_label": "visitorchart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 392,
+      "file_type": "code",
+      "id": "visitorchart_formathour",
+      "label": "formatHour()",
+      "norm_label": "formathour()",
+      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 393,
+      "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
       "norm_label": "logitems()",
@@ -50287,7 +50803,7 @@
       "source_location": "L6"
     },
     {
-      "community": 390,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -50296,7 +50812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 394,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -50305,7 +50821,7 @@
       "source_location": "L10"
     },
     {
-      "community": 391,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -50314,7 +50830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 395,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -50323,7 +50839,7 @@
       "source_location": "L27"
     },
     {
-      "community": 392,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -50332,7 +50848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -50341,7 +50857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 396,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -50350,7 +50866,7 @@
       "source_location": "L12"
     },
     {
-      "community": 394,
+      "community": 397,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -50359,7 +50875,7 @@
       "source_location": "L3"
     },
     {
-      "community": 394,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -50368,7 +50884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 398,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -50377,7 +50893,7 @@
       "source_location": "L5"
     },
     {
-      "community": 395,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -50386,7 +50902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 399,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -50395,66 +50911,12 @@
       "source_location": "L49"
     },
     {
-      "community": 396,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
       "norm_label": "bulkoperationsfilters.tsx",
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 397,
-      "file_type": "code",
-      "id": "bulkoperationspreview_test_makerow",
-      "label": "makeRow()",
-      "norm_label": "makerow()",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 397,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
-      "label": "BulkOperationsPreview.test.tsx",
-      "norm_label": "bulkoperationspreview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "bulkoperationspreview_formatprice",
-      "label": "formatPrice()",
-      "norm_label": "formatprice()",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
-      "label": "BulkOperationsPreview.tsx",
-      "norm_label": "bulkoperationspreview.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "checkoutsessionstable_checkoutsessionstable",
-      "label": "CheckoutSessionsTable()",
-      "norm_label": "checkoutsessionstable()",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
-      "label": "CheckoutSessionsTable.tsx",
-      "norm_label": "checkoutsessionstable.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
       "source_location": "L1"
     },
     {
@@ -50802,6 +51264,60 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "bulkoperationspreview_test_makerow",
+      "label": "makeRow()",
+      "norm_label": "makerow()",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
+      "label": "BulkOperationsPreview.test.tsx",
+      "norm_label": "bulkoperationspreview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "bulkoperationspreview_formatprice",
+      "label": "formatPrice()",
+      "norm_label": "formatprice()",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
+      "label": "BulkOperationsPreview.tsx",
+      "norm_label": "bulkoperationspreview.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "checkoutsessionstable_checkoutsessionstable",
+      "label": "CheckoutSessionsTable()",
+      "norm_label": "checkoutsessionstable()",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
+      "label": "CheckoutSessionsTable.tsx",
+      "norm_label": "checkoutsessionstable.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
@@ -50809,7 +51325,7 @@
       "source_location": "L11"
     },
     {
-      "community": 400,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -50818,7 +51334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -50827,7 +51343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 404,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -50836,7 +51352,7 @@
       "source_location": "L7"
     },
     {
-      "community": 402,
+      "community": 405,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -50845,7 +51361,7 @@
       "source_location": "L29"
     },
     {
-      "community": 402,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -50854,7 +51370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 406,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -50863,7 +51379,7 @@
       "source_location": "L37"
     },
     {
-      "community": 403,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -50872,7 +51388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 407,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -50881,7 +51397,7 @@
       "source_location": "L25"
     },
     {
-      "community": 404,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -50890,7 +51406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 408,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -50899,7 +51415,7 @@
       "source_location": "L83"
     },
     {
-      "community": 405,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -50908,7 +51424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -50917,67 +51433,13 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 409,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
       "norm_label": "handleaddfeatureditem()",
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
       "source_location": "L35"
-    },
-    {
-      "community": 407,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
-      "label": "ShopLookImageUploader.tsx",
-      "norm_label": "shoplookimageuploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 407,
-      "file_type": "code",
-      "id": "shoplookimageuploader_shoplookimageuploader",
-      "label": "ShopLookImageUploader()",
-      "norm_label": "shoplookimageuploader()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "index_jointeam",
-      "label": "JoinTeam()",
-      "norm_label": "jointeam()",
-      "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_join_team_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "customerdetailsview_customerdetailsview",
-      "label": "CustomerDetailsView()",
-      "norm_label": "customerdetailsview()",
-      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
-      "label": "CustomerDetailsView.tsx",
-      "norm_label": "customerdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 41,
@@ -51072,6 +51534,60 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
+      "label": "ShopLookImageUploader.tsx",
+      "norm_label": "shoplookimageuploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "shoplookimageuploader_shoplookimageuploader",
+      "label": "ShopLookImageUploader()",
+      "norm_label": "shoplookimageuploader()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "index_jointeam",
+      "label": "JoinTeam()",
+      "norm_label": "jointeam()",
+      "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_join_team_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 412,
+      "file_type": "code",
+      "id": "customerdetailsview_customerdetailsview",
+      "label": "CustomerDetailsView()",
+      "norm_label": "customerdetailsview()",
+      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 412,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
+      "label": "CustomerDetailsView.tsx",
+      "norm_label": "customerdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 413,
+      "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
       "norm_label": "handlesendorderemail()",
@@ -51079,7 +51595,7 @@
       "source_location": "L41"
     },
     {
-      "community": 410,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -51088,7 +51604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 414,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -51097,7 +51613,7 @@
       "source_location": "L33"
     },
     {
-      "community": 411,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -51106,7 +51622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 415,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -51115,7 +51631,7 @@
       "source_location": "L68"
     },
     {
-      "community": 412,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -51124,7 +51640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 416,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -51133,7 +51649,7 @@
       "source_location": "L35"
     },
     {
-      "community": 413,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -51142,7 +51658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -51151,7 +51667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 417,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -51160,7 +51676,7 @@
       "source_location": "L79"
     },
     {
-      "community": 415,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -51169,7 +51685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 418,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -51178,7 +51694,7 @@
       "source_location": "L6"
     },
     {
-      "community": 416,
+      "community": 419,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -51187,66 +51703,12 @@
       "source_location": "L34"
     },
     {
-      "community": 416,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 417,
-      "file_type": "code",
-      "id": "ordercolumns_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 417,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
-      "label": "orderColumns.tsx",
-      "norm_label": "ordercolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "cashierview_handlesignout",
-      "label": "handleSignOut()",
-      "norm_label": "handlesignout()",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
-      "label": "CashierView.tsx",
-      "norm_label": "cashierview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "debugproducts_debugproducts",
-      "label": "DebugProducts()",
-      "norm_label": "debugproducts()",
-      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
-      "label": "DebugProducts.tsx",
-      "norm_label": "debugproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
       "source_location": "L1"
     },
     {
@@ -51342,6 +51804,60 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "ordercolumns_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
+      "label": "orderColumns.tsx",
+      "norm_label": "ordercolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "cashierview_handlesignout",
+      "label": "handleSignOut()",
+      "norm_label": "handlesignout()",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
+      "label": "CashierView.tsx",
+      "norm_label": "cashierview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
+      "id": "debugproducts_debugproducts",
+      "label": "DebugProducts()",
+      "norm_label": "debugproducts()",
+      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
+      "label": "DebugProducts.tsx",
+      "norm_label": "debugproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 423,
+      "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
       "norm_label": "noresultsmessage()",
@@ -51349,7 +51865,7 @@
       "source_location": "L7"
     },
     {
-      "community": 420,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -51358,7 +51874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -51367,7 +51883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 424,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -51376,7 +51892,7 @@
       "source_location": "L13"
     },
     {
-      "community": 422,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -51385,7 +51901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 425,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
@@ -51394,7 +51910,7 @@
       "source_location": "L35"
     },
     {
-      "community": 423,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -51403,7 +51919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 426,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -51412,7 +51928,7 @@
       "source_location": "L3"
     },
     {
-      "community": 424,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -51421,7 +51937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 427,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -51430,7 +51946,7 @@
       "source_location": "L14"
     },
     {
-      "community": 425,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -51439,7 +51955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 428,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -51448,7 +51964,7 @@
       "source_location": "L86"
     },
     {
-      "community": 426,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_quickactionsbar_tsx",
       "label": "QuickActionsBar.tsx",
@@ -51457,67 +51973,13 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 429,
       "file_type": "code",
       "id": "quickactionsbar_quickactionsbar",
       "label": "QuickActionsBar()",
       "norm_label": "quickactionsbar()",
       "source_file": "packages/athena-webapp/src/components/pos/QuickActionsBar.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 427,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
-      "label": "SessionDemo.tsx",
-      "norm_label": "sessiondemo.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 427,
-      "file_type": "code",
-      "id": "sessiondemo_sessiondemo",
-      "label": "SessionDemo()",
-      "norm_label": "sessiondemo()",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
-      "label": "TotalsDisplay.tsx",
-      "norm_label": "totalsdisplay.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "totalsdisplay_totalsdisplay",
-      "label": "TotalsDisplay()",
-      "norm_label": "totalsdisplay()",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "expensereportsview_istoday",
-      "label": "isToday()",
-      "norm_label": "istoday()",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
-      "label": "ExpenseReportsView.tsx",
-      "norm_label": "expensereportsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 43,
@@ -51612,6 +52074,60 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
+      "label": "SessionDemo.tsx",
+      "norm_label": "sessiondemo.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "sessiondemo_sessiondemo",
+      "label": "SessionDemo()",
+      "norm_label": "sessiondemo()",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
+      "label": "TotalsDisplay.tsx",
+      "norm_label": "totalsdisplay.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "totalsdisplay_totalsdisplay",
+      "label": "TotalsDisplay()",
+      "norm_label": "totalsdisplay()",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
+      "id": "expensereportsview_istoday",
+      "label": "isToday()",
+      "norm_label": "istoday()",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
+      "label": "ExpenseReportsView.tsx",
+      "norm_label": "expensereportsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 433,
+      "file_type": "code",
       "id": "hooks_useposcashier",
       "label": "usePOSCashier()",
       "norm_label": "useposcashier()",
@@ -51619,7 +52135,7 @@
       "source_location": "L5"
     },
     {
-      "community": 430,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_hooks_ts",
       "label": "hooks.ts",
@@ -51628,7 +52144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 434,
       "file_type": "code",
       "id": "holdsessiondialog_holdsessiondialog",
       "label": "HoldSessionDialog()",
@@ -51637,7 +52153,7 @@
       "source_location": "L19"
     },
     {
-      "community": 431,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_holdsessiondialog_tsx",
       "label": "HoldSessionDialog.tsx",
@@ -51646,7 +52162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_voidsessiondialog_tsx",
       "label": "VoidSessionDialog.tsx",
@@ -51655,7 +52171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 435,
       "file_type": "code",
       "id": "voidsessiondialog_voidsessiondialog",
       "label": "VoidSessionDialog()",
@@ -51664,7 +52180,7 @@
       "source_location": "L19"
     },
     {
-      "community": 433,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -51673,7 +52189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 436,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
@@ -51682,7 +52198,7 @@
       "source_location": "L22"
     },
     {
-      "community": 434,
+      "community": 437,
       "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
@@ -51691,7 +52207,7 @@
       "source_location": "L14"
     },
     {
-      "community": 434,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -51700,7 +52216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 438,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -51709,7 +52225,7 @@
       "source_location": "L6"
     },
     {
-      "community": 435,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -51718,7 +52234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 439,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -51727,67 +52243,13 @@
       "source_location": "L38"
     },
     {
-      "community": 436,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
       "norm_label": "imagesview.tsx",
       "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
-      "label": "SKUSelector.tsx",
-      "norm_label": "skuselector.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "skuselector_skuselector",
-      "label": "SKUSelector()",
-      "norm_label": "skuselector()",
-      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_actions_tsx",
-      "label": "product-actions.tsx",
-      "norm_label": "product-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "product_actions_usedeleteproduct",
-      "label": "useDeleteProduct()",
-      "norm_label": "usedeleteproduct()",
-      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productsview_tsx",
-      "label": "ProductsView.tsx",
-      "norm_label": "productsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "productsview_productsview",
-      "label": "ProductsView()",
-      "norm_label": "productsview()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
-      "source_location": "L5"
     },
     {
       "community": 44,
@@ -51882,6 +52344,60 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
+      "label": "SKUSelector.tsx",
+      "norm_label": "skuselector.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "skuselector_skuselector",
+      "label": "SKUSelector()",
+      "norm_label": "skuselector()",
+      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_actions_tsx",
+      "label": "product-actions.tsx",
+      "norm_label": "product-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "product_actions_usedeleteproduct",
+      "label": "useDeleteProduct()",
+      "norm_label": "usedeleteproduct()",
+      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productsview_tsx",
+      "label": "ProductsView.tsx",
+      "norm_label": "productsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
+      "id": "productsview_productsview",
+      "label": "ProductsView()",
+      "norm_label": "productsview()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 443,
+      "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
       "norm_label": "addproductcommand()",
@@ -51889,7 +52405,7 @@
       "source_location": "L17"
     },
     {
-      "community": 440,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -51898,7 +52414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -51907,7 +52423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 444,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -51916,7 +52432,7 @@
       "source_location": "L4"
     },
     {
-      "community": 442,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -51925,7 +52441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 445,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -51934,7 +52450,7 @@
       "source_location": "L84"
     },
     {
-      "community": 443,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -51943,7 +52459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 446,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -51952,7 +52468,7 @@
       "source_location": "L22"
     },
     {
-      "community": 444,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -51961,7 +52477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 447,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -51970,7 +52486,7 @@
       "source_location": "L9"
     },
     {
-      "community": 445,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -51979,7 +52495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 448,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -51988,7 +52504,7 @@
       "source_location": "L23"
     },
     {
-      "community": 446,
+      "community": 449,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -51997,67 +52513,13 @@
       "source_location": "L5"
     },
     {
-      "community": 446,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
       "norm_label": "discounttypetogglegroup.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 447,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
-      "label": "PromoCodeSpanToggleGroup.tsx",
-      "norm_label": "promocodespantogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 447,
-      "file_type": "code",
-      "id": "promocodespantogglegroup_promocodespantogglegroup",
-      "label": "PromoCodeSpanToggleGroup()",
-      "norm_label": "promocodespantogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "capturedemails_capturedemails",
-      "label": "CapturedEmails()",
-      "norm_label": "capturedemails()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
-      "label": "CapturedEmails.tsx",
-      "norm_label": "capturedemails.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
-      "label": "promo-code-modal.tsx",
-      "norm_label": "promo-code-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "promo_code_modal_promocodemodal",
-      "label": "PromoCodeModal()",
-      "norm_label": "promocodemodal()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
-      "source_location": "L29"
     },
     {
       "community": 45,
@@ -52143,6 +52605,60 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
+      "label": "PromoCodeSpanToggleGroup.tsx",
+      "norm_label": "promocodespantogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "promocodespantogglegroup_promocodespantogglegroup",
+      "label": "PromoCodeSpanToggleGroup()",
+      "norm_label": "promocodespantogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "capturedemails_capturedemails",
+      "label": "CapturedEmails()",
+      "norm_label": "capturedemails()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
+      "label": "CapturedEmails.tsx",
+      "norm_label": "capturedemails.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
+      "label": "promo-code-modal.tsx",
+      "norm_label": "promo-code-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
+      "id": "promo_code_modal_promocodemodal",
+      "label": "PromoCodeModal()",
+      "norm_label": "promocodemodal()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 453,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
       "norm_label": "reviewactions.tsx",
@@ -52150,7 +52666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 453,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -52159,7 +52675,7 @@
       "source_location": "L20"
     },
     {
-      "community": 451,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -52168,7 +52684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 454,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -52177,7 +52693,7 @@
       "source_location": "L171"
     },
     {
-      "community": 452,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -52186,7 +52702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 455,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -52195,7 +52711,7 @@
       "source_location": "L52"
     },
     {
-      "community": 453,
+      "community": 456,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -52204,7 +52720,7 @@
       "source_location": "L29"
     },
     {
-      "community": 453,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -52213,7 +52729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 457,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -52222,7 +52738,7 @@
       "source_location": "L3"
     },
     {
-      "community": 454,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -52231,7 +52747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 458,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -52240,7 +52756,7 @@
       "source_location": "L4"
     },
     {
-      "community": 455,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -52249,7 +52765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 459,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -52258,66 +52774,12 @@
       "source_location": "L4"
     },
     {
-      "community": 456,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
       "norm_label": "notfoundview.tsx",
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 457,
-      "file_type": "code",
-      "id": "contactview_contactview",
-      "label": "ContactView()",
-      "norm_label": "contactview()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 457,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
-      "label": "ContactView.tsx",
-      "norm_label": "contactview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "header_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
-      "label": "Header.tsx",
-      "norm_label": "header.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "maintenanceview_maintenanceview",
-      "label": "MaintenanceView()",
-      "norm_label": "maintenanceview()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
-      "label": "MaintenanceView.tsx",
-      "norm_label": "maintenanceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
       "source_location": "L1"
     },
     {
@@ -52404,6 +52866,60 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "contactview_contactview",
+      "label": "ContactView()",
+      "norm_label": "contactview()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
+      "label": "ContactView.tsx",
+      "norm_label": "contactview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "header_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
+      "label": "Header.tsx",
+      "norm_label": "header.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
+      "id": "maintenanceview_maintenanceview",
+      "label": "MaintenanceView()",
+      "norm_label": "maintenanceview()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
+      "label": "MaintenanceView.tsx",
+      "norm_label": "maintenanceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 463,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
       "norm_label": "taxview.tsx",
@@ -52411,7 +52927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 463,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -52420,7 +52936,7 @@
       "source_location": "L25"
     },
     {
-      "community": 461,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -52429,7 +52945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 464,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -52438,7 +52954,7 @@
       "source_location": "L19"
     },
     {
-      "community": 462,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -52447,7 +52963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 465,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -52456,7 +52972,7 @@
       "source_location": "L63"
     },
     {
-      "community": 463,
+      "community": 466,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -52465,7 +52981,7 @@
       "source_location": "L7"
     },
     {
-      "community": 463,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -52474,7 +52990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 467,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -52483,7 +52999,7 @@
       "source_location": "L25"
     },
     {
-      "community": 464,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -52492,7 +53008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 468,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -52501,7 +53017,7 @@
       "source_location": "L15"
     },
     {
-      "community": 465,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -52510,7 +53026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 469,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -52519,66 +53035,12 @@
       "source_location": "L21"
     },
     {
-      "community": 466,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
       "norm_label": "copy-wrapper.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 467,
-      "file_type": "code",
-      "id": "date_time_picker_datetimepicker",
-      "label": "DateTimePicker()",
-      "norm_label": "datetimepicker()",
-      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 467,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
-      "label": "date-time-picker.tsx",
-      "norm_label": "date-time-picker.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "label_label",
-      "label": "Label()",
-      "norm_label": "label()",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "custom_modal_custommodal",
-      "label": "CustomModal()",
-      "norm_label": "custommodal()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
-      "label": "custom-modal.tsx",
-      "norm_label": "custom-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -52665,6 +53127,60 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "date_time_picker_datetimepicker",
+      "label": "DateTimePicker()",
+      "norm_label": "datetimepicker()",
+      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
+      "label": "date-time-picker.tsx",
+      "norm_label": "date-time-picker.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "label_label",
+      "label": "Label()",
+      "norm_label": "label()",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
+      "id": "custom_modal_custommodal",
+      "label": "CustomModal()",
+      "norm_label": "custommodal()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
+      "label": "custom-modal.tsx",
+      "norm_label": "custom-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 473,
+      "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
@@ -52672,7 +53188,7 @@
       "source_location": "L49"
     },
     {
-      "community": 470,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -52681,7 +53197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -52690,7 +53206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 474,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -52699,7 +53215,7 @@
       "source_location": "L63"
     },
     {
-      "community": 472,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -52708,7 +53224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 475,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -52717,7 +53233,7 @@
       "source_location": "L5"
     },
     {
-      "community": 473,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -52726,7 +53242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 476,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -52735,7 +53251,7 @@
       "source_location": "L12"
     },
     {
-      "community": 474,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -52744,7 +53260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 477,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -52753,7 +53269,7 @@
       "source_location": "L15"
     },
     {
-      "community": 475,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -52762,7 +53278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 478,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -52771,7 +53287,7 @@
       "source_location": "L3"
     },
     {
-      "community": 476,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -52780,66 +53296,12 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 479,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
       "norm_label": "webpimage()",
       "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 477,
-      "file_type": "code",
-      "id": "bagitems_bagitems",
-      "label": "BagItems()",
-      "norm_label": "bagitems()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 477,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
-      "label": "BagItems.tsx",
-      "norm_label": "bagitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "bagitemsview_bagitemsview",
-      "label": "BagItemsView()",
-      "norm_label": "bagitemsview()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
-      "label": "BagItemsView.tsx",
-      "norm_label": "bagitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "bags_bags",
-      "label": "Bags()",
-      "norm_label": "bags()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
-      "label": "Bags.tsx",
-      "norm_label": "bags.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L1"
     },
     {
@@ -52926,6 +53388,60 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "bagitems_bagitems",
+      "label": "BagItems()",
+      "norm_label": "bagitems()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
+      "label": "BagItems.tsx",
+      "norm_label": "bagitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "bagitemsview_bagitemsview",
+      "label": "BagItemsView()",
+      "norm_label": "bagitemsview()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
+      "label": "BagItemsView.tsx",
+      "norm_label": "bagitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
+      "id": "bags_bags",
+      "label": "Bags()",
+      "norm_label": "bags()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
+      "label": "Bags.tsx",
+      "norm_label": "bags.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 483,
+      "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
       "norm_label": "string()",
@@ -52933,7 +53449,7 @@
       "source_location": "L110"
     },
     {
-      "community": 480,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -52942,7 +53458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -52951,7 +53467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 484,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -52960,7 +53476,7 @@
       "source_location": "L13"
     },
     {
-      "community": 482,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -52969,7 +53485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 485,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -52978,7 +53494,7 @@
       "source_location": "L7"
     },
     {
-      "community": 483,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -52987,7 +53503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 486,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -52996,7 +53512,7 @@
       "source_location": "L11"
     },
     {
-      "community": 484,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -53005,7 +53521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 487,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -53014,7 +53530,7 @@
       "source_location": "L7"
     },
     {
-      "community": 485,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -53023,7 +53539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 488,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -53032,7 +53548,7 @@
       "source_location": "L45"
     },
     {
-      "community": 486,
+      "community": 489,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -53041,67 +53557,13 @@
       "source_location": "L13"
     },
     {
-      "community": 486,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
       "norm_label": "customerjourneystage.tsx",
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 487,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
-      "label": "use-image-upload.ts",
-      "norm_label": "use-image-upload.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 487,
-      "file_type": "code",
-      "id": "use_image_upload_useimageupload",
-      "label": "useImageUpload()",
-      "norm_label": "useimageupload()",
-      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
-      "label": "use-mobile.tsx",
-      "norm_label": "use-mobile.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "use_mobile_useismobile",
-      "label": "useIsMobile()",
-      "norm_label": "useismobile()",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
-      "label": "use-navigate-back.ts",
-      "norm_label": "use-navigate-back.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "use_navigate_back_usenavigateback",
-      "label": "useNavigateBack()",
-      "norm_label": "usenavigateback()",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L5"
     },
     {
       "community": 49,
@@ -53187,6 +53649,60 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
+      "label": "use-image-upload.ts",
+      "norm_label": "use-image-upload.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "use_image_upload_useimageupload",
+      "label": "useImageUpload()",
+      "norm_label": "useimageupload()",
+      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
+      "label": "use-mobile.tsx",
+      "norm_label": "use-mobile.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "use_mobile_useismobile",
+      "label": "useIsMobile()",
+      "norm_label": "useismobile()",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
+      "label": "use-navigate-back.ts",
+      "norm_label": "use-navigate-back.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
+      "id": "use_navigate_back_usenavigateback",
+      "label": "useNavigateBack()",
+      "norm_label": "usenavigateback()",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 493,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
       "norm_label": "use-navigation-keyboard-shortcuts.ts",
@@ -53194,7 +53710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 490,
+      "community": 493,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -53203,7 +53719,7 @@
       "source_location": "L7"
     },
     {
-      "community": 491,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -53212,7 +53728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 494,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -53221,7 +53737,7 @@
       "source_location": "L9"
     },
     {
-      "community": 492,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -53230,7 +53746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 495,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -53239,7 +53755,7 @@
       "source_location": "L6"
     },
     {
-      "community": 493,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -53248,7 +53764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 496,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -53257,7 +53773,7 @@
       "source_location": "L168"
     },
     {
-      "community": 494,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecartoperations_ts",
       "label": "useCartOperations.ts",
@@ -53266,7 +53782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 497,
       "file_type": "code",
       "id": "usecartoperations_usecartoperations",
       "label": "useCartOperations()",
@@ -53275,7 +53791,7 @@
       "source_location": "L23"
     },
     {
-      "community": 495,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -53284,7 +53800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 498,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -53293,7 +53809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -53302,67 +53818,13 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 499,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
       "norm_label": "usecreatecomplimentaryproduct()",
       "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 497,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usecustomeroperations_ts",
-      "label": "useCustomerOperations.ts",
-      "norm_label": "usecustomeroperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 497,
-      "file_type": "code",
-      "id": "usecustomeroperations_usecustomeroperations",
-      "label": "useCustomerOperations()",
-      "norm_label": "usecustomeroperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
-      "label": "useDebounce.ts",
-      "norm_label": "usedebounce.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "usedebounce_usedebounce",
-      "label": "useDebounce()",
-      "norm_label": "usedebounce()",
-      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
-      "label": "useExpenseOperations.ts",
-      "norm_label": "useexpenseoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "useexpenseoperations_useexpenseoperations",
-      "label": "useExpenseOperations()",
-      "norm_label": "useexpenseoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L23"
     },
     {
       "community": 5,
@@ -53700,6 +54162,60 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usecustomeroperations_ts",
+      "label": "useCustomerOperations.ts",
+      "norm_label": "usecustomeroperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "usecustomeroperations_usecustomeroperations",
+      "label": "useCustomerOperations()",
+      "norm_label": "usecustomeroperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
+      "label": "useDebounce.ts",
+      "norm_label": "usedebounce.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "usedebounce_usedebounce",
+      "label": "useDebounce()",
+      "norm_label": "usedebounce()",
+      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
+      "label": "useExpenseOperations.ts",
+      "norm_label": "useexpenseoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
+      "id": "useexpenseoperations_useexpenseoperations",
+      "label": "useExpenseOperations()",
+      "norm_label": "useexpenseoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 503,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
       "norm_label": "usegetactiveproduct.ts",
@@ -53707,7 +54223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 503,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -53716,7 +54232,7 @@
       "source_location": "L6"
     },
     {
-      "community": 501,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -53725,7 +54241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 504,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -53734,7 +54250,7 @@
       "source_location": "L4"
     },
     {
-      "community": 502,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -53743,7 +54259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 505,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -53752,7 +54268,7 @@
       "source_location": "L5"
     },
     {
-      "community": 503,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -53761,7 +54277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 506,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -53770,7 +54286,7 @@
       "source_location": "L5"
     },
     {
-      "community": 504,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -53779,7 +54295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 507,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -53788,7 +54304,7 @@
       "source_location": "L4"
     },
     {
-      "community": 505,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -53797,7 +54313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 508,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -53806,7 +54322,7 @@
       "source_location": "L5"
     },
     {
-      "community": 506,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -53815,67 +54331,13 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 509,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
       "norm_label": "usegetterminal()",
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
-      "label": "useNewOrderNotification.ts",
-      "norm_label": "usenewordernotification.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "usenewordernotification_usenewordernotification",
-      "label": "useNewOrderNotification()",
-      "norm_label": "usenewordernotification()",
-      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
-      "label": "usePermissions.ts",
-      "norm_label": "usepermissions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "usepermissions_usepermissions",
-      "label": "usePermissions()",
-      "norm_label": "usepermissions()",
-      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useprint_ts",
-      "label": "usePrint.ts",
-      "norm_label": "useprint.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "useprint_useprint",
-      "label": "usePrint()",
-      "norm_label": "useprint()",
-      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L3"
     },
     {
       "community": 51,
@@ -53961,6 +54423,60 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
+      "label": "useNewOrderNotification.ts",
+      "norm_label": "usenewordernotification.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "usenewordernotification_usenewordernotification",
+      "label": "useNewOrderNotification()",
+      "norm_label": "usenewordernotification()",
+      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
+      "label": "usePermissions.ts",
+      "norm_label": "usepermissions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "usepermissions_usepermissions",
+      "label": "usePermissions()",
+      "norm_label": "usepermissions()",
+      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useprint_ts",
+      "label": "usePrint.ts",
+      "norm_label": "useprint.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
+      "id": "useprint_useprint",
+      "label": "usePrint()",
+      "norm_label": "useprint()",
+      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 513,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
       "norm_label": "useproductsearchresults.ts",
@@ -53968,7 +54484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 513,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -53977,7 +54493,7 @@
       "source_location": "L26"
     },
     {
-      "community": 511,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -53986,7 +54502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 514,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -53995,7 +54511,7 @@
       "source_location": "L7"
     },
     {
-      "community": 512,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagement_ts",
       "label": "useSessionManagement.ts",
@@ -54004,7 +54520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 515,
       "file_type": "code",
       "id": "usesessionmanagement_usesessionmanagement",
       "label": "useSessionManagement()",
@@ -54013,7 +54529,7 @@
       "source_location": "L17"
     },
     {
-      "community": 513,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -54022,7 +54538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 516,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -54031,7 +54547,7 @@
       "source_location": "L17"
     },
     {
-      "community": 514,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanageroperations_ts",
       "label": "useSessionManagerOperations.ts",
@@ -54040,7 +54556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 517,
       "file_type": "code",
       "id": "usesessionmanageroperations_usesessionmanageroperations",
       "label": "useSessionManagerOperations()",
@@ -54049,7 +54565,7 @@
       "source_location": "L16"
     },
     {
-      "community": 515,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -54058,7 +54574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 518,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -54067,7 +54583,7 @@
       "source_location": "L12"
     },
     {
-      "community": 516,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -54076,67 +54592,13 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 519,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
       "norm_label": "useskusreservedinpossession()",
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
-      "label": "useToggleComplimentaryProductActive.ts",
-      "norm_label": "usetogglecomplimentaryproductactive.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
-      "label": "useToggleComplimentaryProductActive()",
-      "norm_label": "usetogglecomplimentaryproductactive()",
-      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "navigationutils_getorigin",
-      "label": "getOrigin()",
-      "norm_label": "getorigin()",
-      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_navigationutils_ts",
-      "label": "navigationUtils.ts",
-      "norm_label": "navigationutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "calculations_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
-      "label": "calculations.ts",
-      "norm_label": "calculations.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
-      "source_location": "L1"
     },
     {
       "community": 52,
@@ -54222,6 +54684,60 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
+      "label": "useToggleComplimentaryProductActive.ts",
+      "norm_label": "usetogglecomplimentaryproductactive.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
+      "label": "useToggleComplimentaryProductActive()",
+      "norm_label": "usetogglecomplimentaryproductactive()",
+      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "navigationutils_getorigin",
+      "label": "getOrigin()",
+      "norm_label": "getorigin()",
+      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_navigationutils_ts",
+      "label": "navigationUtils.ts",
+      "norm_label": "navigationutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
+      "id": "calculations_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
+      "label": "calculations.ts",
+      "norm_label": "calculations.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 523,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
       "norm_label": "pinhash.ts",
@@ -54229,7 +54745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 520,
+      "community": 523,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -54238,7 +54754,7 @@
       "source_location": "L12"
     },
     {
-      "community": 521,
+      "community": 524,
       "file_type": "code",
       "id": "closeouts_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -54247,7 +54763,7 @@
       "source_location": "L10"
     },
     {
-      "community": 521,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_closeouts_index_tsx",
       "label": "closeouts.index.tsx",
@@ -54256,7 +54772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 525,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -54265,7 +54781,7 @@
       "source_location": "L6"
     },
     {
-      "community": 522,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
@@ -54274,7 +54790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
@@ -54283,7 +54799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 526,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -54292,7 +54808,7 @@
       "source_location": "L6"
     },
     {
-      "community": 524,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
@@ -54301,7 +54817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 527,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -54310,7 +54826,7 @@
       "source_location": "L6"
     },
     {
-      "community": 525,
+      "community": 528,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -54319,7 +54835,7 @@
       "source_location": "L13"
     },
     {
-      "community": 525,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -54328,7 +54844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -54337,67 +54853,13 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 529,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
       "norm_label": "routecomponent()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 527,
-      "file_type": "code",
-      "id": "index_index",
-      "label": "Index()",
-      "norm_label": "index()",
-      "source_file": "packages/athena-webapp/src/routes/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 527,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "layout_index_athenaloginreadyview",
-      "label": "AthenaLoginReadyView()",
-      "norm_label": "athenaloginreadyview()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
-      "label": "_layout.index.tsx",
-      "norm_label": "_layout.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "layout_loginlayout",
-      "label": "LoginLayout()",
-      "norm_label": "loginlayout()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L36"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_tsx",
-      "label": "_layout.tsx",
-      "norm_label": "_layout.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L1"
     },
     {
       "community": 53,
@@ -54483,6 +54945,60 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "index_index",
+      "label": "Index()",
+      "norm_label": "index()",
+      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "layout_index_athenaloginreadyview",
+      "label": "AthenaLoginReadyView()",
+      "norm_label": "athenaloginreadyview()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
+      "label": "_layout.index.tsx",
+      "norm_label": "_layout.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
+      "id": "layout_loginlayout",
+      "label": "LoginLayout()",
+      "norm_label": "loginlayout()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_tsx",
+      "label": "_layout.tsx",
+      "norm_label": "_layout.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 533,
+      "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
       "norm_label": "organizationsettingsaccordion()",
@@ -54490,7 +55006,7 @@
       "source_location": "L13"
     },
     {
-      "community": 530,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -54499,7 +55015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 534,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -54508,7 +55024,7 @@
       "source_location": "L5"
     },
     {
-      "community": 531,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -54517,7 +55033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 535,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -54526,7 +55042,7 @@
       "source_location": "L17"
     },
     {
-      "community": 532,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -54535,7 +55051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 536,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -54544,7 +55060,7 @@
       "source_location": "L15"
     },
     {
-      "community": 533,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -54553,7 +55069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 537,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -54562,7 +55078,7 @@
       "source_location": "L12"
     },
     {
-      "community": 534,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -54571,7 +55087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 538,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -54580,7 +55096,7 @@
       "source_location": "L5"
     },
     {
-      "community": 535,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -54589,7 +55105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -54598,67 +55114,13 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 539,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
       "norm_label": "popovershowcase()",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
-      "label": "Sheet.stories.tsx",
-      "norm_label": "sheet.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "sheet_stories_sheetshowcase",
-      "label": "SheetShowcase()",
-      "norm_label": "sheetshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
-      "label": "Tooltip.stories.tsx",
-      "norm_label": "tooltip.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "tooltip_stories_tooltipshowcase",
-      "label": "TooltipShowcase()",
-      "norm_label": "tooltipshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "overview_stories_templatesoverview",
-      "label": "TemplatesOverview()",
-      "norm_label": "templatesoverview()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
-      "source_location": "L1"
     },
     {
       "community": 54,
@@ -54735,6 +55197,60 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
+      "label": "Sheet.stories.tsx",
+      "norm_label": "sheet.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "sheet_stories_sheetshowcase",
+      "label": "SheetShowcase()",
+      "norm_label": "sheetshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
+      "label": "Tooltip.stories.tsx",
+      "norm_label": "tooltip.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "tooltip_stories_tooltipshowcase",
+      "label": "TooltipShowcase()",
+      "norm_label": "tooltipshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
+      "id": "overview_stories_templatesoverview",
+      "label": "TemplatesOverview()",
+      "norm_label": "templatesoverview()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 543,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
       "norm_label": "storybook-theme-decorator.tsx",
@@ -54742,7 +55258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 543,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -54751,7 +55267,7 @@
       "source_location": "L17"
     },
     {
-      "community": 541,
+      "community": 544,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -54760,7 +55276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -54769,7 +55285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 545,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -54778,7 +55294,7 @@
       "source_location": "L4"
     },
     {
-      "community": 542,
+      "community": 545,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -54787,7 +55303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 546,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -54796,7 +55312,7 @@
       "source_location": "L27"
     },
     {
-      "community": 543,
+      "community": 546,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -54805,7 +55321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 547,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -54814,7 +55330,7 @@
       "source_location": "L4"
     },
     {
-      "community": 544,
+      "community": 547,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -54823,7 +55339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 548,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -54832,7 +55348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 548,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -54841,7 +55357,7 @@
       "source_location": "L5"
     },
     {
-      "community": 546,
+      "community": 549,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -54850,66 +55366,12 @@
       "source_location": "L10"
     },
     {
-      "community": 546,
+      "community": 549,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
       "norm_label": "entitypage.tsx",
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 547,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productspage_tsx",
-      "label": "ProductsPage.tsx",
-      "norm_label": "productspage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 547,
-      "file_type": "code",
-      "id": "productspage_productcardloadingskeleton",
-      "label": "ProductCardLoadingSkeleton()",
-      "norm_label": "productcardloadingskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "auth_authcomponent",
-      "label": "AuthComponent()",
-      "norm_label": "authcomponent()",
-      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
-      "label": "Auth.tsx",
-      "norm_label": "auth.tsx",
-      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "bagsummary_tobagsummaryitems",
-      "label": "toBagSummaryItems()",
-      "norm_label": "tobagsummaryitems()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
-      "source_location": "L39"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
-      "label": "BagSummary.tsx",
-      "norm_label": "bagsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
       "source_location": "L1"
     },
     {
@@ -54987,6 +55449,60 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productspage_tsx",
+      "label": "ProductsPage.tsx",
+      "norm_label": "productspage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "productspage_productcardloadingskeleton",
+      "label": "ProductCardLoadingSkeleton()",
+      "norm_label": "productcardloadingskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "auth_authcomponent",
+      "label": "AuthComponent()",
+      "norm_label": "authcomponent()",
+      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
+      "label": "Auth.tsx",
+      "norm_label": "auth.tsx",
+      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
+      "id": "bagsummary_tobagsummaryitems",
+      "label": "toBagSummaryItems()",
+      "norm_label": "tobagsummaryitems()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
+      "label": "BagSummary.tsx",
+      "norm_label": "bagsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 553,
+      "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
       "norm_label": "checkoutform()",
@@ -54994,7 +55510,7 @@
       "source_location": "L18"
     },
     {
-      "community": 550,
+      "community": 553,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -55003,7 +55519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 554,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -55012,7 +55528,7 @@
       "source_location": "L71"
     },
     {
-      "community": 551,
+      "community": 554,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -55021,7 +55537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 555,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -55030,7 +55546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 555,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -55039,7 +55555,7 @@
       "source_location": "L12"
     },
     {
-      "community": 553,
+      "community": 556,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -55048,7 +55564,7 @@
       "source_location": "L6"
     },
     {
-      "community": 553,
+      "community": 556,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -55057,7 +55573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 557,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -55066,7 +55582,7 @@
       "source_location": "L18"
     },
     {
-      "community": 554,
+      "community": 557,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -55075,7 +55591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 558,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -55084,7 +55600,7 @@
       "source_location": "L10"
     },
     {
-      "community": 555,
+      "community": 558,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -55093,7 +55609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 559,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -55102,67 +55618,13 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 559,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
       "norm_label": "paymentmethodsection()",
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
       "source_location": "L8"
-    },
-    {
-      "community": 557,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
-      "label": "PaymentSection.tsx",
-      "norm_label": "paymentsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 557,
-      "file_type": "code",
-      "id": "paymentsection_paymentsection",
-      "label": "PaymentSection()",
-      "norm_label": "paymentsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "deliveryfees_calculatedeliveryfee",
-      "label": "calculateDeliveryFee()",
-      "norm_label": "calculatedeliveryfee()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
-      "label": "deliveryFees.ts",
-      "norm_label": "deliveryfees.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "derivecheckoutstate_derivecheckoutstate",
-      "label": "deriveCheckoutState()",
-      "norm_label": "derivecheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
-      "label": "deriveCheckoutState.ts",
-      "norm_label": "derivecheckoutstate.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L1"
     },
     {
       "community": 56,
@@ -55239,6 +55701,60 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
+      "label": "PaymentSection.tsx",
+      "norm_label": "paymentsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "paymentsection_paymentsection",
+      "label": "PaymentSection()",
+      "norm_label": "paymentsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "deliveryfees_calculatedeliveryfee",
+      "label": "calculateDeliveryFee()",
+      "norm_label": "calculatedeliveryfee()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
+      "label": "deliveryFees.ts",
+      "norm_label": "deliveryfees.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
+      "id": "derivecheckoutstate_derivecheckoutstate",
+      "label": "deriveCheckoutState()",
+      "norm_label": "derivecheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
+      "label": "deriveCheckoutState.ts",
+      "norm_label": "derivecheckoutstate.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 563,
+      "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
       "norm_label": "getissuemap()",
@@ -55246,7 +55762,7 @@
       "source_location": "L8"
     },
     {
-      "community": 560,
+      "community": 563,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -55255,7 +55771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 564,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -55264,7 +55780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 564,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -55273,7 +55789,7 @@
       "source_location": "L12"
     },
     {
-      "community": 562,
+      "community": 565,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -55282,7 +55798,7 @@
       "source_location": "L77"
     },
     {
-      "community": 562,
+      "community": 565,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -55291,7 +55807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 566,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -55300,7 +55816,7 @@
       "source_location": "L161"
     },
     {
-      "community": 563,
+      "community": 566,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -55309,7 +55825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 567,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -55318,7 +55834,7 @@
       "source_location": "L3"
     },
     {
-      "community": 564,
+      "community": 567,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -55327,7 +55843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 568,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -55336,7 +55852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 568,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -55345,7 +55861,7 @@
       "source_location": "L4"
     },
     {
-      "community": 566,
+      "community": 569,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -55354,67 +55870,13 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 569,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
       "norm_label": "productfilter()",
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "filter_handlecheckboxchange",
-      "label": "handleCheckboxChange()",
-      "norm_label": "handlecheckboxchange()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
-      "label": "Filter.tsx",
-      "norm_label": "filter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "bestsellerssection_bestsellerssection",
-      "label": "BestSellersSection()",
-      "norm_label": "bestsellerssection()",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
-      "label": "BestSellersSection.tsx",
-      "norm_label": "bestsellerssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "homepagecontent_resolvehomepagecontent",
-      "label": "resolveHomepageContent()",
-      "norm_label": "resolvehomepagecontent()",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
-      "label": "homePageContent.ts",
-      "norm_label": "homepagecontent.ts",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
-      "source_location": "L1"
     },
     {
       "community": 57,
@@ -55491,6 +55953,60 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "filter_handlecheckboxchange",
+      "label": "handleCheckboxChange()",
+      "norm_label": "handlecheckboxchange()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
+      "label": "Filter.tsx",
+      "norm_label": "filter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "bestsellerssection_bestsellerssection",
+      "label": "BestSellersSection()",
+      "norm_label": "bestsellerssection()",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
+      "label": "BestSellersSection.tsx",
+      "norm_label": "bestsellerssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
+      "id": "homepagecontent_resolvehomepagecontent",
+      "label": "resolveHomepageContent()",
+      "norm_label": "resolvehomepagecontent()",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
+      "label": "homePageContent.ts",
+      "norm_label": "homepagecontent.ts",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 573,
+      "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
       "norm_label": "handleonlinkclick()",
@@ -55498,7 +56014,7 @@
       "source_location": "L47"
     },
     {
-      "community": 570,
+      "community": 573,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -55507,7 +56023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 574,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -55516,7 +56032,7 @@
       "source_location": "L7"
     },
     {
-      "community": 571,
+      "community": 574,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -55525,7 +56041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 575,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -55534,7 +56050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 575,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -55543,7 +56059,7 @@
       "source_location": "L17"
     },
     {
-      "community": 573,
+      "community": 576,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -55552,7 +56068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 576,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -55561,7 +56077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 577,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -55570,7 +56086,7 @@
       "source_location": "L12"
     },
     {
-      "community": 574,
+      "community": 577,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -55579,7 +56095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 578,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -55588,7 +56104,7 @@
       "source_location": "L7"
     },
     {
-      "community": 575,
+      "community": 578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -55597,7 +56113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 579,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -55606,67 +56122,13 @@
       "source_location": "L45"
     },
     {
-      "community": 576,
+      "community": 579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
       "norm_label": "galleryviewer.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 577,
-      "file_type": "code",
-      "id": "onsaleproduct_onsaleproduct",
-      "label": "OnsaleProduct()",
-      "norm_label": "onsaleproduct()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 577,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
-      "label": "OnSaleProduct.tsx",
-      "norm_label": "onsaleproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
-      "label": "ProductActions.tsx",
-      "norm_label": "productactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "productactions_productactions",
-      "label": "ProductActions()",
-      "norm_label": "productactions()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
-      "label": "ProductAttributes.tsx",
-      "norm_label": "productattributes.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "productattributes_productattributes",
-      "label": "ProductAttributes()",
-      "norm_label": "productattributes()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
-      "source_location": "L3"
     },
     {
       "community": 58,
@@ -55743,6 +56205,60 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "onsaleproduct_onsaleproduct",
+      "label": "OnsaleProduct()",
+      "norm_label": "onsaleproduct()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
+      "label": "OnSaleProduct.tsx",
+      "norm_label": "onsaleproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
+      "label": "ProductActions.tsx",
+      "norm_label": "productactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "productactions_productactions",
+      "label": "ProductActions()",
+      "norm_label": "productactions()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
+      "label": "ProductAttributes.tsx",
+      "norm_label": "productattributes.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "productattributes_productattributes",
+      "label": "ProductAttributes()",
+      "norm_label": "productattributes()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 583,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
       "norm_label": "productpage.tsx",
@@ -55750,7 +56266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 583,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -55759,7 +56275,7 @@
       "source_location": "L78"
     },
     {
-      "community": 581,
+      "community": 584,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -55768,7 +56284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 584,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -55777,7 +56293,7 @@
       "source_location": "L87"
     },
     {
-      "community": 582,
+      "community": 585,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -55786,7 +56302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 585,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -55795,7 +56311,7 @@
       "source_location": "L8"
     },
     {
-      "community": 583,
+      "community": 586,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -55804,7 +56320,7 @@
       "source_location": "L12"
     },
     {
-      "community": 583,
+      "community": 586,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -55813,7 +56329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 587,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -55822,7 +56338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 587,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -55831,7 +56347,7 @@
       "source_location": "L18"
     },
     {
-      "community": 585,
+      "community": 588,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -55840,7 +56356,7 @@
       "source_location": "L10"
     },
     {
-      "community": 585,
+      "community": 588,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -55849,7 +56365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 589,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -55858,66 +56374,12 @@
       "source_location": "L11"
     },
     {
-      "community": 586,
+      "community": 589,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
       "norm_label": "orderpointsdisplay.tsx",
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
-      "label": "PastOrdersRewards.tsx",
-      "norm_label": "pastordersrewards.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "pastordersrewards_handleclaimpoints",
-      "label": "handleClaimPoints()",
-      "norm_label": "handleclaimpoints()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
-      "source_location": "L59"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
-      "label": "RewardsPanel.tsx",
-      "norm_label": "rewardspanel.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "rewardspanel_handleredeemreward",
-      "label": "handleRedeemReward()",
-      "norm_label": "handleredeemreward()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "bagitem_bagitem",
-      "label": "BagItem()",
-      "norm_label": "bagitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
-      "label": "BagItem.tsx",
-      "norm_label": "bagitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
       "source_location": "L1"
     },
     {
@@ -55995,6 +56457,60 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
+      "label": "PastOrdersRewards.tsx",
+      "norm_label": "pastordersrewards.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "pastordersrewards_handleclaimpoints",
+      "label": "handleClaimPoints()",
+      "norm_label": "handleclaimpoints()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
+      "label": "RewardsPanel.tsx",
+      "norm_label": "rewardspanel.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "rewardspanel_handleredeemreward",
+      "label": "handleRedeemReward()",
+      "norm_label": "handleredeemreward()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
+      "id": "bagitem_bagitem",
+      "label": "BagItem()",
+      "norm_label": "bagitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
+      "label": "BagItem.tsx",
+      "norm_label": "bagitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 593,
+      "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
       "norm_label": "checkoutunavailable()",
@@ -56002,7 +56518,7 @@
       "source_location": "L4"
     },
     {
-      "community": 590,
+      "community": 593,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -56011,7 +56527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 594,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -56020,7 +56536,7 @@
       "source_location": "L22"
     },
     {
-      "community": 591,
+      "community": 594,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -56029,7 +56545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 595,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -56038,7 +56554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 595,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -56047,7 +56563,7 @@
       "source_location": "L11"
     },
     {
-      "community": 593,
+      "community": 596,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -56056,7 +56572,7 @@
       "source_location": "L3"
     },
     {
-      "community": 593,
+      "community": 596,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -56065,7 +56581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 597,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -56074,7 +56590,7 @@
       "source_location": "L3"
     },
     {
-      "community": 594,
+      "community": 597,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -56083,7 +56599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 598,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -56092,7 +56608,7 @@
       "source_location": "L9"
     },
     {
-      "community": 595,
+      "community": 598,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -56101,7 +56617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 599,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -56110,66 +56626,12 @@
       "source_location": "L66"
     },
     {
-      "community": 596,
+      "community": 599,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
       "norm_label": "leaveareviewmodal.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 597,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
-      "label": "UpsellModalSuccess.tsx",
-      "norm_label": "upsellmodalsuccess.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 597,
-      "file_type": "code",
-      "id": "upsellmodalsuccess_upsellmodalsuccess",
-      "label": "UpsellModalSuccess()",
-      "norm_label": "upsellmodalsuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
-      "label": "WelcomeBackModalSuccess.tsx",
-      "norm_label": "welcomebackmodalsuccess.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
-      "label": "WelcomeBackModalSuccess()",
-      "norm_label": "welcomebackmodalsuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "leavereviewmodalconfig_getmodalconfig",
-      "label": "getModalConfig()",
-      "norm_label": "getmodalconfig()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
-      "label": "leaveReviewModalConfig.tsx",
-      "norm_label": "leavereviewmodalconfig.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L1"
     },
     {
@@ -56481,6 +56943,60 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
+      "label": "UpsellModalSuccess.tsx",
+      "norm_label": "upsellmodalsuccess.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "upsellmodalsuccess_upsellmodalsuccess",
+      "label": "UpsellModalSuccess()",
+      "norm_label": "upsellmodalsuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
+      "label": "WelcomeBackModalSuccess.tsx",
+      "norm_label": "welcomebackmodalsuccess.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
+      "label": "WelcomeBackModalSuccess()",
+      "norm_label": "welcomebackmodalsuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "leavereviewmodalconfig_getmodalconfig",
+      "label": "getModalConfig()",
+      "norm_label": "getmodalconfig()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
+      "label": "leaveReviewModalConfig.tsx",
+      "norm_label": "leavereviewmodalconfig.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 603,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
       "norm_label": "welcomebackmodalconfig.tsx",
@@ -56488,7 +57004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 603,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -56497,7 +57013,7 @@
       "source_location": "L46"
     },
     {
-      "community": 601,
+      "community": 604,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -56506,7 +57022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 604,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -56515,7 +57031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 605,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -56524,7 +57040,7 @@
       "source_location": "L15"
     },
     {
-      "community": 602,
+      "community": 605,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -56533,7 +57049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 606,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -56542,7 +57058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 606,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -56551,7 +57067,7 @@
       "source_location": "L5"
     },
     {
-      "community": 604,
+      "community": 607,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -56560,7 +57076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 607,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -56569,7 +57085,7 @@
       "source_location": "L14"
     },
     {
-      "community": 605,
+      "community": 608,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -56578,7 +57094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 608,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -56587,7 +57103,7 @@
       "source_location": "L29"
     },
     {
-      "community": 606,
+      "community": 609,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -56596,67 +57112,13 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 609,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
       "norm_label": "usegetactivecheckoutsession()",
       "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
-      "label": "useGetProduct.tsx",
-      "norm_label": "usegetproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "usegetproduct_usegetproductquery",
-      "label": "useGetProductQuery()",
-      "norm_label": "usegetproductquery()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
-      "label": "useGetProductFilters.ts",
-      "norm_label": "usegetproductfilters.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "usegetproductfilters_usegetproductfilters",
-      "label": "useGetProductFilters()",
-      "norm_label": "usegetproductfilters()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
-      "label": "useGetProductReviews.ts",
-      "norm_label": "usegetproductreviews.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "usegetproductreviews_usegetproductreviewsquery",
-      "label": "useGetProductReviewsQuery()",
-      "norm_label": "usegetproductreviewsquery()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
-      "source_location": "L4"
     },
     {
       "community": 61,
@@ -56733,6 +57195,60 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
+      "label": "useGetProduct.tsx",
+      "norm_label": "usegetproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "usegetproduct_usegetproductquery",
+      "label": "useGetProductQuery()",
+      "norm_label": "usegetproductquery()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
+      "label": "useGetProductFilters.ts",
+      "norm_label": "usegetproductfilters.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "usegetproductfilters_usegetproductfilters",
+      "label": "useGetProductFilters()",
+      "norm_label": "usegetproductfilters()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
+      "label": "useGetProductReviews.ts",
+      "norm_label": "usegetproductreviews.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "usegetproductreviews_usegetproductreviewsquery",
+      "label": "useGetProductReviewsQuery()",
+      "norm_label": "usegetproductreviewsquery()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 613,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
       "norm_label": "usegetstore.ts",
@@ -56740,7 +57256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 613,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -56749,7 +57265,7 @@
       "source_location": "L4"
     },
     {
-      "community": 611,
+      "community": 614,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -56758,7 +57274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 614,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -56767,7 +57283,7 @@
       "source_location": "L9"
     },
     {
-      "community": 612,
+      "community": 615,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -56776,7 +57292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 615,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -56785,7 +57301,7 @@
       "source_location": "L17"
     },
     {
-      "community": 613,
+      "community": 616,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -56794,7 +57310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 616,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -56803,7 +57319,7 @@
       "source_location": "L5"
     },
     {
-      "community": 614,
+      "community": 617,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -56812,7 +57328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 617,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -56821,7 +57337,7 @@
       "source_location": "L15"
     },
     {
-      "community": 615,
+      "community": 618,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -56830,7 +57346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 618,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -56839,7 +57355,7 @@
       "source_location": "L18"
     },
     {
-      "community": 616,
+      "community": 619,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -56848,67 +57364,13 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 619,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
       "norm_label": "useproductreminder()",
       "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 617,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
-      "label": "usePromoAlert.tsx",
-      "norm_label": "usepromoalert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 617,
-      "file_type": "code",
-      "id": "usepromoalert_usepromoalert",
-      "label": "usePromoAlert()",
-      "norm_label": "usepromoalert()",
-      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
-      "label": "useQueryEnabled.ts",
-      "norm_label": "usequeryenabled.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "usequeryenabled_usequeryenabled",
-      "label": "useQueryEnabled()",
-      "norm_label": "usequeryenabled()",
-      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
-      "label": "useRewardsAlert.tsx",
-      "norm_label": "userewardsalert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "userewardsalert_userewardsalert",
-      "label": "useRewardsAlert()",
-      "norm_label": "userewardsalert()",
-      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
-      "source_location": "L11"
     },
     {
       "community": 62,
@@ -56985,6 +57447,60 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
+      "label": "usePromoAlert.tsx",
+      "norm_label": "usepromoalert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "usepromoalert_usepromoalert",
+      "label": "usePromoAlert()",
+      "norm_label": "usepromoalert()",
+      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
+      "label": "useQueryEnabled.ts",
+      "norm_label": "usequeryenabled.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "usequeryenabled_usequeryenabled",
+      "label": "useQueryEnabled()",
+      "norm_label": "usequeryenabled()",
+      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
+      "label": "useRewardsAlert.tsx",
+      "norm_label": "userewardsalert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
+      "id": "userewardsalert_userewardsalert",
+      "label": "useRewardsAlert()",
+      "norm_label": "userewardsalert()",
+      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 623,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
       "norm_label": "usescrolltotop.ts",
@@ -56992,7 +57508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 623,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -57001,7 +57517,7 @@
       "source_location": "L3"
     },
     {
-      "community": 621,
+      "community": 624,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -57010,7 +57526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 624,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -57019,7 +57535,7 @@
       "source_location": "L7"
     },
     {
-      "community": 622,
+      "community": 625,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -57028,7 +57544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 625,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -57037,7 +57553,7 @@
       "source_location": "L4"
     },
     {
-      "community": 623,
+      "community": 626,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -57046,7 +57562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 626,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -57055,7 +57571,7 @@
       "source_location": "L14"
     },
     {
-      "community": 624,
+      "community": 627,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -57064,7 +57580,7 @@
       "source_location": "L4"
     },
     {
-      "community": 624,
+      "community": 627,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -57073,7 +57589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 628,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -57082,7 +57598,7 @@
       "source_location": "L7"
     },
     {
-      "community": 625,
+      "community": 628,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -57091,7 +57607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 629,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -57100,66 +57616,12 @@
       "source_location": "L6"
     },
     {
-      "community": 626,
+      "community": 629,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
       "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 627,
-      "file_type": "code",
-      "id": "checkout_usecheckoutsessionqueries",
-      "label": "useCheckoutSessionQueries()",
-      "norm_label": "usecheckoutsessionqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 627,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
-      "label": "checkout.ts",
-      "norm_label": "checkout.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "inventory_useinventoryqueries",
-      "label": "useInventoryQueries()",
-      "norm_label": "useinventoryqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
-      "label": "inventory.ts",
-      "norm_label": "inventory.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "onlineorder_useonlineorderqueries",
-      "label": "useOnlineOrderQueries()",
-      "norm_label": "useonlineorderqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -57237,6 +57699,60 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "checkout_usecheckoutsessionqueries",
+      "label": "useCheckoutSessionQueries()",
+      "norm_label": "usecheckoutsessionqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
+      "label": "checkout.ts",
+      "norm_label": "checkout.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "inventory_useinventoryqueries",
+      "label": "useInventoryQueries()",
+      "norm_label": "useinventoryqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
+      "label": "inventory.ts",
+      "norm_label": "inventory.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
+      "id": "onlineorder_useonlineorderqueries",
+      "label": "useOnlineOrderQueries()",
+      "norm_label": "useonlineorderqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 633,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
@@ -57244,7 +57760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 630,
+      "community": 633,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -57253,7 +57769,7 @@
       "source_location": "L14"
     },
     {
-      "community": 631,
+      "community": 634,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -57262,7 +57778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 634,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -57271,7 +57787,7 @@
       "source_location": "L9"
     },
     {
-      "community": 632,
+      "community": 635,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -57280,7 +57796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 635,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -57289,7 +57805,7 @@
       "source_location": "L10"
     },
     {
-      "community": 633,
+      "community": 636,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -57298,7 +57814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 636,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -57307,7 +57823,7 @@
       "source_location": "L11"
     },
     {
-      "community": 634,
+      "community": 637,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -57316,7 +57832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 637,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -57325,7 +57841,7 @@
       "source_location": "L6"
     },
     {
-      "community": 635,
+      "community": 638,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -57334,7 +57850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 638,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -57343,7 +57859,7 @@
       "source_location": "L5"
     },
     {
-      "community": 636,
+      "community": 639,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -57352,67 +57868,13 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 639,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
       "norm_label": "useuseroffersqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 637,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
-      "label": "storeConfig.test.ts",
-      "norm_label": "storeconfig.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 637,
-      "file_type": "code",
-      "id": "storeconfig_test_buildv2config",
-      "label": "buildV2Config()",
-      "norm_label": "buildv2config()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
-      "label": "storefrontObservability.test.ts",
-      "norm_label": "storefrontobservability.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "storefrontobservability_test_creatememorystorage",
-      "label": "createMemoryStorage()",
-      "norm_label": "creatememorystorage()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "email_validateemail",
-      "label": "validateEmail()",
-      "norm_label": "validateemail()",
-      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_validations_email_ts",
-      "label": "email.ts",
-      "norm_label": "email.ts",
-      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
-      "source_location": "L1"
     },
     {
       "community": 64,
@@ -57489,6 +57951,60 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
+      "label": "storeConfig.test.ts",
+      "norm_label": "storeconfig.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "storeconfig_test_buildv2config",
+      "label": "buildV2Config()",
+      "norm_label": "buildv2config()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
+      "label": "storefrontObservability.test.ts",
+      "norm_label": "storefrontobservability.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "storefrontobservability_test_creatememorystorage",
+      "label": "createMemoryStorage()",
+      "norm_label": "creatememorystorage()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "email_validateemail",
+      "label": "validateEmail()",
+      "norm_label": "validateemail()",
+      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_validations_email_ts",
+      "label": "email.ts",
+      "norm_label": "email.ts",
+      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 643,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
       "norm_label": "router.tsx",
@@ -57496,7 +58012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 643,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -57505,7 +58021,7 @@
       "source_location": "L6"
     },
     {
-      "community": 641,
+      "community": 644,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -57514,7 +58030,7 @@
       "source_location": "L13"
     },
     {
-      "community": 641,
+      "community": 644,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -57523,7 +58039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 645,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -57532,7 +58048,7 @@
       "source_location": "L8"
     },
     {
-      "community": 642,
+      "community": 645,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -57541,7 +58057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 646,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -57550,7 +58066,7 @@
       "source_location": "L14"
     },
     {
-      "community": 643,
+      "community": 646,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -57559,7 +58075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 647,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -57568,7 +58084,7 @@
       "source_location": "L13"
     },
     {
-      "community": 644,
+      "community": 647,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -57577,7 +58093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 648,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -57586,7 +58102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 648,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -57595,7 +58111,7 @@
       "source_location": "L9"
     },
     {
-      "community": 646,
+      "community": 649,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -57604,67 +58120,13 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 649,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
       "norm_label": "tossection()",
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L15"
-    },
-    {
-      "community": 647,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
-      "label": "shop.product.$productSlug.tsx",
-      "norm_label": "shop.product.$productslug.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 647,
-      "file_type": "code",
-      "id": "shop_product_productslug_component",
-      "label": "Component()",
-      "norm_label": "component()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "layout_layoutcomponent",
-      "label": "LayoutComponent()",
-      "norm_label": "layoutcomponent()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_tsx",
-      "label": "_layout.tsx",
-      "norm_label": "_layout.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "index_homeroute",
-      "label": "HomeRoute()",
-      "norm_label": "homeroute()",
-      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 65,
@@ -57741,6 +58203,60 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
+      "label": "shop.product.$productSlug.tsx",
+      "norm_label": "shop.product.$productslug.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "shop_product_productslug_component",
+      "label": "Component()",
+      "norm_label": "component()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "layout_layoutcomponent",
+      "label": "LayoutComponent()",
+      "norm_label": "layoutcomponent()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_tsx",
+      "label": "_layout.tsx",
+      "norm_label": "_layout.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
+      "id": "index_homeroute",
+      "label": "HomeRoute()",
+      "norm_label": "homeroute()",
+      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 653,
+      "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
       "norm_label": "checkoutcanceledview()",
@@ -57748,7 +58264,7 @@
       "source_location": "L21"
     },
     {
-      "community": 650,
+      "community": 653,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -57757,7 +58273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 654,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -57766,7 +58282,7 @@
       "source_location": "L33"
     },
     {
-      "community": 651,
+      "community": 654,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -57775,7 +58291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 655,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -57784,7 +58300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 655,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -57793,7 +58309,7 @@
       "source_location": "L193"
     },
     {
-      "community": 653,
+      "community": 656,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -57802,7 +58318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 656,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -57811,7 +58327,7 @@
       "source_location": "L7"
     },
     {
-      "community": 654,
+      "community": 657,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -57820,7 +58336,7 @@
       "source_location": "L10"
     },
     {
-      "community": 654,
+      "community": 657,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -57829,7 +58345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 658,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -57838,7 +58354,7 @@
       "source_location": "L32"
     },
     {
-      "community": 655,
+      "community": 658,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -57847,7 +58363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 659,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -57856,57 +58372,12 @@
       "source_location": "L211"
     },
     {
-      "community": 656,
+      "community": 659,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
       "norm_label": "athena-runtime-app.ts",
       "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "sample_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_sample_app_ts",
-      "label": "sample-app.ts",
-      "norm_label": "sample-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "harness_runtime_trends_test_buildreportline",
-      "label": "buildReportLine()",
-      "norm_label": "buildreportline()",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "scripts_harness_runtime_trends_test_ts",
-      "label": "harness-runtime-trends.test.ts",
-      "norm_label": "harness-runtime-trends.test.ts",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_api_d_ts",
-      "label": "api.d.ts",
-      "norm_label": "api.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
       "source_location": "L1"
     },
     {
@@ -57975,6 +58446,51 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "sample_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_sample_app_ts",
+      "label": "sample-app.ts",
+      "norm_label": "sample-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "harness_runtime_trends_test_buildreportline",
+      "label": "buildReportLine()",
+      "norm_label": "buildreportline()",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "scripts_harness_runtime_trends_test_ts",
+      "label": "harness-runtime-trends.test.ts",
+      "norm_label": "harness-runtime-trends.test.ts",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_api_d_ts",
+      "label": "api.d.ts",
+      "norm_label": "api.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 663,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
       "norm_label": "api.js",
@@ -57982,7 +58498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -57991,7 +58507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -58000,7 +58516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -58009,7 +58525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -58018,7 +58534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -58027,39 +58543,12 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
       "source_file": "packages/athena-webapp/convex/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 667,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
-      "label": "registerSessions.test.ts",
-      "norm_label": "registersessions.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/registerSessions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_email_ts",
-      "label": "email.ts",
-      "norm_label": "email.ts",
-      "source_file": "packages/athena-webapp/convex/constants/email.ts",
       "source_location": "L1"
     },
     {
@@ -58128,6 +58617,33 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
+      "label": "registerSessions.test.ts",
+      "norm_label": "registersessions.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/registerSessions.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_email_ts",
+      "label": "email.ts",
+      "norm_label": "email.ts",
+      "source_file": "packages/athena-webapp/convex/constants/email.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 673,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
       "norm_label": "ghana.ts",
@@ -58135,7 +58651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -58144,7 +58660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -58153,7 +58669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -58162,7 +58678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -58171,7 +58687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -58180,39 +58696,12 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
       "norm_label": "posreceiptemail.tsx",
       "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 677,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_env_ts",
-      "label": "env.ts",
-      "norm_label": "env.ts",
-      "source_file": "packages/athena-webapp/convex/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts",
       "source_location": "L1"
     },
     {
@@ -58281,6 +58770,33 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_env_ts",
+      "label": "env.ts",
+      "norm_label": "env.ts",
+      "source_file": "packages/athena-webapp/convex/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 683,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
@@ -58288,7 +58804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -58297,7 +58813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -58306,7 +58822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -58315,7 +58831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 687,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
@@ -58324,7 +58840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 688,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
@@ -58333,39 +58849,12 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 689,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
       "label": "stores.ts",
       "norm_label": "stores.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 687,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
-      "label": "subcategories.ts",
-      "norm_label": "subcategories.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
       "source_location": "L1"
     },
     {
@@ -58434,6 +58923,33 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
+      "label": "subcategories.ts",
+      "norm_label": "subcategories.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 693,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
@@ -58441,7 +58957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 694,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
@@ -58450,7 +58966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
@@ -58459,7 +58975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
@@ -58468,7 +58984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -58477,7 +58993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
@@ -58486,39 +59002,12 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
       "label": "reviews.ts",
       "norm_label": "reviews.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 697,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
-      "label": "security.test.ts",
-      "norm_label": "security.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
       "source_location": "L1"
     },
     {
@@ -58812,6 +59301,33 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
+      "label": "security.test.ts",
+      "norm_label": "security.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 703,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
       "norm_label": "storefront.ts",
@@ -58819,7 +59335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
@@ -58828,7 +59344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -58837,7 +59353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -58846,7 +59362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -58855,7 +59371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -58864,39 +59380,12 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
       "norm_label": "athenauser.ts",
       "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 707,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
-      "label": "bestSeller.ts",
-      "norm_label": "bestseller.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.ts",
       "source_location": "L1"
     },
     {
@@ -58965,6 +59454,33 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
+      "label": "bestSeller.ts",
+      "norm_label": "bestseller.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 713,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
       "norm_label": "categories.ts",
@@ -58972,7 +59488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 714,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -58981,7 +59497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 715,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -58990,7 +59506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 716,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -58999,7 +59515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 717,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -59008,7 +59524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 718,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -59017,39 +59533,12 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 719,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
       "norm_label": "invitecode.ts",
       "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 717,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
-      "label": "organizationMembers.ts",
-      "norm_label": "organizationmembers.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_organizations_ts",
-      "label": "organizations.ts",
-      "norm_label": "organizations.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
-      "label": "posCustomers.ts",
-      "norm_label": "poscustomers.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
       "source_location": "L1"
     },
     {
@@ -59118,6 +59607,33 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
+      "label": "organizationMembers.ts",
+      "norm_label": "organizationmembers.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_organizations_ts",
+      "label": "organizations.ts",
+      "norm_label": "organizations.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
+      "label": "posCustomers.ts",
+      "norm_label": "poscustomers.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 723,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
       "norm_label": "possessionitems.ts",
@@ -59125,7 +59641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 724,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -59134,7 +59650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 725,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -59143,7 +59659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -59152,7 +59668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -59161,7 +59677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -59170,39 +59686,12 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
       "norm_label": "storeconfigv2.test.ts",
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 727,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
-      "label": "subcategories.ts",
-      "norm_label": "subcategories.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/subcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_test_ts",
-      "label": "currency.test.ts",
-      "norm_label": "currency.test.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
-      "label": "storeInsights.ts",
-      "norm_label": "storeinsights.ts",
-      "source_file": "packages/athena-webapp/convex/llm/storeInsights.ts",
       "source_location": "L1"
     },
     {
@@ -59271,6 +59760,33 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
+      "label": "subcategories.ts",
+      "norm_label": "subcategories.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/subcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_test_ts",
+      "label": "currency.test.ts",
+      "norm_label": "currency.test.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 732,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
+      "label": "storeInsights.ts",
+      "norm_label": "storeinsights.ts",
+      "source_file": "packages/athena-webapp/convex/llm/storeInsights.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 733,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
       "norm_label": "userinsights.ts",
@@ -59278,7 +59794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -59287,7 +59803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -59296,7 +59812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -59305,7 +59821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -59314,7 +59830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -59323,39 +59839,12 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
       "norm_label": "customerprofiles.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/customerProfiles.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 737,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
-      "label": "inventoryMovements.test.ts",
-      "norm_label": "inventorymovements.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
-      "label": "paymentAllocations.test.ts",
-      "norm_label": "paymentallocations.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
-      "label": "staffProfiles.test.ts",
-      "norm_label": "staffprofiles.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
       "source_location": "L1"
     },
     {
@@ -59424,6 +59913,33 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
+      "label": "inventoryMovements.test.ts",
+      "norm_label": "inventorymovements.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
+      "label": "paymentAllocations.test.ts",
+      "norm_label": "paymentallocations.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 742,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
+      "label": "staffProfiles.test.ts",
+      "norm_label": "staffprofiles.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 743,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_resendotp_ts",
       "label": "ResendOTP.ts",
       "norm_label": "resendotp.ts",
@@ -59431,7 +59947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -59440,7 +59956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -59449,7 +59965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -59458,7 +59974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -59467,7 +59983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -59476,7 +59992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -59485,7 +60001,70 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 75,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "label": "session.ts",
+      "norm_label": "session.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "session_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "session_hasactiveregistersession",
+      "label": "hasActiveRegisterSession()",
+      "norm_label": "hasactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "session_hasresumableregistersession",
+      "label": "hasResumableRegisterSession()",
+      "norm_label": "hasresumableregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "session_isregisterreadytostart",
+      "label": "isRegisterReadyToStart()",
+      "norm_label": "isregisterreadytostart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "session_requirescashier",
+      "label": "requiresCashier()",
+      "norm_label": "requirescashier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "session_requiresterminal",
+      "label": "requiresTerminal()",
+      "norm_label": "requiresterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 750,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -59494,7 +60073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 751,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -59503,7 +60082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 749,
+      "community": 752,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -59512,70 +60091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 75,
-      "file_type": "code",
-      "id": "calculationservice_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "calculationservice_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "calculationservice_calculateitemtotal",
-      "label": "calculateItemTotal()",
-      "norm_label": "calculateitemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "calculationservice_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "calculationservice_geteffectiveprice",
-      "label": "getEffectivePrice()",
-      "norm_label": "geteffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "calculationservice_ispaymentsufficient",
-      "label": "isPaymentSufficient()",
-      "norm_label": "ispaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "label": "calculationService.ts",
-      "norm_label": "calculationservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 750,
+      "community": 753,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -59584,7 +60100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -59593,7 +60109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -59602,7 +60118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -59611,7 +60127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -59620,7 +60136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -59629,7 +60145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -59638,7 +60154,70 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 76,
+      "file_type": "code",
+      "id": "calculationservice_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "calculationservice_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "calculationservice_calculateitemtotal",
+      "label": "calculateItemTotal()",
+      "norm_label": "calculateitemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "calculationservice_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "calculationservice_geteffectiveprice",
+      "label": "getEffectivePrice()",
+      "norm_label": "geteffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "calculationservice_ispaymentsufficient",
+      "label": "isPaymentSufficient()",
+      "norm_label": "ispaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
+      "label": "calculationService.ts",
+      "norm_label": "calculationservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 760,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -59647,7 +60226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 761,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -59656,7 +60235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 759,
+      "community": 762,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -59665,70 +60244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
-    },
-    {
-      "community": 760,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -59737,7 +60253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -59746,7 +60262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -59755,7 +60271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -59764,7 +60280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -59773,7 +60289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -59782,7 +60298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -59791,7 +60307,70 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
+    },
+    {
+      "community": 770,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -59800,7 +60379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 771,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -59809,7 +60388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 769,
+      "community": 772,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -59818,70 +60397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 77,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 770,
+      "community": 773,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -59890,7 +60406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -59899,7 +60415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -59908,7 +60424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -59917,7 +60433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -59926,7 +60442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -59935,7 +60451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -59944,7 +60460,70 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 78,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 780,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -59953,7 +60532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 781,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -59962,7 +60541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 779,
+      "community": 782,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -59971,70 +60550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 78,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 780,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -60043,7 +60559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -60052,7 +60568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -60061,7 +60577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -60070,7 +60586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -60079,7 +60595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -60088,7 +60604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -60097,7 +60613,70 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 79,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 790,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -60106,7 +60685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 791,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -60115,7 +60694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 789,
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -60124,70 +60703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 79,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "label": "storefront-runtime-api.ts",
-      "norm_label": "storefront-runtime-api.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "storefront_runtime_api_emitsignal",
-      "label": "emitSignal()",
-      "norm_label": "emitsignal()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L195"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "label": "handleCheckoutSessionFetch()",
-      "norm_label": "handlecheckoutsessionfetch()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "label": "handleCheckoutSessionUpdate()",
-      "norm_label": "handlecheckoutsessionupdate()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "storefront_runtime_api_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "storefront_runtime_api_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L394"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "storefront_runtime_api_withcorsheaders",
-      "label": "withCorsHeaders()",
-      "norm_label": "withcorsheaders()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 790,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -60196,7 +60712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -60205,7 +60721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -60214,7 +60730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
@@ -60223,7 +60739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -60232,7 +60748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -60241,39 +60757,12 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
       "norm_label": "bagitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 797,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
-      "label": "checkoutSessionItem.ts",
-      "norm_label": "checkoutsessionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
-      "label": "customer.ts",
-      "norm_label": "customer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/customer.ts",
       "source_location": "L1"
     },
     {
@@ -60477,68 +60966,95 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "harness_janitor_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "label": "overwriteFreshGeneratedDocs()",
-      "norm_label": "overwritefreshgenerateddocs()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "label": "overwriteFreshGraphifyArtifacts()",
-      "norm_label": "overwritefreshgraphifyartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "harness_janitor_test_seedartifacts",
-      "label": "seedArtifacts()",
-      "norm_label": "seedartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "harness_janitor_test_sortpaths",
-      "label": "sortPaths()",
-      "norm_label": "sortpaths()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "harness_janitor_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "scripts_harness_janitor_test_ts",
-      "label": "harness-janitor.test.ts",
-      "norm_label": "harness-janitor.test.ts",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "label": "storefront-runtime-api.ts",
+      "norm_label": "storefront-runtime-api.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L1"
     },
     {
+      "community": 80,
+      "file_type": "code",
+      "id": "storefront_runtime_api_emitsignal",
+      "label": "emitSignal()",
+      "norm_label": "emitsignal()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L195"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "label": "handleCheckoutSessionFetch()",
+      "norm_label": "handlecheckoutsessionfetch()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L199"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "label": "handleCheckoutSessionUpdate()",
+      "norm_label": "handlecheckoutsessionupdate()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "storefront_runtime_api_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "storefront_runtime_api_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L394"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "storefront_runtime_api_withcorsheaders",
+      "label": "withCorsHeaders()",
+      "norm_label": "withcorsheaders()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L171"
+    },
+    {
       "community": 800,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
+      "label": "checkoutSessionItem.ts",
+      "norm_label": "checkoutsessionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 802,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
+      "label": "customer.ts",
+      "norm_label": "customer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/customer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -60547,7 +61063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -60556,7 +61072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -60565,7 +61081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -60574,7 +61090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -60583,7 +61099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -60592,7 +61108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -60601,7 +61117,70 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 81,
+      "file_type": "code",
+      "id": "harness_janitor_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgenerateddocs",
+      "label": "overwriteFreshGeneratedDocs()",
+      "norm_label": "overwritefreshgenerateddocs()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
+      "label": "overwriteFreshGraphifyArtifacts()",
+      "norm_label": "overwritefreshgraphifyartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "harness_janitor_test_seedartifacts",
+      "label": "seedArtifacts()",
+      "norm_label": "seedartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "harness_janitor_test_sortpaths",
+      "label": "sortPaths()",
+      "norm_label": "sortpaths()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "harness_janitor_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_test_ts",
+      "label": "harness-janitor.test.ts",
+      "norm_label": "harness-janitor.test.ts",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 810,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -60610,7 +61189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 811,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -60619,7 +61198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 809,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -60628,70 +61207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 81,
-      "file_type": "code",
-      "id": "harness_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "harness_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "harness_review_test_initializegithistory",
-      "label": "initializeGitHistory()",
-      "norm_label": "initializegithistory()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L259"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "harness_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "harness_review_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L245"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "harness_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "scripts_harness_review_test_ts",
-      "label": "harness-review.test.ts",
-      "norm_label": "harness-review.test.ts",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 810,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -60700,7 +61216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -60709,7 +61225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -60718,7 +61234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -60727,7 +61243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -60736,7 +61252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -60745,7 +61261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -60754,7 +61270,70 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 82,
+      "file_type": "code",
+      "id": "harness_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "harness_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "harness_review_test_initializegithistory",
+      "label": "initializeGitHistory()",
+      "norm_label": "initializegithistory()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L259"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "harness_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "harness_review_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L245"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "harness_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "scripts_harness_review_test_ts",
+      "label": "harness-review.test.ts",
+      "norm_label": "harness-review.test.ts",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 820,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -60763,7 +61342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 821,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -60772,7 +61351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 819,
+      "community": 822,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -60781,61 +61360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 82,
-      "file_type": "code",
-      "id": "index_valkeyclient",
-      "label": "ValkeyClient",
-      "norm_label": "valkeyclient",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "index_valkeyclient_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "index_valkeyclient_get",
-      "label": ".get()",
-      "norm_label": ".get()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "index_valkeyclient_invalidate",
-      "label": ".invalidate()",
-      "norm_label": ".invalidate()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "index_valkeyclient_set",
-      "label": ".set()",
-      "norm_label": ".set()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cache_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 820,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -60844,7 +61369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -60853,7 +61378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -60862,7 +61387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -60871,7 +61396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -60880,7 +61405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -60889,7 +61414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -60898,7 +61423,61 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 83,
+      "file_type": "code",
+      "id": "index_valkeyclient",
+      "label": "ValkeyClient",
+      "norm_label": "valkeyclient",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "index_valkeyclient_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "index_valkeyclient_get",
+      "label": ".get()",
+      "norm_label": ".get()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "index_valkeyclient_invalidate",
+      "label": ".invalidate()",
+      "norm_label": ".invalidate()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "index_valkeyclient_set",
+      "label": ".set()",
+      "norm_label": ".set()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cache_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 830,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -60907,7 +61486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 831,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -60916,7 +61495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 829,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -60925,61 +61504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 83,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
-      "label": "paymentAllocationAttribution.ts",
-      "norm_label": "paymentallocationattribution.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "paymentallocationattribution_buildinstorepaymentallocations",
-      "label": "buildInStorePaymentAllocations()",
-      "norm_label": "buildinstorepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "paymentallocationattribution_isactiveregistersessionstatus",
-      "label": "isActiveRegisterSessionStatus()",
-      "norm_label": "isactiveregistersessionstatus()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "paymentallocationattribution_normalizeinstorepayments",
-      "label": "normalizeInStorePayments()",
-      "norm_label": "normalizeinstorepayments()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
-      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
-      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "paymentallocationattribution_selectregistersessionforattribution",
-      "label": "selectRegisterSessionForAttribution()",
-      "norm_label": "selectregistersessionforattribution()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 830,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -60988,7 +61513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -60997,7 +61522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -61006,7 +61531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -61015,7 +61540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -61024,7 +61549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -61033,7 +61558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -61042,7 +61567,61 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 84,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "label": "paymentAllocationAttribution.ts",
+      "norm_label": "paymentallocationattribution.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "paymentallocationattribution_buildinstorepaymentallocations",
+      "label": "buildInStorePaymentAllocations()",
+      "norm_label": "buildinstorepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "paymentallocationattribution_isactiveregistersessionstatus",
+      "label": "isActiveRegisterSessionStatus()",
+      "norm_label": "isactiveregistersessionstatus()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "paymentallocationattribution_normalizeinstorepayments",
+      "label": "normalizeInStorePayments()",
+      "norm_label": "normalizeinstorepayments()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
+      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "paymentallocationattribution_selectregistersessionforattribution",
+      "label": "selectRegisterSessionForAttribution()",
+      "norm_label": "selectregistersessionforattribution()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 840,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -61051,7 +61630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 841,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -61060,7 +61639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 839,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -61069,61 +61648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 84,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 840,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -61132,7 +61657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -61141,7 +61666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -61150,7 +61675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -61159,7 +61684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -61168,7 +61693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -61177,7 +61702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -61186,7 +61711,61 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 85,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 850,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -61195,7 +61774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 851,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -61204,7 +61783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 849,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -61213,61 +61792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 85,
-      "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 850,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -61276,7 +61801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -61285,7 +61810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -61294,7 +61819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -61303,7 +61828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -61312,7 +61837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -61321,7 +61846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -61330,7 +61855,61 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 86,
+      "file_type": "code",
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 860,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -61339,7 +61918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 861,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -61348,7 +61927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 859,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -61357,61 +61936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 86,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
-      "label": "purchaseOrders.ts",
-      "norm_label": "purchaseorders.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
-      "label": "assertValidPurchaseOrderStatusTransition()",
-      "norm_label": "assertvalidpurchaseorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordernumber",
-      "label": "buildPurchaseOrderNumber()",
-      "norm_label": "buildpurchaseordernumber()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "purchaseorders_calculatepurchaseordertotals",
-      "label": "calculatePurchaseOrderTotals()",
-      "norm_label": "calculatepurchaseordertotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "purchaseorders_getoperationalworkitemstatus",
-      "label": "getOperationalWorkItemStatus()",
-      "norm_label": "getoperationalworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "purchaseorders_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 860,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -61420,7 +61945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -61429,7 +61954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -61438,7 +61963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -61447,7 +61972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -61456,7 +61981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -61465,7 +61990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -61474,7 +61999,61 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 87,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
+      "label": "purchaseOrders.ts",
+      "norm_label": "purchaseorders.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
+      "label": "assertValidPurchaseOrderStatusTransition()",
+      "norm_label": "assertvalidpurchaseorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "purchaseorders_buildpurchaseordernumber",
+      "label": "buildPurchaseOrderNumber()",
+      "norm_label": "buildpurchaseordernumber()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "purchaseorders_calculatepurchaseordertotals",
+      "label": "calculatePurchaseOrderTotals()",
+      "norm_label": "calculatepurchaseordertotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "purchaseorders_getoperationalworkitemstatus",
+      "label": "getOperationalWorkItemStatus()",
+      "norm_label": "getoperationalworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "purchaseorders_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 870,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -61483,7 +62062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 871,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -61492,7 +62071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 869,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -61501,61 +62080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 87,
-      "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 870,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -61564,7 +62089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -61573,7 +62098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -61582,7 +62107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -61591,7 +62116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -61600,7 +62125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -61609,7 +62134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -61618,7 +62143,61 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 88,
+      "file_type": "code",
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 880,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -61627,7 +62206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 881,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -61636,7 +62215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 879,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -61645,61 +62224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 88,
-      "file_type": "code",
-      "id": "onlineorder_appendtransition",
-      "label": "appendTransition()",
-      "norm_label": "appendtransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "onlineorder_applyonlineorderupdate",
-      "label": "applyOnlineOrderUpdate()",
-      "norm_label": "applyonlineorderupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereplacementsourceid",
-      "label": "buildReturnExchangeReplacementSourceId()",
-      "norm_label": "buildreturnexchangereplacementsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L204"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereturnsourceid",
-      "label": "buildReturnExchangeReturnSourceId()",
-      "norm_label": "buildreturnexchangereturnsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L212"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "onlineorder_listorderitems",
-      "label": "listOrderItems()",
-      "norm_label": "listorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 880,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -61708,7 +62233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -61717,7 +62242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -61726,7 +62251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -61735,7 +62260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
@@ -61744,7 +62269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -61753,7 +62278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -61762,7 +62287,61 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 89,
+      "file_type": "code",
+      "id": "onlineorder_appendtransition",
+      "label": "appendTransition()",
+      "norm_label": "appendtransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "onlineorder_applyonlineorderupdate",
+      "label": "applyOnlineOrderUpdate()",
+      "norm_label": "applyonlineorderupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereplacementsourceid",
+      "label": "buildReturnExchangeReplacementSourceId()",
+      "norm_label": "buildreturnexchangereplacementsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L204"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereturnsourceid",
+      "label": "buildReturnExchangeReturnSourceId()",
+      "norm_label": "buildreturnexchangereturnsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L212"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "onlineorder_listorderitems",
+      "label": "listOrderItems()",
+      "norm_label": "listorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 890,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -61771,7 +62350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 891,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -61780,7 +62359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 889,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -61789,61 +62368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 89,
-      "file_type": "code",
-      "id": "data_table_toolbar_datatabletoolbar",
-      "label": "DataTableToolbar()",
-      "norm_label": "datatabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 890,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -61852,7 +62377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -61861,7 +62386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -61870,7 +62395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -61879,7 +62404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -61888,7 +62413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -61897,39 +62422,12 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 897,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
-      "label": "BulkOperationsPage.tsx",
-      "norm_label": "bulkoperationspage.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
-      "label": "CashControlsDashboard.test.tsx",
-      "norm_label": "cashcontrolsdashboard.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
-      "label": "RegisterCloseoutView.test.tsx",
-      "norm_label": "registercloseoutview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -62124,59 +62622,86 @@
     {
       "community": 90,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "id": "data_table_toolbar_datatabletoolbar",
+      "label": "DataTableToolbar()",
+      "norm_label": "datatabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 900,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
+      "label": "BulkOperationsPage.tsx",
+      "norm_label": "bulkoperationspage.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
+      "label": "CashControlsDashboard.test.tsx",
+      "norm_label": "cashcontrolsdashboard.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 902,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
+      "label": "RegisterCloseoutView.test.tsx",
+      "norm_label": "registercloseoutview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterCloseoutView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -62185,7 +62710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
       "label": "index.tsx",
@@ -62194,7 +62719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -62203,7 +62728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -62212,7 +62737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -62221,7 +62746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -62230,7 +62755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -62239,7 +62764,61 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 91,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 910,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -62248,7 +62827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 911,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -62257,7 +62836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 909,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -62266,61 +62845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 91,
-      "file_type": "code",
-      "id": "cashiermanagement_buildusername",
-      "label": "buildUsername()",
-      "norm_label": "buildusername()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "cashiermanagement_handledelete",
-      "label": "handleDelete()",
-      "norm_label": "handledelete()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L320"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "cashiermanagement_handlepinkeydown",
-      "label": "handlePinKeyDown()",
-      "norm_label": "handlepinkeydown()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L169"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "cashiermanagement_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L109"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "cashiermanagement_normalizenamesegment",
-      "label": "normalizeNameSegment()",
-      "norm_label": "normalizenamesegment()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cashiers_cashiermanagement_tsx",
-      "label": "CashierManagement.tsx",
-      "norm_label": "cashiermanagement.tsx",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 910,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -62329,7 +62854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -62338,7 +62863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -62347,7 +62872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
@@ -62356,7 +62881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -62365,7 +62890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -62374,7 +62899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -62383,7 +62908,61 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 92,
+      "file_type": "code",
+      "id": "cashiermanagement_buildusername",
+      "label": "buildUsername()",
+      "norm_label": "buildusername()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "cashiermanagement_handledelete",
+      "label": "handleDelete()",
+      "norm_label": "handledelete()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L320"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "cashiermanagement_handlepinkeydown",
+      "label": "handlePinKeyDown()",
+      "norm_label": "handlepinkeydown()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L169"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "cashiermanagement_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L109"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "cashiermanagement_normalizenamesegment",
+      "label": "normalizeNameSegment()",
+      "norm_label": "normalizenamesegment()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cashiers_cashiermanagement_tsx",
+      "label": "CashierManagement.tsx",
+      "norm_label": "cashiermanagement.tsx",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 920,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -62392,7 +62971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 921,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -62401,7 +62980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 919,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -62410,61 +62989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 92,
-      "file_type": "code",
-      "id": "bannermessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L123"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleactivetoggle",
-      "label": "handleActiveToggle()",
-      "norm_label": "handleactivetoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleclear",
-      "label": "handleClear()",
-      "norm_label": "handleclear()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L113"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "label": "BannerMessageEditor.tsx",
-      "norm_label": "bannermessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 920,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -62473,7 +62998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -62482,7 +63007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -62491,7 +63016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -62500,7 +63025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -62509,7 +63034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -62518,7 +63043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -62527,7 +63052,61 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 93,
+      "file_type": "code",
+      "id": "bannermessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L123"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleactivetoggle",
+      "label": "handleActiveToggle()",
+      "norm_label": "handleactivetoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L113"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
+      "label": "BannerMessageEditor.tsx",
+      "norm_label": "bannermessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 930,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -62536,7 +63115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 931,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -62545,7 +63124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 929,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -62554,61 +63133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 93,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
-      "label": "PaymentsAddedList.tsx",
-      "norm_label": "paymentsaddedlist.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "label": "getPaymentMethodLabel()",
-      "norm_label": "getpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handleremovepayment",
-      "label": "handleRemovePayment()",
-      "norm_label": "handleremovepayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "paymentsaddedlist_handlestartedit",
-      "label": "handleStartEdit()",
-      "norm_label": "handlestartedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L59"
-    },
-    {
-      "community": 930,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -62617,7 +63142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -62626,7 +63151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -62635,7 +63160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -62644,7 +63169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -62653,7 +63178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -62662,7 +63187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -62671,7 +63196,61 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 94,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
+      "label": "PaymentsAddedList.tsx",
+      "norm_label": "paymentsaddedlist.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "paymentsaddedlist_getpaymentmethodlabel",
+      "label": "getPaymentMethodLabel()",
+      "norm_label": "getpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "paymentsaddedlist_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "paymentsaddedlist_handleremovepayment",
+      "label": "handleRemovePayment()",
+      "norm_label": "handleremovepayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "paymentsaddedlist_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "paymentsaddedlist_handlestartedit",
+      "label": "handleStartEdit()",
+      "norm_label": "handlestartedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 940,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -62680,7 +63259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 941,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -62689,7 +63268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 939,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -62698,61 +63277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 94,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "label": "ReviewsView.tsx",
-      "norm_label": "reviewsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "reviewsview_handleapprove",
-      "label": "handleApprove()",
-      "norm_label": "handleapprove()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "reviewsview_handlepublish",
-      "label": "handlePublish()",
-      "norm_label": "handlepublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "reviewsview_handlereject",
-      "label": "handleReject()",
-      "norm_label": "handlereject()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "reviewsview_handleunpublish",
-      "label": "handleUnpublish()",
-      "norm_label": "handleunpublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "reviewsview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 940,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -62761,7 +63286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -62770,7 +63295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -62779,7 +63304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
@@ -62788,7 +63313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -62797,7 +63322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -62806,7 +63331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
@@ -62815,7 +63340,61 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 95,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
+      "label": "ReviewsView.tsx",
+      "norm_label": "reviewsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "reviewsview_handleapprove",
+      "label": "handleApprove()",
+      "norm_label": "handleapprove()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "reviewsview_handlepublish",
+      "label": "handlePublish()",
+      "norm_label": "handlepublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "reviewsview_handlereject",
+      "label": "handleReject()",
+      "norm_label": "handlereject()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "reviewsview_handleunpublish",
+      "label": "handleUnpublish()",
+      "norm_label": "handleunpublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "reviewsview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 950,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -62824,7 +63403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 951,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -62833,7 +63412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 949,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -62842,61 +63421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 95,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 950,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -62905,7 +63430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -62914,7 +63439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -62923,7 +63448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -62932,7 +63457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -62941,7 +63466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -62950,7 +63475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -62959,7 +63484,61 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 96,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 960,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -62968,7 +63547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 961,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -62977,7 +63556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 959,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -62986,61 +63565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 96,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 960,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -63049,7 +63574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -63058,7 +63583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -63067,7 +63592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -63076,7 +63601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -63085,7 +63610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -63094,7 +63619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -63103,7 +63628,61 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 97,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 970,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -63112,7 +63691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 971,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -63121,7 +63700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 969,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -63130,61 +63709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 97,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 970,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -63193,7 +63718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -63202,7 +63727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -63211,7 +63736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -63220,7 +63745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -63229,7 +63754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -63238,7 +63763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -63247,7 +63772,61 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 98,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 980,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -63256,7 +63835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 981,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -63265,7 +63844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 979,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -63274,61 +63853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 98,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 980,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -63337,7 +63862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -63346,7 +63871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -63355,7 +63880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -63364,7 +63889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -63373,7 +63898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -63382,7 +63907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -63391,7 +63916,61 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 99,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 990,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -63400,7 +63979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 991,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -63409,7 +63988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 989,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -63418,61 +63997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 99,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
-      "label": "usePOSCustomers.ts",
-      "norm_label": "useposcustomers.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomer",
-      "label": "usePOSCustomer()",
-      "norm_label": "useposcustomer()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomercreate",
-      "label": "usePOSCustomerCreate()",
-      "norm_label": "useposcustomercreate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomersearch",
-      "label": "usePOSCustomerSearch()",
-      "norm_label": "useposcustomersearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomertransactions",
-      "label": "usePOSCustomerTransactions()",
-      "norm_label": "useposcustomertransactions()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomerupdate",
-      "label": "usePOSCustomerUpdate()",
-      "norm_label": "useposcustomerupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 990,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -63481,7 +64006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -63490,7 +64015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -63499,7 +64024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -63508,7 +64033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -63517,7 +64042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -63526,39 +64051,12 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
       "norm_label": "calendar.test.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 997,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_card_tsx",
-      "label": "card.tsx",
-      "norm_label": "card.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
-      "label": "collapsible.tsx",
-      "norm_label": "collapsible.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1359
-- Graph nodes: 3295
-- Graph edges: 2825
-- Communities: 1275
+- Code files discovered: 1366
+- Graph nodes: 3317
+- Graph edges: 2850
+- Communities: 1282
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 28) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 199) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 202) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 28) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 28) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 28) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -12,7 +12,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 43 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 5 file(s); key children: OnlineOrderContext.tsx, PermissionsContext.tsx, ProductContext.tsx, ThemeContext.tsx, UserContext.tsx.
-- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 35 file(s); key children: aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts, countries.ts.
+- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 42 file(s); key children: aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts, countries.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 3 file(s); key children: formatNumber.ts, index.ts, versionChecker.ts.
 
 ## Backend and test surfaces

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -86,6 +86,8 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/hooks/useBulkOperations.test.ts`](../../src/hooks/useBulkOperations.test.ts)
 - [`src/lib/imageUtils.test.ts`](../../src/lib/imageUtils.test.ts)
 - [`src/lib/pos/displayAmounts.test.ts`](../../src/lib/pos/displayAmounts.test.ts)
+- [`src/lib/pos/domain/cart.test.ts`](../../src/lib/pos/domain/cart.test.ts)
+- [`src/lib/pos/domain/session.test.ts`](../../src/lib/pos/domain/session.test.ts)
 - [`src/lib/productUtils.test.ts`](../../src/lib/productUtils.test.ts)
 - [`src/lib/storeConfig.test.ts`](../../src/lib/storeConfig.test.ts)
 - [`src/lib/utils.test.ts`](../../src/lib/utils.test.ts)

--- a/packages/athena-webapp/src/components/pos/types.ts
+++ b/packages/athena-webapp/src/components/pos/types.ts
@@ -1,24 +1,9 @@
 import { Id } from "../../../convex/_generated/dataModel";
-
-export interface CartItem {
-  id:
-    | Id<"posSessionItem">
-    | Id<"posTransactionItem">
-    | Id<"expenseSessionItem">
-    | Id<"expenseTransactionItem">; // Database ID is the single source of truth
-  name: string;
-  barcode: string;
-  sku?: string;
-  price: number;
-  quantity: number;
-  image?: string | null;
-  size?: string;
-  length?: number | null;
-  color?: string;
-  productId?: Id<"product">; // Product ID for backend operations
-  skuId?: Id<"productSku">; // Product SKU ID for backend operations
-  areProcessingFeesAbsorbed?: boolean;
-}
+export type {
+  PosCartLineInput as CartItem,
+  PosPayment as Payment,
+  PosPaymentState as PaymentState,
+} from "@/lib/pos/domain";
 
 export interface CustomerInfo {
   customerId?: Id<"posCustomer">; // Added to link to POS customer database
@@ -133,16 +118,3 @@ export const CATEGORIES = [
   "Dairy",
   "Snacks",
 ];
-
-export type Payment = {
-  id: string;
-  method: "cash" | "card" | "mobile_money";
-  amount: number;
-  timestamp: number;
-};
-
-export type PaymentState = {
-  payments: Payment[];
-  totalPaid: number;
-  remainingDue: number;
-};

--- a/packages/athena-webapp/src/lib/pos/domain/cart.test.ts
+++ b/packages/athena-webapp/src/lib/pos/domain/cart.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculatePosCartTotals,
+  calculatePosChange,
+  calculatePosRemainingDue,
+  type PosCartLineId,
+  calculatePosTotalPaid,
+  isPosPaymentSufficient,
+} from "./index";
+
+describe("calculatePosCartTotals", () => {
+  it("matches the legacy register subtotal rounding behavior", () => {
+    const totals = calculatePosCartTotals([
+      {
+        id: "line-1" as PosCartLineId,
+        name: "Shirt",
+        barcode: "111111111111",
+        price: 12.4,
+        quantity: 2,
+      },
+      {
+        id: "line-2" as PosCartLineId,
+        name: "Cap",
+        barcode: "222222222222",
+        price: 5.255,
+        quantity: 1,
+      },
+    ]);
+
+    expect(totals).toEqual({
+      subtotal: 30.05,
+      tax: 0,
+      total: 30.05,
+    });
+  });
+});
+
+describe("payment helpers", () => {
+  it("returns change due when payment exceeds total", () => {
+    expect(calculatePosChange(40, 30.05)).toBe(9.95);
+  });
+
+  it("calculates total paid and remaining due from payment state", () => {
+    const totalPaid = calculatePosTotalPaid([
+      {
+        id: "payment-1",
+        method: "cash",
+        amount: 10,
+        timestamp: 1,
+      },
+      {
+        id: "payment-2",
+        method: "card",
+        amount: 12.5,
+        timestamp: 2,
+      },
+    ]);
+
+    expect(totalPaid).toBe(22.5);
+    expect(calculatePosRemainingDue(totalPaid, 30.06)).toBe(7.56);
+    expect(isPosPaymentSufficient(totalPaid, 30.06)).toBe(false);
+  });
+});

--- a/packages/athena-webapp/src/lib/pos/domain/cart.ts
+++ b/packages/athena-webapp/src/lib/pos/domain/cart.ts
@@ -1,0 +1,42 @@
+import type { PosCartLineInput, PosMoneyTotals } from "./types";
+
+export function calculatePosCartTotals(
+  items: PosCartLineInput[],
+  taxRate: number = 0,
+): PosMoneyTotals {
+  if (!items.length) {
+    return {
+      subtotal: 0,
+      tax: 0,
+      total: 0,
+    };
+  }
+
+  const subtotal = items.reduce(
+    (sum, item) => sum + getPosEffectivePrice(item.price, item.areProcessingFeesAbsorbed) * item.quantity,
+    0,
+  );
+  const tax = subtotal * taxRate;
+  const total = subtotal + tax;
+
+  return {
+    subtotal: roundPosAmount(subtotal),
+    tax: roundPosAmount(tax),
+    total: roundPosAmount(total),
+  };
+}
+
+export function calculatePosItemTotal(price: number, quantity: number): number {
+  return roundPosAmount(price * quantity);
+}
+
+export function getPosEffectivePrice(
+  price: number,
+  _areProcessingFeesAbsorbed?: boolean,
+): number {
+  return price;
+}
+
+function roundPosAmount(amount: number): number {
+  return Number(amount.toFixed(2));
+}

--- a/packages/athena-webapp/src/lib/pos/domain/index.ts
+++ b/packages/athena-webapp/src/lib/pos/domain/index.ts
@@ -1,0 +1,32 @@
+export type {
+  PosCartLineId,
+  PosCartLineInput,
+  PosMoneyTotals,
+  PosPayment,
+  PosPaymentMethod,
+  PosPaymentState,
+  PosRegisterPhase,
+  PosRegisterPhaseInput,
+} from "./types";
+
+export {
+  calculatePosCartTotals,
+  calculatePosItemTotal,
+  getPosEffectivePrice,
+} from "./cart";
+
+export {
+  calculatePosChange,
+  calculatePosRemainingDue,
+  calculatePosTotalPaid,
+  isPosPaymentSufficient,
+} from "./payments";
+
+export {
+  deriveRegisterPhase,
+  hasActiveRegisterSession,
+  hasResumableRegisterSession,
+  isRegisterReadyToStart,
+  requiresCashier,
+  requiresTerminal,
+} from "./session";

--- a/packages/athena-webapp/src/lib/pos/domain/payments.ts
+++ b/packages/athena-webapp/src/lib/pos/domain/payments.ts
@@ -1,0 +1,29 @@
+import type { PosPayment } from "./types";
+
+export function calculatePosChange(amountPaid: number, total: number): number {
+  return roundPosAmount(amountPaid - total);
+}
+
+export function isPosPaymentSufficient(
+  amountPaid: number,
+  total: number,
+): boolean {
+  return amountPaid >= total;
+}
+
+export function calculatePosTotalPaid(payments: PosPayment[]): number {
+  return roundPosAmount(
+    payments.reduce((sum, payment) => sum + payment.amount, 0),
+  );
+}
+
+export function calculatePosRemainingDue(
+  amountPaid: number,
+  total: number,
+): number {
+  return roundPosAmount(Math.max(0, total - amountPaid));
+}
+
+function roundPosAmount(amount: number): number {
+  return Number(amount.toFixed(2));
+}

--- a/packages/athena-webapp/src/lib/pos/domain/session.test.ts
+++ b/packages/athena-webapp/src/lib/pos/domain/session.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveRegisterPhase,
+  hasActiveRegisterSession,
+  hasResumableRegisterSession,
+  isRegisterReadyToStart,
+  requiresCashier,
+  requiresTerminal,
+} from "./index";
+
+describe("deriveRegisterPhase", () => {
+  it("prefers an active session when one exists", () => {
+    expect(
+      deriveRegisterPhase({
+        hasTerminal: true,
+        hasCashier: true,
+        activeSessionId: "session-1",
+        resumableSessionId: "session-2",
+      }),
+    ).toBe("active");
+  });
+
+  it("returns readyToStart when prerequisites are met but no session exists", () => {
+    expect(
+      deriveRegisterPhase({
+        hasTerminal: true,
+        hasCashier: true,
+        activeSessionId: null,
+        resumableSessionId: null,
+      }),
+    ).toBe("readyToStart");
+  });
+});
+
+describe("phase selectors", () => {
+  it("surfaces missing terminal and cashier prerequisites", () => {
+    expect(
+      requiresTerminal({
+        hasTerminal: false,
+        hasCashier: false,
+        activeSessionId: null,
+        resumableSessionId: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      requiresCashier({
+        hasTerminal: true,
+        hasCashier: false,
+        activeSessionId: null,
+        resumableSessionId: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("detects active and resumable register states", () => {
+    expect(
+      hasActiveRegisterSession({
+        hasTerminal: true,
+        hasCashier: true,
+        activeSessionId: "session-1",
+        resumableSessionId: "session-2",
+      }),
+    ).toBe(true);
+
+    expect(
+      hasResumableRegisterSession({
+        hasTerminal: true,
+        hasCashier: true,
+        activeSessionId: null,
+        resumableSessionId: "session-2",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects when the register is ready to start a new session", () => {
+    expect(
+      isRegisterReadyToStart({
+        hasTerminal: true,
+        hasCashier: true,
+        activeSessionId: null,
+        resumableSessionId: null,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/athena-webapp/src/lib/pos/domain/session.ts
+++ b/packages/athena-webapp/src/lib/pos/domain/session.ts
@@ -1,0 +1,47 @@
+import type { PosRegisterPhase, PosRegisterPhaseInput } from "./types";
+
+export function deriveRegisterPhase(
+  input: PosRegisterPhaseInput,
+): PosRegisterPhase {
+  if (!input.hasTerminal) {
+    return "requiresTerminal";
+  }
+
+  if (!input.hasCashier) {
+    return "requiresCashier";
+  }
+
+  if (input.activeSessionId) {
+    return "active";
+  }
+
+  if (input.resumableSessionId) {
+    return "resumable";
+  }
+
+  return "readyToStart";
+}
+
+export function requiresTerminal(input: PosRegisterPhaseInput): boolean {
+  return deriveRegisterPhase(input) === "requiresTerminal";
+}
+
+export function requiresCashier(input: PosRegisterPhaseInput): boolean {
+  return deriveRegisterPhase(input) === "requiresCashier";
+}
+
+export function hasActiveRegisterSession(
+  input: PosRegisterPhaseInput,
+): boolean {
+  return deriveRegisterPhase(input) === "active";
+}
+
+export function hasResumableRegisterSession(
+  input: PosRegisterPhaseInput,
+): boolean {
+  return deriveRegisterPhase(input) === "resumable";
+}
+
+export function isRegisterReadyToStart(input: PosRegisterPhaseInput): boolean {
+  return deriveRegisterPhase(input) === "readyToStart";
+}

--- a/packages/athena-webapp/src/lib/pos/domain/types.ts
+++ b/packages/athena-webapp/src/lib/pos/domain/types.ts
@@ -1,0 +1,58 @@
+import type { Id } from "../../../../convex/_generated/dataModel";
+
+export type PosRegisterPhase =
+  | "requiresTerminal"
+  | "requiresCashier"
+  | "active"
+  | "resumable"
+  | "readyToStart";
+
+export type PosCartLineId =
+  | Id<"posSessionItem">
+  | Id<"posTransactionItem">
+  | Id<"expenseSessionItem">
+  | Id<"expenseTransactionItem">;
+
+export interface PosCartLineInput {
+  id: PosCartLineId;
+  name: string;
+  barcode: string;
+  sku?: string;
+  price: number;
+  quantity: number;
+  image?: string | null;
+  size?: string;
+  length?: number | null;
+  color?: string;
+  productId?: Id<"product">;
+  skuId?: Id<"productSku">;
+  areProcessingFeesAbsorbed?: boolean;
+}
+
+export interface PosMoneyTotals {
+  subtotal: number;
+  tax: number;
+  total: number;
+}
+
+export type PosPaymentMethod = "cash" | "card" | "mobile_money";
+
+export interface PosPayment {
+  id: string;
+  method: PosPaymentMethod;
+  amount: number;
+  timestamp: number;
+}
+
+export interface PosPaymentState {
+  payments: PosPayment[];
+  totalPaid: number;
+  remainingDue: number;
+}
+
+export interface PosRegisterPhaseInput {
+  hasTerminal: boolean;
+  hasCashier: boolean;
+  activeSessionId: string | null;
+  resumableSessionId: string | null;
+}

--- a/packages/athena-webapp/src/lib/pos/services/calculationService.ts
+++ b/packages/athena-webapp/src/lib/pos/services/calculationService.ts
@@ -1,22 +1,20 @@
 /**
  * Calculation Service
  *
- * Handles all POS cart calculations including totals, tax, and pricing.
- * Extracted from posStore for better separation of concerns.
+ * Legacy compatibility surface over the extracted POS browser domain helpers.
  */
 
-export interface CartItem {
-  id: string;
-  price: number;
-  quantity: number;
-  areProcessingFeesAbsorbed?: boolean;
-}
+import {
+  calculatePosCartTotals,
+  calculatePosChange,
+  calculatePosItemTotal,
+  getPosEffectivePrice,
+  isPosPaymentSufficient,
+} from "../domain";
+import type { PosCartLineInput, PosMoneyTotals } from "../domain";
 
-export interface CartTotals {
-  subtotal: number;
-  tax: number;
-  total: number;
-}
+export type CartItem = PosCartLineInput;
+export type CartTotals = PosMoneyTotals;
 
 /**
  * Tax rate for calculations (default 10%)
@@ -28,45 +26,21 @@ const TAX_RATE = 0.0;
  * Calculates cart totals including subtotal, tax, and total
  */
 export function calculateCartTotals(items: CartItem[]): CartTotals {
-  if (!items || items.length === 0) {
-    return {
-      subtotal: 0,
-      tax: 0,
-      total: 0,
-    };
-  }
-
-  // Calculate subtotal (sum of price * quantity for all items)
-  const subtotal = items.reduce(
-    (sum, item) => sum + item.price * item.quantity,
-    0
-  );
-
-  // Calculate tax on subtotal
-  const tax = subtotal * TAX_RATE;
-
-  // Calculate total
-  const total = subtotal + tax;
-
-  return {
-    subtotal: Number(subtotal.toFixed(2)),
-    tax: Number(tax.toFixed(2)),
-    total: Number(total.toFixed(2)),
-  };
+  return calculatePosCartTotals(items ?? [], TAX_RATE);
 }
 
 /**
  * Calculates total for a single item
  */
 export function calculateItemTotal(price: number, quantity: number): number {
-  return Number((price * quantity).toFixed(2));
+  return calculatePosItemTotal(price, quantity);
 }
 
 /**
  * Calculates change to give customer
  */
 export function calculateChange(amountPaid: number, total: number): number {
-  return Number((amountPaid - total).toFixed(2));
+  return calculatePosChange(amountPaid, total);
 }
 
 /**
@@ -86,7 +60,7 @@ export function isPaymentSufficient(
   amountPaid: number,
   total: number
 ): boolean {
-  return amountPaid >= total;
+  return isPosPaymentSufficient(amountPaid, total);
 }
 
 /**
@@ -97,7 +71,5 @@ export function getEffectivePrice(
   price: number,
   areProcessingFeesAbsorbed?: boolean
 ): number {
-  // If processing fees are absorbed, we don't modify the price
-  // This is here for future expansion if needed
-  return price;
+  return getPosEffectivePrice(price, areProcessingFeesAbsorbed);
 }


### PR DESCRIPTION
## Summary
- add a shared browser POS domain module for cart, payment, and register-phase helpers
- cover the extracted domain with focused cart and register-phase tests
- route the legacy POS type and calculation compatibility surfaces through the new domain layer

## Why
This is the first slice of the layered POS refactor. It extracts pure browser-side POS rules into a reusable domain surface while preserving the existing register and expense UI behavior.

## Validation
- bun run --filter '@athena/webapp' test -- src/lib/pos/domain/cart.test.ts src/lib/pos/domain/session.test.ts\n- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json\n- bun run --filter '@athena/webapp' lint:architecture\n- bun run --filter '@athena/webapp' test\n\nLinear: https://linear.app/v26-labs/issue/V26-300/lay-browser-pos-domain-foundation-for-the-layered-register