### PR TITLE
[docs] prefer convex dev over codegen

### DIFF
--- a/packages/athena-webapp/AGENTS.md
+++ b/packages/athena-webapp/AGENTS.md
@@ -5,3 +5,4 @@
 - Read [docs/agent/architecture.md](./docs/agent/architecture.md) before changing router, auth-shell, or Convex boundaries.
 - Use [docs/agent/testing.md](./docs/agent/testing.md) to choose the smallest honest validation set.
 - Use [docs/agent/code-map.md](./docs/agent/code-map.md) when tracing ownership across `src/` and `convex/`.
+- When generated Convex client artifacts need to refresh, start `bunx convex dev` from `packages/athena-webapp`. Do not use `bunx convex codegen` in this repo's normal agent flow because local workspaces may not have `CONVEX_DEPLOYMENT` configured.

--- a/packages/athena-webapp/docs/agent/index.md
+++ b/packages/athena-webapp/docs/agent/index.md
@@ -27,3 +27,8 @@ Common validation commands:
 - `bun run --filter '@athena/webapp' lint:convex:changed`
 - `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
 - `bun run --filter '@athena/webapp' build`
+
+Generated Convex client note:
+
+- If you need refreshed `convex/_generated` artifacts or new client refs, start `bunx convex dev` from `packages/athena-webapp`.
+- Do not default to `bunx convex codegen`; in this repo it can fail in local workspaces that do not have `CONVEX_DEPLOYMENT` configured.

--- a/packages/athena-webapp/docs/agent/testing.md
+++ b/packages/athena-webapp/docs/agent/testing.md
@@ -31,6 +31,11 @@ Current shared scenarios include:
 - `storefront-checkout-validation-blocker`
 - `storefront-checkout-verification-recovery`
 
+Convex artifact refresh rule:
+
+- If a change needs new `convex/_generated` artifacts or refreshed client refs, start `bunx convex dev` from `packages/athena-webapp` before validation.
+- Do not substitute `bunx convex codegen` for this workflow; local agent worktrees may not have `CONVEX_DEPLOYMENT` configured, and `convex dev` is the documented artifact-refresh path in this repo.
+
 Start with the package suite in [vitest.config.ts](../../vitest.config.ts): `bun run --filter '@athena/webapp' test`. It covers both `src/**/*.test.{ts,tsx}` and `convex/**/*.test.{ts,tsx}`, so it is the default regression pass for mixed UI and backend changes.
 
 Escalate validation based on the surface you touched:


### PR DESCRIPTION
## Summary
- add an explicit Athena agent rule to use `bunx convex dev` when Convex client artifacts need to refresh
- document in the Athena agent docs index that `bunx convex codegen` should not be the default local workflow
- add the same guidance to the Athena testing guide where generated Convex refs are already discussed

## Why
Agents were still vulnerable to reaching for `bunx convex codegen` in local workspaces, even though the tracked docs already preferred `bunx convex dev` in some validation flows. Making the rule explicit in the entrypoint docs prevents avoidable failures when `CONVEX_DEPLOYMENT` is not configured locally.

## Validation
- `bun run harness:check`
- `bun run harness:review`
- repo pre-push review suite
