### PR TITLE
[V26-307]: Handle procurement auth/session failures before stock-ops queries crash the workspace

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -16931,7 +16931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L78",
+      "source_location": "L79",
       "target": "procurementview_formatoptionaldate",
       "weight": 1
     },
@@ -16943,7 +16943,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L118",
+      "source_location": "L119",
       "target": "procurementview_getfilteremptystatecopy",
       "weight": 1
     },
@@ -16955,7 +16955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L89",
+      "source_location": "L90",
       "target": "procurementview_getrecommendationstatuscopy",
       "weight": 1
     },
@@ -45451,7 +45451,7 @@
       "label": "formatOptionalDate()",
       "norm_label": "formatoptionaldate()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L78"
+      "source_location": "L79"
     },
     {
       "community": 195,
@@ -45460,7 +45460,7 @@
       "label": "getFilterEmptyStateCopy()",
       "norm_label": "getfilteremptystatecopy()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L118"
+      "source_location": "L119"
     },
     {
       "community": 195,
@@ -45469,7 +45469,7 @@
       "label": "getRecommendationStatusCopy()",
       "norm_label": "getrecommendationstatuscopy()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L89"
+      "source_location": "L90"
     },
     {
       "community": 196,

--- a/packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx
+++ b/packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx
@@ -1,7 +1,30 @@
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "~/convex/_generated/dataModel";
-import { ProcurementViewContent } from "./ProcurementView";
+import {
+  ProcurementView,
+  ProcurementViewContent,
+} from "./ProcurementView";
+
+const mockedHooks = vi.hoisted(() => ({
+  useConvexAuth: vi.fn(),
+  useGetActiveStore: vi.fn(),
+  usePermissions: vi.fn(),
+  useQuery: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: mockedHooks.useConvexAuth,
+  useQuery: mockedHooks.useQuery,
+}));
+
+vi.mock("@/hooks/useGetActiveStore", () => ({
+  default: mockedHooks.useGetActiveStore,
+}));
+
+vi.mock("@/hooks/usePermissions", () => ({
+  usePermissions: mockedHooks.usePermissions,
+}));
 
 const baseProps: React.ComponentProps<typeof ProcurementViewContent> = {
   activeVendorCount: 3,
@@ -75,7 +98,20 @@ const baseProps: React.ComponentProps<typeof ProcurementViewContent> = {
 
 describe("ProcurementViewContent", () => {
   beforeEach(() => {
-    window.scrollTo = () => {};
+    window.scrollTo = vi.fn();
+    vi.clearAllMocks();
+    mockedHooks.useConvexAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    });
+    mockedHooks.useGetActiveStore.mockReturnValue({
+      activeStore: { _id: "store-1" as Id<"store"> },
+    });
+    mockedHooks.usePermissions.mockReturnValue({
+      canAccessOperations: () => true,
+      isLoading: false,
+    });
+    mockedHooks.useQuery.mockReset();
   });
 
   it("renders the denied state for users without procurement access", () => {
@@ -143,5 +179,61 @@ describe("ProcurementViewContent", () => {
     expect(
       screen.getByText(/review the purchase-order workspace to inspect the remaining 1/i)
     ).toBeInTheDocument();
+  });
+
+  it("skips protected procurement queries while Convex auth is still loading", () => {
+    mockedHooks.useConvexAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: true,
+    });
+    mockedHooks.useQuery.mockReturnValue(undefined);
+
+    render(<ProcurementView />);
+
+    expect(screen.getByText("Loading procurement workspace...")).toBeInTheDocument();
+    expect(mockedHooks.useQuery.mock.calls.map(([, args]) => args)).toEqual([
+      "skip",
+      "skip",
+      "skip",
+    ]);
+  });
+
+  it("renders a sign-in fallback instead of subscribing when Convex auth is missing", () => {
+    mockedHooks.useConvexAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+    mockedHooks.useQuery.mockReturnValue(undefined);
+
+    render(<ProcurementView />);
+
+    expect(screen.getByText("Sign in required")).toBeInTheDocument();
+    expect(
+      screen.getByText(/your athena session needs to reconnect before procurement planning can load protected stock operations data/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /sign in again/i })).toHaveAttribute(
+      "href",
+      "/login"
+    );
+    expect(mockedHooks.useQuery.mock.calls.map(([, args]) => args)).toEqual([
+      "skip",
+      "skip",
+      "skip",
+    ]);
+  });
+
+  it("subscribes to protected procurement queries once auth and permissions are ready", () => {
+    mockedHooks.useQuery
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([]);
+
+    render(<ProcurementView />);
+
+    expect(mockedHooks.useQuery.mock.calls.map(([, args]) => args)).toEqual([
+      { storeId: "store-1" },
+      { storeId: "store-1" },
+      { status: "active", storeId: "store-1" },
+    ]);
   });
 });

--- a/packages/athena-webapp/src/components/procurement/ProcurementView.tsx
+++ b/packages/athena-webapp/src/components/procurement/ProcurementView.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import View from "../View";
 import { FadeIn } from "../common/FadeIn";
 import { EmptyState } from "../states/empty/empty-state";
 import { NoPermissionView } from "../states/no-permission/NoPermissionView";
+import { Button } from "../ui/button";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { usePermissions } from "@/hooks/usePermissions";
 import { api } from "~/convex/_generated/api";
@@ -504,10 +505,16 @@ export function ProcurementViewContent({
 
 export function ProcurementView() {
   const { activeStore } = useGetActiveStore();
+  const { isAuthenticated, isLoading: isLoadingAuth } = useConvexAuth();
   const { canAccessOperations, isLoading } = usePermissions();
   const hasFullAdminAccess = canAccessOperations();
+  const canQueryProtectedProcurement =
+    activeStore?._id &&
+    hasFullAdminAccess &&
+    isAuthenticated &&
+    !isLoadingAuth;
   const procurementQueryArgs =
-    activeStore?._id && hasFullAdminAccess
+    canQueryProtectedProcurement
       ? { storeId: activeStore._id }
       : "skip";
   const recommendations = useQuery(
@@ -520,20 +527,49 @@ export function ProcurementView() {
   ) as ProcurementOrderSummary[] | undefined;
   const vendors = useQuery(
     api.stockOps.vendors.listVendors,
-    activeStore?._id && hasFullAdminAccess
+    canQueryProtectedProcurement
       ? { status: "active", storeId: activeStore._id }
       : "skip"
   ) as Array<{ _id: Id<"vendor"> }> | undefined;
+
+  if (isLoading || isLoadingAuth) {
+    return (
+      <View>
+        <div className="container mx-auto py-10 text-sm text-muted-foreground">
+          Loading procurement workspace...
+        </div>
+      </View>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <View>
+        <div className="container mx-auto py-8">
+          <EmptyState
+            cta={
+              <Button asChild className="mt-4" variant="outline">
+                <a href="/login">Sign in again</a>
+              </Button>
+            }
+            description="Your Athena session needs to reconnect before procurement planning can load protected stock operations data."
+            title="Sign in required"
+          />
+        </div>
+      </View>
+    );
+  }
 
   return (
     <ProcurementViewContent
       activeVendorCount={vendors?.length ?? 0}
       hasActiveStore={Boolean(activeStore)}
       hasFullAdminAccess={hasFullAdminAccess}
-      isLoadingPermissions={isLoading}
+      isLoadingPermissions={false}
       isLoadingProcurement={Boolean(
         activeStore &&
           hasFullAdminAccess &&
+          isAuthenticated &&
           (recommendations === undefined ||
             purchaseOrders === undefined ||
             vendors === undefined)


### PR DESCRIPTION
## Summary
- gate protected procurement stock-ops subscriptions on Convex auth readiness before the workspace subscribes
- render a deliberate sign-in-required fallback with a direct login recovery action instead of the raw server error page
- add procurement regression coverage for auth-loading skip behavior, signed-out fallback behavior, and the normal authenticated subscription path

## Why
The procurement workspace was trusting the locally cached Athena user and permission state before the Convex auth session had finished authenticating. That let stock-ops queries subscribe while `ctx.auth.getUserIdentity()` was still empty, which surfaced the raw `Authentication required.` server error when operators entered procurement.

This keeps the fix scoped to the user-reported procurement entry failure and tracks the broader authenticated-shell cleanup separately in `V26-308`.

## Validation
- `bun run --filter '@athena/webapp' test src/components/procurement/ProcurementView.test.tsx`
- `bun run --filter '@athena/webapp' test convex/stockOps/access.test.ts convex/stockOps/adjustments.test.ts convex/stockOps/purchaseOrders.test.ts convex/stockOps/receiving.test.ts convex/stockOps/replenishment.test.ts convex/stockOps/vendors.test.ts src/components/operations/StockAdjustmentWorkspace.test.tsx src/components/operations/OperationsQueueView.test.tsx src/components/procurement/ProcurementView.test.tsx src/components/procurement/ReceivingView.test.tsx`
- `bun run --filter '@athena/webapp' test`
- `bun run --filter '@athena/webapp' audit:convex`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run harness:review --base origin/main`
- `bun run graphify:rebuild`
- `bun run graphify:check`
- `git diff --check`

https://linear.app/v26-labs/issue/V26-307/handle-procurement-authsession-failures-before-stock-ops-queries-crash
