### PR TITLE
[V26-311]: Add workflow trace IDs and shared Convex schema registration

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1418 files · ~0 words
+- 1425 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3487 nodes · 2989 edges · 1333 communities detected
+- 3497 nodes · 2993 edges · 1340 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1343,6 +1343,13 @@
 - [[_COMMUNITY_Community 1330|Community 1330]]
 - [[_COMMUNITY_Community 1331|Community 1331]]
 - [[_COMMUNITY_Community 1332|Community 1332]]
+- [[_COMMUNITY_Community 1333|Community 1333]]
+- [[_COMMUNITY_Community 1334|Community 1334]]
+- [[_COMMUNITY_Community 1335|Community 1335]]
+- [[_COMMUNITY_Community 1336|Community 1336]]
+- [[_COMMUNITY_Community 1337|Community 1337]]
+- [[_COMMUNITY_Community 1338|Community 1338]]
+- [[_COMMUNITY_Community 1339|Community 1339]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1495,20 +1502,20 @@ Cohesion: 0.24
 Nodes (6): createApp(), createHandlers(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern()
 
 ### Community 31 - "Community 31"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 32 - "Community 32"
 Cohesion: 0.36
 Nodes (9): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), resolveStockAdjustmentApprovalDecisionWithCtx(), submitStockAdjustmentBatchWithCtx() (+1 more)
 
-### Community 33 - "Community 33"
+### Community 32 - "Community 32"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 34 - "Community 34"
+### Community 33 - "Community 33"
 Cohesion: 0.18
 Nodes (0):
+
+### Community 34 - "Community 34"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 35 - "Community 35"
 Cohesion: 0.18
@@ -2351,12 +2358,12 @@ Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 245 - "Community 245"
-Cohesion: 0.67
-Nodes (1): View()
+Cohesion: 1.0
+Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
 ### Community 246 - "Community 246"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.67
@@ -2371,16 +2378,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 250 - "Community 250"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 251 - "Community 251"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 252 - "Community 252"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 253 - "Community 253"
 Cohesion: 0.67
@@ -2388,11 +2395,11 @@ Nodes (0):
 
 ### Community 254 - "Community 254"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 255 - "Community 255"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 256 - "Community 256"
 Cohesion: 0.67
@@ -2400,11 +2407,11 @@ Nodes (0):
 
 ### Community 257 - "Community 257"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 258 - "Community 258"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 259 - "Community 259"
 Cohesion: 0.67
@@ -2452,75 +2459,75 @@ Nodes (0):
 
 ### Community 270 - "Community 270"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 271 - "Community 271"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 272 - "Community 272"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 273 - "Community 273"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 274 - "Community 274"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 275 - "Community 275"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 277 - "Community 277"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 278 - "Community 278"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (0):
 
 ### Community 279 - "Community 279"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): AppContextMenu()
 
 ### Community 280 - "Community 280"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): Badge()
 
 ### Community 281 - "Community 281"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 282 - "Community 282"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 283 - "Community 283"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 284 - "Community 284"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 285 - "Community 285"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 286 - "Community 286"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 287 - "Community 287"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 288 - "Community 288"
 Cohesion: 0.67
@@ -2548,11 +2555,11 @@ Nodes (0):
 
 ### Community 294 - "Community 294"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 295 - "Community 295"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 296 - "Community 296"
 Cohesion: 0.67
@@ -2564,11 +2571,11 @@ Nodes (0):
 
 ### Community 298 - "Community 298"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 299 - "Community 299"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 300 - "Community 300"
 Cohesion: 0.67
@@ -2576,59 +2583,59 @@ Nodes (0):
 
 ### Community 301 - "Community 301"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 302 - "Community 302"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 303 - "Community 303"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 304 - "Community 304"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 305 - "Community 305"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 306 - "Community 306"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 306 - "Community 306"
+### Community 307 - "Community 307"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 307 - "Community 307"
+### Community 308 - "Community 308"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.67
 Nodes (1): manualChunks()
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 312 - "Community 312"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 313 - "Community 313"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 314 - "Community 314"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 315 - "Community 315"
 Cohesion: 0.67
@@ -2639,12 +2646,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 317 - "Community 317"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 318 - "Community 318"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 318 - "Community 318"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 319 - "Community 319"
 Cohesion: 0.67
@@ -2655,12 +2662,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 321 - "Community 321"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 322 - "Community 322"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 322 - "Community 322"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 323 - "Community 323"
 Cohesion: 0.67
@@ -2739,16 +2746,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 342 - "Community 342"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 343 - "Community 343"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 344 - "Community 344"
+### Community 343 - "Community 343"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 344 - "Community 344"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 345 - "Community 345"
 Cohesion: 1.0
@@ -2763,20 +2770,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 348 - "Community 348"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 349 - "Community 349"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 350 - "Community 350"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 351 - "Community 351"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 352 - "Community 352"
 Cohesion: 1.0
@@ -6702,1226 +6709,1252 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1333 - "Community 1333"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1334 - "Community 1334"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1335 - "Community 1335"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1336 - "Community 1336"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1337 - "Community 1337"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1338 - "Community 1338"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1339 - "Community 1339"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 351`** (2 nodes): `getSource()`, `closeouts.test.ts`
+- **Thin community `Community 352`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 352`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 353`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 354`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 355`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 356`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 357`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 358`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 359`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (2 nodes): `authenticateHandler()`, `cashier.ts`
+- **Thin community `Community 360`** (2 nodes): `authenticateHandler()`, `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 361`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 362`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 363`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 364`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 365`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 366`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 367`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 368`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 369`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 370`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
+- **Thin community `Community 371`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 372`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 373`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 374`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 375`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 376`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 377`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 378`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 379`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 380`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `receiving.test.ts`, `getSource()`
+- **Thin community `Community 381`** (2 nodes): `receiving.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 382`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 383`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 384`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 385`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 386`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 387`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 388`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 389`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 390`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 391`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 392`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 393`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 394`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 395`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 396`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 397`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 398`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 399`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 400`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 401`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 402`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 403`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 404`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 405`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 406`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 407`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 408`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 409`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 410`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 411`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 412`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 413`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 414`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 415`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 416`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 417`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 418`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 419`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 420`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 421`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 422`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 423`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 424`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 425`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 426`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 427`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 428`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 429`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 430`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 431`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 432`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 433`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 434`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 435`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 436`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 437`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 438`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 439`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 440`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 441`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 442`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 443`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 444`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 445`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
+- **Thin community `Community 446`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 447`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 448`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 449`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 450`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 451`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `CashierView()`, `CashierView.tsx`
+- **Thin community `Community 452`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 453`** (2 nodes): `CashierView()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 454`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 455`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 456`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 457`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 458`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 459`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 460`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 461`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 462`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 463`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 464`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 465`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 466`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 467`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 468`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 469`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 470`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 471`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 472`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 473`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 474`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 475`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 476`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 477`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 478`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 479`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 480`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 481`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 482`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
+- **Thin community `Community 483`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 484`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 485`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 486`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 487`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 488`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 489`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 490`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 491`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 492`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 493`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 494`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 495`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 496`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 497`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 498`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
+- **Thin community `Community 499`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 500`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 501`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 502`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 503`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 504`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 505`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 506`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 507`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 508`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 509`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 510`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 511`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 512`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 513`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 514`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 515`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 516`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 517`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 518`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 519`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 520`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 521`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 522`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 523`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 524`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 525`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 526`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 527`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 528`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 529`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 530`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 531`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 532`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 533`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 534`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 535`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 536`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 537`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 538`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 539`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 540`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 541`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 542`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 543`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 544`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 545`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 546`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 547`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 548`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 549`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 550`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 551`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 552`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
+- **Thin community `Community 553`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 554`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 555`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 556`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 557`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 558`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 559`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 560`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 561`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 562`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 563`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 564`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 565`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 566`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 567`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 568`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 569`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 570`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 571`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 572`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 573`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 574`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 575`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 576`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 577`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 578`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 579`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 580`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 581`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 582`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 583`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 584`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 585`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 586`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 587`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 588`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 589`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 590`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 591`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 592`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 593`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 594`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 595`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 596`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 597`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 598`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 599`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 600`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 601`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 602`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 603`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 604`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 605`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 606`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 607`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 608`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 609`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 610`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 611`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 612`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 613`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 614`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 615`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 616`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 617`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 618`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 619`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 620`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 621`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 622`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 623`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 624`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 625`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 626`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 627`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 628`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 629`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 630`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 631`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 632`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 633`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 634`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 635`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 636`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 637`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 638`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 639`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 640`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 641`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 642`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 643`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 644`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 645`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 646`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 647`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 648`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 649`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 650`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 651`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 652`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 653`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 654`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 655`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 656`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 657`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 658`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 659`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 660`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 661`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 662`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 663`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 664`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 665`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 666`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 667`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 668`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 669`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 670`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 671`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 672`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 673`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 674`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 675`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 676`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 677`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 678`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 679`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 680`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 681`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 682`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 683`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 684`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 685`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 686`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 687`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 688`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 689`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `api.d.ts`
+- **Thin community `Community 690`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `api.js`
+- **Thin community `Community 691`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 692`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `server.d.ts`
+- **Thin community `Community 693`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `server.js`
+- **Thin community `Community 694`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `app.ts`
+- **Thin community `Community 695`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `auth.config.js`
+- **Thin community `Community 696`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `auth.ts`
+- **Thin community `Community 697`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 698`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `countries.ts`
+- **Thin community `Community 699`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `email.ts`
+- **Thin community `Community 700`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `ghana.ts`
+- **Thin community `Community 701`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `payment.ts`
+- **Thin community `Community 702`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `crons.ts`
+- **Thin community `Community 703`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 704`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 705`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 706`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 707`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `env.ts`
+- **Thin community `Community 708`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `analytics.ts`
+- **Thin community `Community 709`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `auth.ts`
+- **Thin community `Community 710`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 711`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `categories.ts`
+- **Thin community `Community 712`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `colors.ts`
+- **Thin community `Community 713`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `index.ts`
+- **Thin community `Community 714`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `organizations.ts`
+- **Thin community `Community 715`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `products.ts`
+- **Thin community `Community 716`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `stores.ts`
+- **Thin community `Community 717`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 718`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `index.ts`
+- **Thin community `Community 719`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `bag.ts`
+- **Thin community `Community 720`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `guest.ts`
+- **Thin community `Community 721`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `index.ts`
+- **Thin community `Community 722`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `me.ts`
+- **Thin community `Community 723`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `offers.ts`
+- **Thin community `Community 724`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 725`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `paystack.ts`
+- **Thin community `Community 726`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `reviews.ts`
+- **Thin community `Community 727`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `rewards.ts`
+- **Thin community `Community 728`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 729`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `security.test.ts`
+- **Thin community `Community 730`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `storefront.ts`
+- **Thin community `Community 731`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `upsells.ts`
+- **Thin community `Community 732`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `user.ts`
+- **Thin community `Community 733`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 734`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `health.test.ts`
+- **Thin community `Community 735`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `http.ts`
+- **Thin community `Community 736`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 737`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `auth.ts`
+- **Thin community `Community 738`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 739`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 740`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `categories.ts`
+- **Thin community `Community 741`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `colors.ts`
+- **Thin community `Community 742`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 743`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 744`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 745`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 746`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 747`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 748`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `organizations.ts`
+- **Thin community `Community 749`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `pos.ts`
+- **Thin community `Community 750`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 751`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 752`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 753`** (1 nodes): `posSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `productSku.ts`
+- **Thin community `Community 754`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 755`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 756`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 757`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 758`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 759`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 760`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 761`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 762`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 763`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `client.test.ts`
+- **Thin community `Community 764`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `config.test.ts`
+- **Thin community `Community 765`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 766`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `types.ts`
+- **Thin community `Community 767`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 768`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 769`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 770`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `staffProfiles.test.ts`
+- **Thin community `Community 771`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 772`** (1 nodes): `staffProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `completeTransaction.test.ts`
+- **Thin community `Community 773`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `dto.ts`
+- **Thin community `Community 774`** (1 nodes): `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 775`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `types.ts`
+- **Thin community `Community 776`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 777`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `catalog.ts`
+- **Thin community `Community 778`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `customers.ts`
+- **Thin community `Community 779`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `register.ts`
+- **Thin community `Community 780`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `terminals.ts`
+- **Thin community `Community 781`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `transactions.ts`
+- **Thin community `Community 782`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `schema.ts`
+- **Thin community `Community 783`** (1 nodes): `transactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 784`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 785`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 786`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 787`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `cashier.ts`
+- **Thin community `Community 788`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `category.ts`
+- **Thin community `Community 789`** (1 nodes): `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `color.ts`
+- **Thin community `Community 790`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 791`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 792`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `index.ts`
+- **Thin community `Community 793`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 794`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `organization.ts`
+- **Thin community `Community 795`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 796`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `product.ts`
+- **Thin community `Community 797`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 798`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 799`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `store.ts`
+- **Thin community `Community 800`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 801`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `approvalRequest.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 802`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 803`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 804`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 805`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 806`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 807`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 808`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 809`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 810`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 811`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `customer.ts`
+- **Thin community `Community 812`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 813`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 814`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 815`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 816`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `index.ts`
+- **Thin community `Community 817`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `posSession.ts`
+- **Thin community `Community 818`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 819`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 820`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 821`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 822`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 823`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 824`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 825`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 826`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 827`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 828`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 829`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 830`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 831`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 832`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 833`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `vendor.ts`
+- **Thin community `Community 834`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `analytics.ts`
+- **Thin community `Community 835`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `bag.ts`
+- **Thin community `Community 836`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 837`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 838`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 839`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `customer.ts`
+- **Thin community `Community 840`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `guest.ts`
+- **Thin community `Community 841`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `index.ts`
+- **Thin community `Community 842`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `offer.ts`
+- **Thin community `Community 843`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 844`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 845`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `review.ts`
+- **Thin community `Community 846`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `rewards.ts`
+- **Thin community `Community 847`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 848`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 849`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 850`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 851`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 852`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 853`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 854`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `bag.ts`
+- **Thin community `Community 855`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 856`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `customer.ts`
+- **Thin community `Community 857`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `guest.ts`
+- **Thin community `Community 858`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 859`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 860`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `payment.ts`
+- **Thin community `Community 861`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 862`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 863`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 864`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `users.ts`
+- **Thin community `Community 865`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `payment.ts`
+- **Thin community `Community 866`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 867`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `index.ts`
+- **Thin community `Community 868`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 869`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `auth.ts`
+- **Thin community `Community 870`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 871`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 872`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 873`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 874`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 875`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 876`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `constants.ts`
+- **Thin community `Community 877`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 878`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 879`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 880`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `types.ts`
+- **Thin community `Community 881`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 882`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 883`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 884`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 885`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 886`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 887`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 888`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 889`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `columns.tsx`
+- **Thin community `Community 890`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 891`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 892`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 893`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 894`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `columns.tsx`
+- **Thin community `Community 895`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 896`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 897`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `chart.tsx`
+- **Thin community `Community 898`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `columns.tsx`
+- **Thin community `Community 899`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 900`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 901`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `columns.tsx`
+- **Thin community `Community 902`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `constants.ts`
+- **Thin community `Community 903`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 904`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 905`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 906`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `data.ts`
+- **Thin community `Community 907`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 908`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 909`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 910`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `columns.tsx`
+- **Thin community `Community 911`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 912`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 913`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 914`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 915`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 916`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 917`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 918`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `constants.ts`
+- **Thin community `Community 919`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 920`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 921`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 922`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `data.ts`
+- **Thin community `Community 923`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 924`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 925`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 926`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 927`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `columns.tsx`
+- **Thin community `Community 928`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 929`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 930`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 931`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 932`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 933`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 934`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `constants.ts`
+- **Thin community `Community 935`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 936`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 937`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 938`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 939`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 940`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `RegisterCloseoutView.test.tsx`
+- **Thin community `Community 941`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 942`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `index.tsx`
+- **Thin community `Community 943`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `columns.tsx`
+- **Thin community `Community 944`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 945`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 946`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 947`** (1 nodes): `RegisterCloseoutView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 948`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 949`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 950`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 951`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 952`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 953`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 954`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `constants.ts`
+- **Thin community `Community 955`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 956`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 957`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 958`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `data.ts`
+- **Thin community `Community 959`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 960`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 961`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -7929,743 +7962,757 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 963`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 964`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 965`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `data.ts`
+- **Thin community `Community 966`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 967`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `constants.ts`
+- **Thin community `Community 968`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 969`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 970`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 971`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 972`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `data.ts`
+- **Thin community `Community 973`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 974`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 975`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 976`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 977`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 978`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 979`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 980`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 981`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 982`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 983`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 984`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 985`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 986`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 987`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 988`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 989`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 990`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `types.ts`
+- **Thin community `Community 991`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 992`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 993`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 994`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 995`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 996`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 997`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 998`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 999`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1000`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1001`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1002`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1003`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1004`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1005`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1006`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1007`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1008`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1009`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1010`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `data.ts`
+- **Thin community `Community 1011`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1012`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `PromoCodePreview.tsx`
+- **Thin community `Community 1013`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1014`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1015`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1016`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1017`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1018`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1019`** (1 nodes): `PromoCodePreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1020`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1021`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1022`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1023`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `constants.ts`
+- **Thin community `Community 1024`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1025`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1026`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1027`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `data.ts`
+- **Thin community `Community 1028`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `types.ts`
+- **Thin community `Community 1029`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1030`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1031`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1032`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1033`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `ServiceAppointmentsView.test.tsx`
+- **Thin community `Community 1034`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `ServiceCasesView.test.tsx`
+- **Thin community `Community 1035`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `ServiceCatalogView.test.tsx`
+- **Thin community `Community 1036`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `ServiceIntakeView.test.tsx`
+- **Thin community `Community 1037`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1038`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `index.tsx`
+- **Thin community `Community 1039`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1040`** (1 nodes): `ServiceAppointmentsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1041`** (1 nodes): `ServiceCasesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `button.tsx`
+- **Thin community `Community 1042`** (1 nodes): `ServiceCatalogView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1043`** (1 nodes): `ServiceIntakeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `card.tsx`
+- **Thin community `Community 1044`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1045`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1046`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `command.tsx`
+- **Thin community `Community 1047`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1048`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1049`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1050`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `form.tsx`
+- **Thin community `Community 1051`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1052`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1053`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `input.tsx`
+- **Thin community `Community 1054`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1055`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1056`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1057`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1058`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1059`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `select.tsx`
+- **Thin community `Community 1060`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1061`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1062`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1063`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `table.tsx`
+- **Thin community `Community 1064`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1065`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1066`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1067`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1068`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1069`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1070`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1071`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1072`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `constants.ts`
+- **Thin community `Community 1073`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1074`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1075`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1076`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `data.ts`
+- **Thin community `Community 1077`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1078`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1079`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1080`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1081`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1082`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1083`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1084`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1085`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1086`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1087`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1088`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1089`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1090`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `index.ts`
+- **Thin community `Community 1091`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `config.ts`
+- **Thin community `Community 1092`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1093`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1094`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1095`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `aws.ts`
+- **Thin community `Community 1096`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `constants.ts`
+- **Thin community `Community 1097`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `countries.ts`
+- **Thin community `Community 1098`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1099`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1100`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `bootstrapRegister.test.ts`
+- **Thin community `Community 1101`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `dto.ts`
+- **Thin community `Community 1102`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `ports.ts`
+- **Thin community `Community 1103`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `constants.ts`
+- **Thin community `Community 1104`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1105`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1106`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `index.ts`
+- **Thin community `Community 1107`** (1 nodes): `bootstrapRegister.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1108`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `types.ts`
+- **Thin community `Community 1109`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1110`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1111`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1112`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `useRegisterViewModel.test.ts`
+- **Thin community `Community 1113`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1114`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `category.ts`
+- **Thin community `Community 1115`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `product.ts`
+- **Thin community `Community 1116`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `store.ts`
+- **Thin community `Community 1117`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1118`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `user.ts`
+- **Thin community `Community 1119`** (1 nodes): `useRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1120`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1121`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1122`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1123`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `index.tsx`
+- **Thin community `Community 1124`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `index.tsx`
+- **Thin community `Community 1125`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `index.tsx`
+- **Thin community `Community 1126`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1127`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1128`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1129`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1130`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1131`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1132`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1133`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1134`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1135`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `home.tsx`
+- **Thin community `Community 1136`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1137`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1138`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1139`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `index.tsx`
+- **Thin community `Community 1140`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `index.tsx`
+- **Thin community `Community 1141`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1142`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1143`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1144`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `index.tsx`
+- **Thin community `Community 1145`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1146`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1147`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1148`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1149`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1150`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1151`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1152`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `index.tsx`
+- **Thin community `Community 1153`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1154`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1155`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1156`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1157`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1158`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1159`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1160`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `index.tsx`
+- **Thin community `Community 1161`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `new.tsx`
+- **Thin community `Community 1162`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `index.tsx`
+- **Thin community `Community 1163`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `new.tsx`
+- **Thin community `Community 1164`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1165`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1166`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1167`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `new.tsx`
+- **Thin community `Community 1168`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `index.tsx`
+- **Thin community `Community 1169`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1170`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1171`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1172`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1173`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1174`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1175`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1176`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1177`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1178`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1179`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1180`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1181`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1182`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1183`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1184`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1185`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1186`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1187`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1188`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1189`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1190`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1191`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1192`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1193`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `setup.ts`
+- **Thin community `Community 1194`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1195`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1196`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `types.ts`
+- **Thin community `Community 1197`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1198`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1199`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1200`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1201`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1202`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1203`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1204`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1205`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1206`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1207`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1208`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1209`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1210`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1211`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1212`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1213`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `schema.ts`
+- **Thin community `Community 1214`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1215`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1216`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1217`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1218`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1219`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1220`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1221`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1222`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1223`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `types.ts`
+- **Thin community `Community 1224`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1225`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1226`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1227`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1228`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1229`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1230`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1231`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `constants.ts`
+- **Thin community `Community 1232`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1233`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `About.tsx`
+- **Thin community `Community 1234`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1235`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1236`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1237`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1238`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1239`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1240`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1241`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1242`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1243`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `types.ts`
+- **Thin community `Community 1244`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1245`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1246`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1247`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1248`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1249`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1250`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1251`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1252`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1253`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1254`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `button.tsx`
+- **Thin community `Community 1255`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `card.tsx`
+- **Thin community `Community 1256`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1257`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `command.tsx`
+- **Thin community `Community 1258`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1259`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1260`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1261`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `form.tsx`
+- **Thin community `Community 1262`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1263`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1264`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1265`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1266`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `input.tsx`
+- **Thin community `Community 1267`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `label.tsx`
+- **Thin community `Community 1268`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1269`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1270`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1271`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `index.ts`
+- **Thin community `Community 1272`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `types.ts`
+- **Thin community `Community 1273`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1274`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1275`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1276`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1277`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `select.tsx`
+- **Thin community `Community 1278`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1279`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1280`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `table.tsx`
+- **Thin community `Community 1281`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1282`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1283`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1284`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1285`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1286`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `config.ts`
+- **Thin community `Community 1287`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1288`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1289`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1290`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `constants.ts`
+- **Thin community `Community 1291`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `countries.ts`
+- **Thin community `Community 1292`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1293`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1294`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1295`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1296`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `index.ts`
+- **Thin community `Community 1297`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `store.ts`
+- **Thin community `Community 1298`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `bag.ts`
+- **Thin community `Community 1299`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1300`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `category.ts`
+- **Thin community `Community 1301`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `organization.ts`
+- **Thin community `Community 1302`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `product.ts`
+- **Thin community `Community 1303`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `store.ts`
+- **Thin community `Community 1304`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1305`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `user.ts`
+- **Thin community `Community 1306`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `states.ts`
+- **Thin community `Community 1307`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1308`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1310`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1311`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1312`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1313`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1314`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `index.tsx`
+- **Thin community `Community 1315`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1316`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `index.tsx`
+- **Thin community `Community 1317`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1318`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1319`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1320`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1321`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1322`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `index.tsx`
+- **Thin community `Community 1323`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1324`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1325`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1326`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1327`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `index.js`
+- **Thin community `Community 1328`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1329`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1330`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1331`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1332`** (1 nodes): `tailwind.config.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1333`** (1 nodes): `vitest.config.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1334`** (1 nodes): `vitest.setup.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1335`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1336`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1337`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1338`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1339`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -12916,6 +12916,18 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
+      "_tgt": "schemaindexes_test_gettableindexes",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
+      "source_location": "L5",
+      "target": "schemaindexes_test_gettableindexes",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_shared_serviceintake_ts",
       "_tgt": "serviceintake_validateserviceintakeinput",
       "confidence": "EXTRACTED",
@@ -12985,6 +12997,30 @@
       "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
       "source_location": "L76",
       "target": "stockadjustment_summarizestockadjustmentlineitems",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_shared_workflowtrace_ts",
+      "_tgt": "workflowtrace_createworkflowtraceid",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_shared_workflowtrace_ts",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L35",
+      "target": "workflowtrace_createworkflowtraceid",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_shared_workflowtrace_ts",
+      "_tgt": "workflowtrace_normalizeworkflowtracelookupvalue",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_shared_workflowtrace_ts",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L25",
+      "target": "workflowtrace_normalizeworkflowtracelookupvalue",
       "weight": 1
     },
     {
@@ -35870,6 +35906,18 @@
       "source_location": "L80",
       "target": "valkey_runtime_app_shutdown",
       "weight": 1
+    },
+    {
+      "_src": "workflowtrace_createworkflowtraceid",
+      "_tgt": "workflowtrace_normalizeworkflowtracelookupvalue",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "workflowtrace_normalizeworkflowtracelookupvalue",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L45",
+      "target": "workflowtrace_createworkflowtraceid",
+      "weight": 1
     }
   ],
   "multigraph": false,
@@ -36948,6 +36996,60 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
+      "label": "AnalyticsInsights.tsx",
+      "norm_label": "analyticsinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
+      "label": "AttributesView.tsx",
+      "norm_label": "attributesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
+      "label": "DetailsView.tsx",
+      "norm_label": "detailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1003,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
+      "label": "ProductDetailView.tsx",
+      "norm_label": "productdetailview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1004,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
+      "label": "ProductStatus.tsx",
+      "norm_label": "productstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1005,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
+      "label": "CategoryListView.tsx",
+      "norm_label": "categorylistview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1006,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
       "norm_label": "productsubcategorytogglegroup.tsx",
@@ -36955,7 +37057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -36964,7 +37066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -36973,66 +37075,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
       "norm_label": "unresolvedproducts.tsx",
       "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1004,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
-      "label": "ComplimentaryProducts.tsx",
-      "norm_label": "complimentaryproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1005,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
-      "label": "complimentaryProductsColumn.tsx",
-      "norm_label": "complimentaryproductscolumn.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1006,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1007,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1008,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -37092,6 +37140,60 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
+      "label": "ComplimentaryProducts.tsx",
+      "norm_label": "complimentaryproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
+      "label": "complimentaryProductsColumn.tsx",
+      "norm_label": "complimentaryproductscolumn.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1012,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1013,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1014,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1015,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1016,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -37099,7 +37201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -37108,7 +37210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -37117,66 +37219,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
       "norm_label": "promocodepreview.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodePreview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1014,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
-      "label": "PromoCodes.tsx",
-      "norm_label": "promocodes.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodes.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1015,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
-      "label": "PromoCodeAnalytics.tsx",
-      "norm_label": "promocodeanalytics.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/analytics/PromoCodeAnalytics.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1016,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
-      "label": "captured-emails-columns.tsx",
-      "norm_label": "captured-emails-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1017,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1018,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -37236,6 +37284,60 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
+      "label": "PromoCodes.tsx",
+      "norm_label": "promocodes.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
+      "label": "PromoCodeAnalytics.tsx",
+      "norm_label": "promocodeanalytics.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/analytics/PromoCodeAnalytics.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1022,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
+      "label": "captured-emails-columns.tsx",
+      "norm_label": "captured-emails-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1023,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1024,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1025,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1026,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -37243,7 +37345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -37252,7 +37354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -37261,66 +37363,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1024,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1025,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1026,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1027,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1028,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/types.ts",
       "source_location": "L1"
     },
     {
@@ -37380,6 +37428,60 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1032,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1033,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1034,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1035,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1036,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
       "norm_label": "welcome-offer-card.tsx",
@@ -37387,7 +37489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -37396,7 +37498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -37405,66 +37507,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
       "norm_label": "reviewmetadata.tsx",
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1034,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
-      "label": "ServiceAppointmentsView.test.tsx",
-      "norm_label": "serviceappointmentsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1035,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
-      "label": "ServiceCasesView.test.tsx",
-      "norm_label": "servicecasesview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1036,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
-      "label": "ServiceCatalogView.test.tsx",
-      "norm_label": "servicecatalogview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1037,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
-      "label": "ServiceIntakeView.test.tsx",
-      "norm_label": "serviceintakeview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1038,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
-      "label": "MtnMomoView.test.tsx",
-      "norm_label": "mtnmomoview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
       "source_location": "L1"
     },
     {
@@ -37524,6 +37572,60 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
+      "label": "ServiceAppointmentsView.test.tsx",
+      "norm_label": "serviceappointmentsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
+      "label": "ServiceCasesView.test.tsx",
+      "norm_label": "servicecasesview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1042,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
+      "label": "ServiceCatalogView.test.tsx",
+      "norm_label": "servicecatalogview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1043,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
+      "label": "ServiceIntakeView.test.tsx",
+      "norm_label": "serviceintakeview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1044,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
+      "label": "MtnMomoView.test.tsx",
+      "norm_label": "mtnmomoview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1045,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1046,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
       "norm_label": "accordion.tsx",
@@ -37531,7 +37633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -37540,7 +37642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -37549,66 +37651,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
       "norm_label": "calendar.test.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1044,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_card_tsx",
-      "label": "card.tsx",
-      "norm_label": "card.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1045,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1046,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
-      "label": "collapsible.tsx",
-      "norm_label": "collapsible.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1047,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_command_tsx",
-      "label": "command.tsx",
-      "norm_label": "command.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/command.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1048,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
-      "label": "context-menu.tsx",
-      "norm_label": "context-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1"
     },
     {
@@ -37668,6 +37716,60 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_card_tsx",
+      "label": "card.tsx",
+      "norm_label": "card.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1052,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
+      "label": "collapsible.tsx",
+      "norm_label": "collapsible.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1053,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_command_tsx",
+      "label": "command.tsx",
+      "norm_label": "command.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1054,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
+      "label": "context-menu.tsx",
+      "norm_label": "context-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1055,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1056,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
       "norm_label": "dropdown-menu.tsx",
@@ -37675,7 +37777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -37684,7 +37786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -37693,66 +37795,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
       "norm_label": "input-otp.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1054,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1055,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
-      "label": "action-modal.tsx",
-      "norm_label": "action-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1056,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_popover_tsx",
-      "label": "popover.tsx",
-      "norm_label": "popover.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1057,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
-      "label": "primitives.test.tsx",
-      "norm_label": "primitives.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1058,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
-      "label": "radio-group.tsx",
-      "norm_label": "radio-group.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1"
     },
     {
@@ -37812,6 +37860,60 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
+      "label": "action-modal.tsx",
+      "norm_label": "action-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1062,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_popover_tsx",
+      "label": "popover.tsx",
+      "norm_label": "popover.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1063,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
+      "label": "primitives.test.tsx",
+      "norm_label": "primitives.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1064,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
+      "label": "radio-group.tsx",
+      "norm_label": "radio-group.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1065,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1066,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
       "norm_label": "select.tsx",
@@ -37819,7 +37921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -37828,7 +37930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -37837,66 +37939,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
       "norm_label": "switch.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1064,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_table_tsx",
-      "label": "table.tsx",
-      "norm_label": "table.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1065,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
-      "label": "tabs.tsx",
-      "norm_label": "tabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1066,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
-      "label": "textarea.tsx",
-      "norm_label": "textarea.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1067,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1068,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
-      "label": "toggle.tsx",
-      "norm_label": "toggle.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
       "source_location": "L1"
     },
     {
@@ -37956,6 +38004,60 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_table_tsx",
+      "label": "table.tsx",
+      "norm_label": "table.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
+      "label": "tabs.tsx",
+      "norm_label": "tabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1072,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
+      "label": "textarea.tsx",
+      "norm_label": "textarea.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1073,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1074,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
+      "label": "toggle.tsx",
+      "norm_label": "toggle.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1075,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1076,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
       "norm_label": "upload-button.tsx",
@@ -37963,7 +38065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -37972,7 +38074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -37981,66 +38083,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1074,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1075,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1076,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1077,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1078,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
-      "label": "bag-columns.tsx",
-      "norm_label": "bag-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
-      "label": "bags-table.tsx",
-      "norm_label": "bags-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1"
     },
     {
@@ -38100,6 +38148,60 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1082,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1083,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1084,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
+      "label": "bag-columns.tsx",
+      "norm_label": "bag-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1085,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
+      "label": "bags-table.tsx",
+      "norm_label": "bags-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1086,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -38107,7 +38209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -38116,7 +38218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -38125,66 +38227,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1084,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1085,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1086,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
-      "label": "LinkedAccounts.tsx",
-      "norm_label": "linkedaccounts.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1087,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
-      "label": "TimelineEventCard.test.tsx",
-      "norm_label": "timelineeventcard.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1088,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
-      "label": "UserCheckoutSession.tsx",
-      "norm_label": "usercheckoutsession.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
-      "label": "UserInsightsSection.tsx",
-      "norm_label": "userinsightssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
       "source_location": "L1"
     },
     {
@@ -38244,6 +38292,60 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1092,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
+      "label": "LinkedAccounts.tsx",
+      "norm_label": "linkedaccounts.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1093,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
+      "label": "TimelineEventCard.test.tsx",
+      "norm_label": "timelineeventcard.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1094,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
+      "label": "UserCheckoutSession.tsx",
+      "norm_label": "usercheckoutsession.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1095,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
+      "label": "UserInsightsSection.tsx",
+      "norm_label": "userinsightssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1096,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
       "norm_label": "userbehaviorinsights.tsx",
@@ -38251,7 +38353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -38260,7 +38362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -38269,66 +38371,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
       "norm_label": "themecontext.tsx",
       "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1094,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1095,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1096,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_aws_ts",
-      "label": "aws.ts",
-      "norm_label": "aws.ts",
-      "source_file": "packages/athena-webapp/src/lib/aws.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1097,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1098,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/src/lib/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
       "source_location": "L1"
     },
     {
@@ -38568,6 +38616,60 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1102,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_aws_ts",
+      "label": "aws.ts",
+      "norm_label": "aws.ts",
+      "source_file": "packages/athena-webapp/src/lib/aws.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1103,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1104,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/src/lib/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1105,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1106,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
       "norm_label": "ghanaregions.ts",
@@ -38575,7 +38677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
       "label": "bootstrapRegister.test.ts",
@@ -38584,7 +38686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
@@ -38593,66 +38695,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
       "norm_label": "ports.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1104,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1105,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
-      "label": "displayAmounts.test.ts",
-      "norm_label": "displayamounts.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1106,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
-      "label": "cart.test.ts",
-      "norm_label": "cart.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1107,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1108,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
-      "label": "session.test.ts",
-      "norm_label": "session.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
       "source_location": "L1"
     },
     {
@@ -38712,6 +38760,60 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
+      "label": "displayAmounts.test.ts",
+      "norm_label": "displayamounts.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1112,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
+      "label": "cart.test.ts",
+      "norm_label": "cart.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1113,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1114,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
+      "label": "session.test.ts",
+      "norm_label": "session.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1115,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1116,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
       "norm_label": "registergateway.test.ts",
@@ -38719,7 +38821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
@@ -38728,7 +38830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
@@ -38737,66 +38839,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
       "label": "useRegisterViewModel.test.ts",
       "norm_label": "useregisterviewmodel.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1114,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
-      "label": "productUtils.test.ts",
-      "norm_label": "productutils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1115,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1116,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1117,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1118,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
       "source_location": "L1"
     },
     {
@@ -38856,6 +38904,60 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
+      "label": "productUtils.test.ts",
+      "norm_label": "productutils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1123,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1124,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1125,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1126,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
       "norm_label": "storeconfig.test.ts",
@@ -38863,7 +38965,16 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1127,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
+      "label": "createWorkflowTraceId.test.ts",
+      "norm_label": "createworkflowtraceid.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -38872,75 +38983,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
       "norm_label": "routetree.gen.ts",
       "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1123,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_root_tsx",
-      "label": "__root.tsx",
-      "norm_label": "__root.tsx",
-      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1124,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1125,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1126,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
-      "label": "$storeUrlSlug.tsx",
-      "norm_label": "$storeurlslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
-      "label": "analytics.tsx",
-      "norm_label": "analytics.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
-      "label": "assets.index.tsx",
-      "norm_label": "assets.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
       "source_location": "L1"
     },
     {
@@ -39000,6 +39048,69 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_root_tsx",
+      "label": "__root.tsx",
+      "norm_label": "__root.tsx",
+      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1132,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1133,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1134,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
+      "label": "$storeUrlSlug.tsx",
+      "norm_label": "$storeurlslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1135,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
+      "label": "analytics.tsx",
+      "norm_label": "analytics.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1136,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
+      "label": "assets.index.tsx",
+      "norm_label": "assets.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1137,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
       "norm_label": "bags.$bagid.tsx",
@@ -39007,7 +39118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -39016,75 +39127,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1133,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
-      "label": "checkout-sessions.index.tsx",
-      "norm_label": "checkout-sessions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1134,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
-      "label": "configuration.index.tsx",
-      "norm_label": "configuration.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1135,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
-      "label": "dashboard.index.tsx",
-      "norm_label": "dashboard.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1136,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
-      "label": "home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1137,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
-      "label": "logs.$logId.tsx",
-      "norm_label": "logs.$logid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1138,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
-      "label": "logs.index.tsx",
-      "norm_label": "logs.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
-      "label": "members.index.tsx",
-      "norm_label": "members.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
       "source_location": "L1"
     },
     {
@@ -39144,6 +39192,69 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
+      "label": "checkout-sessions.index.tsx",
+      "norm_label": "checkout-sessions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
+      "label": "configuration.index.tsx",
+      "norm_label": "configuration.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1142,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
+      "label": "dashboard.index.tsx",
+      "norm_label": "dashboard.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1143,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
+      "label": "home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1144,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
+      "label": "logs.$logId.tsx",
+      "norm_label": "logs.$logid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1145,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
+      "label": "logs.index.tsx",
+      "norm_label": "logs.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1146,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
+      "label": "members.index.tsx",
+      "norm_label": "members.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1147,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -39151,7 +39262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -39160,75 +39271,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
       "norm_label": "all.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1143,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
-      "label": "cancelled.index.tsx",
-      "norm_label": "cancelled.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1144,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
-      "label": "completed.index.tsx",
-      "norm_label": "completed.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1145,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1146,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
-      "label": "open.index.tsx",
-      "norm_label": "open.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1147,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
-      "label": "out-for-delivery.index.tsx",
-      "norm_label": "out-for-delivery.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1148,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
-      "label": "ready.index.tsx",
-      "norm_label": "ready.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
-      "label": "refunded.index.tsx",
-      "norm_label": "refunded.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
       "source_location": "L1"
     },
     {
@@ -39288,6 +39336,69 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
+      "label": "cancelled.index.tsx",
+      "norm_label": "cancelled.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
+      "label": "completed.index.tsx",
+      "norm_label": "completed.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1152,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1153,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
+      "label": "open.index.tsx",
+      "norm_label": "open.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1154,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
+      "label": "out-for-delivery.index.tsx",
+      "norm_label": "out-for-delivery.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1155,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
+      "label": "ready.index.tsx",
+      "norm_label": "ready.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1156,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
+      "label": "refunded.index.tsx",
+      "norm_label": "refunded.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1157,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
       "norm_label": "$reportid.tsx",
@@ -39295,7 +39406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -39304,75 +39415,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
       "norm_label": "expense.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1153,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1154,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
-      "label": "register.index.tsx",
-      "norm_label": "register.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1155,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
-      "label": "settings.index.tsx",
-      "norm_label": "settings.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1156,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
-      "label": "$transactionId.tsx",
-      "norm_label": "$transactionid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1157,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
-      "label": "transactions.index.tsx",
-      "norm_label": "transactions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
-      "label": "procurement.index.tsx",
-      "norm_label": "procurement.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
-      "label": "edit.tsx",
-      "norm_label": "edit.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
       "source_location": "L1"
     },
     {
@@ -39432,6 +39480,69 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
+      "label": "register.index.tsx",
+      "norm_label": "register.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1162,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
+      "label": "settings.index.tsx",
+      "norm_label": "settings.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1163,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
+      "label": "$transactionId.tsx",
+      "norm_label": "$transactionid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1164,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
+      "label": "transactions.index.tsx",
+      "norm_label": "transactions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1165,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
+      "label": "procurement.index.tsx",
+      "norm_label": "procurement.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1166,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
+      "label": "edit.tsx",
+      "norm_label": "edit.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1167,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -39439,7 +39550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -39448,75 +39559,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1163,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1164,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1165,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
-      "label": "unresolved.tsx",
-      "norm_label": "unresolved.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1166,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
-      "label": "$promoCodeSlug.tsx",
-      "norm_label": "$promocodeslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1167,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1168,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
       "source_location": "L1"
     },
     {
@@ -39576,6 +39624,69 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1172,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
+      "label": "unresolved.tsx",
+      "norm_label": "unresolved.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1173,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
+      "label": "$promoCodeSlug.tsx",
+      "norm_label": "$promocodeslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1174,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1175,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1176,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1177,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
       "norm_label": "new.index.tsx",
@@ -39583,7 +39694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -39592,75 +39703,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
       "norm_label": "appointments.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/appointments.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1173,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
-      "label": "catalog-management.index.tsx",
-      "norm_label": "catalog-management.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1174,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
-      "label": "intake.index.tsx",
-      "norm_label": "intake.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1175,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
-      "label": "users.$userId.tsx",
-      "norm_label": "users.$userid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1176,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1177,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
-      "label": "join-team.index.tsx",
-      "norm_label": "join-team.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1178,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
-      "label": "_layout.index.test.tsx",
-      "norm_label": "_layout.index.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
-      "label": "_layout.test.tsx",
-      "norm_label": "_layout.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.test.tsx",
       "source_location": "L1"
     },
     {
@@ -39720,6 +39768,69 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
+      "label": "catalog-management.index.tsx",
+      "norm_label": "catalog-management.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
+      "label": "intake.index.tsx",
+      "norm_label": "intake.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1182,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
+      "label": "users.$userId.tsx",
+      "norm_label": "users.$userid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1183,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1184,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
+      "label": "join-team.index.tsx",
+      "norm_label": "join-team.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1185,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
+      "label": "_layout.index.test.tsx",
+      "norm_label": "_layout.index.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1186,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
+      "label": "_layout.test.tsx",
+      "norm_label": "_layout.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1187,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
       "norm_label": "storessettingsaccordion.tsx",
@@ -39727,7 +39838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -39736,75 +39847,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
       "norm_label": "overview.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1183,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
-      "label": "foundations-content.test.tsx",
-      "norm_label": "foundations-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1184,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
-      "label": "Introduction.stories.tsx",
-      "norm_label": "introduction.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1185,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
-      "label": "introduction-content.test.tsx",
-      "norm_label": "introduction-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1186,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
-      "label": "introduction-content.tsx",
-      "norm_label": "introduction-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1187,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
-      "label": "AdminShell.stories.tsx",
-      "norm_label": "adminshell.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
-      "label": "admin-shell-patterns.test.tsx",
-      "norm_label": "admin-shell-patterns.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
-      "label": "Surfaces.stories.tsx",
-      "norm_label": "surfaces.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -39864,6 +39912,69 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
+      "label": "foundations-content.test.tsx",
+      "norm_label": "foundations-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
+      "label": "Introduction.stories.tsx",
+      "norm_label": "introduction.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1192,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
+      "label": "introduction-content.test.tsx",
+      "norm_label": "introduction-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1193,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
+      "label": "introduction-content.tsx",
+      "norm_label": "introduction-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1194,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
+      "label": "AdminShell.stories.tsx",
+      "norm_label": "adminshell.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1195,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
+      "label": "admin-shell-patterns.test.tsx",
+      "norm_label": "admin-shell-patterns.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1196,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
+      "label": "Surfaces.stories.tsx",
+      "norm_label": "surfaces.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1197,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
       "norm_label": "dashboardworkspace.stories.tsx",
@@ -39871,7 +39982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -39880,75 +39991,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
       "norm_label": "settingsworkspace.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1193,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
-      "label": "reference-fixtures.test.tsx",
-      "norm_label": "reference-fixtures.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1194,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_test_setup_ts",
-      "label": "setup.ts",
-      "norm_label": "setup.ts",
-      "source_file": "packages/athena-webapp/src/test/setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1195,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
-      "label": "usePrint.test.ts",
-      "norm_label": "useprint.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1196,
-      "file_type": "code",
-      "id": "packages_athena_webapp_tailwind_config_js",
-      "label": "tailwind.config.js",
-      "norm_label": "tailwind.config.js",
-      "source_file": "packages/athena-webapp/tailwind.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1197,
-      "file_type": "code",
-      "id": "packages_athena_webapp_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/athena-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
       "source_location": "L1"
     },
     {
@@ -40170,6 +40218,69 @@
     {
       "community": 1200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
+      "label": "reference-fixtures.test.tsx",
+      "norm_label": "reference-fixtures.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_test_setup_ts",
+      "label": "setup.ts",
+      "norm_label": "setup.ts",
+      "source_file": "packages/athena-webapp/src/test/setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1202,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
+      "label": "usePrint.test.ts",
+      "norm_label": "useprint.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1203,
+      "file_type": "code",
+      "id": "packages_athena_webapp_tailwind_config_js",
+      "label": "tailwind.config.js",
+      "norm_label": "tailwind.config.js",
+      "source_file": "packages/athena-webapp/tailwind.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1204,
+      "file_type": "code",
+      "id": "packages_athena_webapp_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1205,
+      "file_type": "code",
+      "id": "packages_athena_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/athena-webapp/vitest.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1206,
+      "file_type": "code",
+      "id": "packages_athena_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1207,
+      "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
       "norm_label": "eslint.config.js",
@@ -40177,7 +40288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -40186,75 +40297,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
       "norm_label": "playwright.config.ts",
       "source_file": "packages/storefront-webapp/playwright.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1203,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
-      "label": "analytics.test.ts",
-      "norm_label": "analytics.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1204,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/api/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1205,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
-      "label": "HeartIconFilled.tsx",
-      "norm_label": "hearticonfilled.tsx",
-      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1206,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
-      "label": "DefaultCatchBoundary.tsx",
-      "norm_label": "defaultcatchboundary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1207,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
-      "label": "HomePage.test.tsx",
-      "norm_label": "homepage.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1208,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
-      "label": "ProductCard.test.tsx",
-      "norm_label": "productcard.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_tsx",
-      "label": "ProductCard.tsx",
-      "norm_label": "productcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
       "source_location": "L1"
     },
     {
@@ -40314,6 +40362,69 @@
     {
       "community": 1210,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
+      "label": "analytics.test.ts",
+      "norm_label": "analytics.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1211,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/api/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1212,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
+      "label": "HeartIconFilled.tsx",
+      "norm_label": "hearticonfilled.tsx",
+      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1213,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
+      "label": "DefaultCatchBoundary.tsx",
+      "norm_label": "defaultcatchboundary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1214,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
+      "label": "HomePage.test.tsx",
+      "norm_label": "homepage.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1215,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
+      "label": "ProductCard.test.tsx",
+      "norm_label": "productcard.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1216,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productcard_tsx",
+      "label": "ProductCard.tsx",
+      "norm_label": "productcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1217,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
       "norm_label": "upsell.tsx",
@@ -40321,7 +40432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -40330,75 +40441,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
       "norm_label": "checkout.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1213,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
-      "label": "CustomerInfoSection.tsx",
-      "norm_label": "customerinfosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1214,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
-      "label": "schema.ts",
-      "norm_label": "schema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1215,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
-      "label": "DeliveryDetailsSection.tsx",
-      "norm_label": "deliverydetailssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1216,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
-      "label": "checkoutStorage.test.ts",
-      "norm_label": "checkoutstorage.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1217,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
-      "label": "deliveryFees.test.ts",
-      "norm_label": "deliveryfees.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1218,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
-      "label": "deriveCheckoutState.test.ts",
-      "norm_label": "derivecheckoutstate.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
-      "label": "billingDetailsSchema.ts",
-      "norm_label": "billingdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
       "source_location": "L1"
     },
     {
@@ -40449,6 +40497,69 @@
     {
       "community": 1220,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
+      "label": "CustomerInfoSection.tsx",
+      "norm_label": "customerinfosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
+      "label": "schema.ts",
+      "norm_label": "schema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1222,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
+      "label": "DeliveryDetailsSection.tsx",
+      "norm_label": "deliverydetailssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1223,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
+      "label": "checkoutStorage.test.ts",
+      "norm_label": "checkoutstorage.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1224,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
+      "label": "deliveryFees.test.ts",
+      "norm_label": "deliveryfees.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1225,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
+      "label": "deriveCheckoutState.test.ts",
+      "norm_label": "derivecheckoutstate.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1226,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
+      "label": "billingDetailsSchema.ts",
+      "norm_label": "billingdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1227,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
       "norm_label": "checkoutformschema.ts",
@@ -40456,7 +40567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -40465,75 +40576,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
       "norm_label": "deliverydetailsschema.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1223,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
-      "label": "webOrderSchema.ts",
-      "norm_label": "weborderschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1224,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1225,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1226,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
-      "label": "ProductFilterBar.tsx",
-      "norm_label": "productfilterbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1227,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
-      "label": "BestSellersSection.test.tsx",
-      "norm_label": "bestsellerssection.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1228,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
-      "label": "HomeHero.tsx",
-      "norm_label": "homehero.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
-      "label": "HomeHeroSection.tsx",
-      "norm_label": "homeherosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
       "source_location": "L1"
     },
     {
@@ -40584,6 +40632,69 @@
     {
       "community": 1230,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
+      "label": "webOrderSchema.ts",
+      "norm_label": "weborderschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1231,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1232,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1233,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
+      "label": "ProductFilterBar.tsx",
+      "norm_label": "productfilterbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1234,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
+      "label": "BestSellersSection.test.tsx",
+      "norm_label": "bestsellerssection.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1235,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
+      "label": "HomeHero.tsx",
+      "norm_label": "homehero.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1236,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
+      "label": "HomeHeroSection.tsx",
+      "norm_label": "homeherosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1237,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
       "norm_label": "homepagecontent.test.ts",
@@ -40591,7 +40702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -40600,75 +40711,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1233,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
-      "label": "navBarConstants.ts",
-      "norm_label": "navbarconstants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1234,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
-      "label": "About.tsx",
-      "norm_label": "about.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1235,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
-      "label": "AboutProduct.tsx",
-      "norm_label": "aboutproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1236,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
-      "label": "ProductActions.test.tsx",
-      "norm_label": "productactions.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1237,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
-      "label": "ProductInfo.tsx",
-      "norm_label": "productinfo.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1238,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
-      "label": "ProductReviews.tsx",
-      "norm_label": "productreviews.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
-      "label": "ProductsNavigationBar.tsx",
-      "norm_label": "productsnavigationbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
       "source_location": "L1"
     },
     {
@@ -40719,6 +40767,69 @@
     {
       "community": 1240,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
+      "label": "navBarConstants.ts",
+      "norm_label": "navbarconstants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1241,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
+      "label": "About.tsx",
+      "norm_label": "about.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1242,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
+      "label": "AboutProduct.tsx",
+      "norm_label": "aboutproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1243,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
+      "label": "ProductActions.test.tsx",
+      "norm_label": "productactions.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1244,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
+      "label": "ProductInfo.tsx",
+      "norm_label": "productinfo.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1245,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
+      "label": "ProductReviews.tsx",
+      "norm_label": "productreviews.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1246,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
+      "label": "ProductsNavigationBar.tsx",
+      "norm_label": "productsnavigationbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1247,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
       "norm_label": "errormessage.tsx",
@@ -40726,7 +40837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -40735,75 +40846,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
       "norm_label": "reviewform.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1243,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
-      "label": "SuccessMessage.tsx",
-      "norm_label": "successmessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1244,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1245,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
-      "label": "SavedBag.tsx",
-      "norm_label": "savedbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1246,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
-      "label": "SavedIcon.tsx",
-      "norm_label": "savedicon.tsx",
-      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1247,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
-      "label": "CartIcon.tsx",
-      "norm_label": "carticon.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1248,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
-      "label": "ShoppingBag.test.tsx",
-      "norm_label": "shoppingbag.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
-      "label": "empty-state.tsx",
-      "norm_label": "empty-state.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1"
     },
     {
@@ -40854,6 +40902,69 @@
     {
       "community": 1250,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
+      "label": "SuccessMessage.tsx",
+      "norm_label": "successmessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1251,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1252,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
+      "label": "SavedBag.tsx",
+      "norm_label": "savedbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1253,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
+      "label": "SavedIcon.tsx",
+      "norm_label": "savedicon.tsx",
+      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1254,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
+      "label": "CartIcon.tsx",
+      "norm_label": "carticon.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1255,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
+      "label": "ShoppingBag.test.tsx",
+      "norm_label": "shoppingbag.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1256,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
+      "label": "empty-state.tsx",
+      "norm_label": "empty-state.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1257,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
       "norm_label": "maintenance.tsx",
@@ -40861,7 +40972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -40870,75 +40981,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
       "norm_label": "accordion.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1253,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
-      "label": "alert.tsx",
-      "norm_label": "alert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1254,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
-      "label": "breadcrumb.tsx",
-      "norm_label": "breadcrumb.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1255,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
-      "label": "button.tsx",
-      "norm_label": "button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1256,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_card_tsx",
-      "label": "card.tsx",
-      "norm_label": "card.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1257,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1258,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
-      "label": "command.tsx",
-      "norm_label": "command.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1259,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
-      "label": "context-menu.tsx",
-      "norm_label": "context-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
       "source_location": "L1"
     },
     {
@@ -40989,6 +41037,69 @@
     {
       "community": 1260,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
+      "label": "alert.tsx",
+      "norm_label": "alert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1261,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
+      "label": "breadcrumb.tsx",
+      "norm_label": "breadcrumb.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1262,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
+      "label": "button.tsx",
+      "norm_label": "button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1263,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_card_tsx",
+      "label": "card.tsx",
+      "norm_label": "card.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1264,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1265,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
+      "label": "command.tsx",
+      "norm_label": "command.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1266,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
+      "label": "context-menu.tsx",
+      "norm_label": "context-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1267,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
       "norm_label": "dialog.tsx",
@@ -40996,7 +41107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -41005,75 +41116,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
       "norm_label": "form.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1263,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
-      "label": "icons.tsx",
-      "norm_label": "icons.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1264,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
-      "label": "image-with-fallback.tsx",
-      "norm_label": "image-with-fallback.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1265,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
-      "label": "input-otp.tsx",
-      "norm_label": "input-otp.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1266,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
-      "label": "input-with-end-button.tsx",
-      "norm_label": "input-with-end-button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1267,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1268,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1269,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
-      "label": "LeaveAReviewModalForm.tsx",
-      "norm_label": "leaveareviewmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
       "source_location": "L1"
     },
     {
@@ -41124,6 +41172,69 @@
     {
       "community": 1270,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
+      "label": "icons.tsx",
+      "norm_label": "icons.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1271,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
+      "label": "image-with-fallback.tsx",
+      "norm_label": "image-with-fallback.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1272,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
+      "label": "input-otp.tsx",
+      "norm_label": "input-otp.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1273,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
+      "label": "input-with-end-button.tsx",
+      "norm_label": "input-with-end-button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1274,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1275,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1276,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
+      "label": "LeaveAReviewModalForm.tsx",
+      "norm_label": "leaveareviewmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1277,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
       "norm_label": "action-modal.tsx",
@@ -41131,7 +41242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -41140,75 +41251,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1273,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1274,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
-      "label": "navigation-menu.tsx",
-      "norm_label": "navigation-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1275,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
-      "label": "popover.tsx",
-      "norm_label": "popover.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1276,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
-      "label": "radio-group.tsx",
-      "norm_label": "radio-group.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1277,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1278,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
-      "label": "select.tsx",
-      "norm_label": "select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
-      "label": "separator.tsx",
-      "norm_label": "separator.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
       "source_location": "L1"
     },
     {
@@ -41259,6 +41307,69 @@
     {
       "community": 1280,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1281,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
+      "label": "navigation-menu.tsx",
+      "norm_label": "navigation-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1282,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
+      "label": "popover.tsx",
+      "norm_label": "popover.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1283,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
+      "label": "radio-group.tsx",
+      "norm_label": "radio-group.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1284,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1285,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
+      "label": "select.tsx",
+      "norm_label": "select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1286,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
+      "label": "separator.tsx",
+      "norm_label": "separator.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1287,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
       "norm_label": "sheet.tsx",
@@ -41266,7 +41377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -41275,75 +41386,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
       "norm_label": "tabs.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1283,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
-      "label": "textarea.tsx",
-      "norm_label": "textarea.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1284,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1285,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
-      "label": "toggle.tsx",
-      "norm_label": "toggle.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1286,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1287,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/storefront-webapp/src/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1288,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1"
     },
     {
@@ -41394,6 +41442,69 @@
     {
       "community": 1290,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
+      "label": "textarea.tsx",
+      "norm_label": "textarea.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1291,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1292,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
+      "label": "toggle.tsx",
+      "norm_label": "toggle.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1293,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1294,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/storefront-webapp/src/config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1295,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1296,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1297,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
       "norm_label": "usestorefrontobservability.ts",
@@ -41401,7 +41512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -41410,75 +41521,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
       "norm_label": "countries.ts",
       "source_file": "packages/storefront-webapp/src/lib/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1293,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
-      "label": "feeUtils.test.ts",
-      "norm_label": "feeutils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1294,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/storefront-webapp/src/lib/ghana.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1295,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
-      "label": "ghanaRegions.ts",
-      "norm_label": "ghanaregions.ts",
-      "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1296,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
-      "label": "maintenanceUtils.test.ts",
-      "norm_label": "maintenanceutils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1297,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1298,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
       "source_location": "L1"
     },
     {
@@ -41691,6 +41739,69 @@
     {
       "community": 1300,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
+      "label": "feeUtils.test.ts",
+      "norm_label": "feeutils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/storefront-webapp/src/lib/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1302,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
+      "label": "ghanaRegions.ts",
+      "norm_label": "ghanaregions.ts",
+      "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1303,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
+      "label": "maintenanceUtils.test.ts",
+      "norm_label": "maintenanceutils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1304,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1305,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1306,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1307,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
       "norm_label": "bagitem.ts",
@@ -41698,7 +41809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -41707,75 +41818,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
       "norm_label": "organization.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1303,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1304,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1305,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1306,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1307,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_states_ts",
-      "label": "states.ts",
-      "norm_label": "states.ts",
-      "source_file": "packages/storefront-webapp/src/lib/states.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1308,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
-      "label": "storefrontFailureObservability.test.ts",
-      "norm_label": "storefrontfailureobservability.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
-      "label": "storefrontJourneyEvents.test.ts",
-      "norm_label": "storefrontjourneyevents.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
       "source_location": "L1"
     },
     {
@@ -41826,6 +41874,69 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1312,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1313,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1314,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_states_ts",
+      "label": "states.ts",
+      "norm_label": "states.ts",
+      "source_file": "packages/storefront-webapp/src/lib/states.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1315,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
+      "label": "storefrontFailureObservability.test.ts",
+      "norm_label": "storefrontfailureobservability.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1316,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
+      "label": "storefrontJourneyEvents.test.ts",
+      "norm_label": "storefrontjourneyevents.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1317,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
@@ -41833,7 +41944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -41842,75 +41953,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
       "norm_label": "-homepageloader.test.ts",
       "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1313,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_root_tsx",
-      "label": "__root.tsx",
-      "norm_label": "__root.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1314,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
-      "label": "$orderItemId.review.tsx",
-      "norm_label": "$orderitemid.review.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1315,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1316,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
-      "label": "$subcategorySlug.tsx",
-      "norm_label": "$subcategoryslug.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1317,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1318,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
-      "label": "rewards.index.tsx",
-      "norm_label": "rewards.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
-      "label": "shop.saved.index.tsx",
-      "norm_label": "shop.saved.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
       "source_location": "L1"
     },
     {
@@ -41961,6 +42009,69 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_root_tsx",
+      "label": "__root.tsx",
+      "norm_label": "__root.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
+      "label": "$orderItemId.review.tsx",
+      "norm_label": "$orderitemid.review.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1322,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1323,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
+      "label": "$subcategorySlug.tsx",
+      "norm_label": "$subcategoryslug.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1324,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1325,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
+      "label": "rewards.index.tsx",
+      "norm_label": "rewards.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1326,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
+      "label": "shop.saved.index.tsx",
+      "norm_label": "shop.saved.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1327,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
       "norm_label": "bag.index.tsx",
@@ -41968,7 +42079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -41977,75 +42088,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
       "norm_label": "incomplete.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1323,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1324,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
-      "label": "pending.tsx",
-      "norm_label": "pending.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1325,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tailwind_config_js",
-      "label": "tailwind.config.js",
-      "norm_label": "tailwind.config.js",
-      "source_file": "packages/storefront-webapp/tailwind.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1326,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/storefront-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1327,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/storefront-webapp/vitest.setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1328,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_index_js",
-      "label": "index.js",
-      "norm_label": "index.js",
-      "source_file": "packages/valkey-proxy-server/index.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "scripts_harness_app_registry_test_ts",
-      "label": "harness-app-registry.test.ts",
-      "norm_label": "harness-app-registry.test.ts",
-      "source_file": "scripts/harness-app-registry.test.ts",
       "source_location": "L1"
     },
     {
@@ -42096,6 +42144,69 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
+      "label": "pending.tsx",
+      "norm_label": "pending.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1332,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_tailwind_config_js",
+      "label": "tailwind.config.js",
+      "norm_label": "tailwind.config.js",
+      "source_file": "packages/storefront-webapp/tailwind.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1333,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/storefront-webapp/vitest.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1334,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/storefront-webapp/vitest.setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1335,
+      "file_type": "code",
+      "id": "packages_valkey_proxy_server_index_js",
+      "label": "index.js",
+      "norm_label": "index.js",
+      "source_file": "packages/valkey-proxy-server/index.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1336,
+      "file_type": "code",
+      "id": "scripts_harness_app_registry_test_ts",
+      "label": "harness-app-registry.test.ts",
+      "norm_label": "harness-app-registry.test.ts",
+      "source_file": "scripts/harness-app-registry.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1337,
+      "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
       "norm_label": "valkey-runtime-app.test.ts",
@@ -42103,7 +42214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1338,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -42112,7 +42223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1339,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -48135,6 +48246,33 @@
     {
       "community": 245,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_workflowtrace_ts",
+      "label": "workflowTrace.ts",
+      "norm_label": "workflowtrace.ts",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "workflowtrace_createworkflowtraceid",
+      "label": "createWorkflowTraceId()",
+      "norm_label": "createworkflowtraceid()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "workflowtrace_normalizeworkflowtracelookupvalue",
+      "label": "normalizeWorkflowTraceLookupValue()",
+      "norm_label": "normalizeworkflowtracelookupvalue()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
       "norm_label": "view.tsx",
@@ -48142,7 +48280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -48151,7 +48289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -48160,7 +48298,7 @@
       "source_location": "L4"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -48169,7 +48307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -48178,7 +48316,7 @@
       "source_location": "L18"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -48187,7 +48325,7 @@
       "source_location": "L5"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -48196,7 +48334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -48205,7 +48343,7 @@
       "source_location": "L19"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -48214,7 +48352,7 @@
       "source_location": "L11"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -48223,7 +48361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -48232,40 +48370,13 @@
       "source_location": "L21"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
       "norm_label": "wigtypeview()",
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L8"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "copyimagesprovider_copyimagesprovider",
-      "label": "CopyImagesProvider()",
-      "norm_label": "copyimagesprovider()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "copyimagesprovider_usecopyimages",
-      "label": "useCopyImages()",
-      "norm_label": "usecopyimages()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
-      "label": "CopyImagesProvider.tsx",
-      "norm_label": "copyimagesprovider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
-      "source_location": "L1"
     },
     {
       "community": 25,
@@ -48396,6 +48507,33 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "copyimagesprovider_copyimagesprovider",
+      "label": "CopyImagesProvider()",
+      "norm_label": "copyimagesprovider()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "copyimagesprovider_usecopyimages",
+      "label": "useCopyImages()",
+      "norm_label": "usecopyimages()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
+      "label": "CopyImagesProvider.tsx",
+      "norm_label": "copyimagesprovider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
       "norm_label": "analyticscombinedusers()",
@@ -48403,7 +48541,7 @@
       "source_location": "L100"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -48412,7 +48550,7 @@
       "source_location": "L10"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -48421,7 +48559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -48430,7 +48568,7 @@
       "source_location": "L100"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -48439,7 +48577,7 @@
       "source_location": "L10"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -48448,7 +48586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -48457,7 +48595,7 @@
       "source_location": "L15"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -48466,7 +48604,7 @@
       "source_location": "L39"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -48475,7 +48613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -48484,7 +48622,7 @@
       "source_location": "L43"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -48493,7 +48631,7 @@
       "source_location": "L51"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -48502,7 +48640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -48511,7 +48649,7 @@
       "source_location": "L3"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -48520,7 +48658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -48529,7 +48667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -48538,7 +48676,7 @@
       "source_location": "L53"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -48547,7 +48685,7 @@
       "source_location": "L65"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -48556,7 +48694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -48565,7 +48703,7 @@
       "source_location": "L47"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -48574,7 +48712,7 @@
       "source_location": "L53"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -48583,7 +48721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -48592,7 +48730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -48601,7 +48739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
@@ -48610,7 +48748,7 @@
       "source_location": "L9"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "operationsqueueview_handledecideapprovalrequest",
       "label": "handleDecideApprovalRequest()",
@@ -48619,7 +48757,7 @@
       "source_location": "L289"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "operationsqueueview_handlesubmitstockbatch",
       "label": "handleSubmitStockBatch()",
@@ -48628,40 +48766,13 @@
       "source_location": "L279"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
       "norm_label": "operationsqueueview.tsx",
       "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
-      "label": "PickupDetailsView.tsx",
-      "norm_label": "pickupdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "pickupdetailsview_deliverydetails",
-      "label": "DeliveryDetails()",
-      "norm_label": "deliverydetails()",
-      "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "pickupdetailsview_pickupdetailsview",
-      "label": "PickupDetailsView()",
-      "norm_label": "pickupdetailsview()",
-      "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
-      "source_location": "L9"
     },
     {
       "community": 26,
@@ -48783,6 +48894,33 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
+      "label": "PickupDetailsView.tsx",
+      "norm_label": "pickupdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "pickupdetailsview_deliverydetails",
+      "label": "DeliveryDetails()",
+      "norm_label": "deliverydetails()",
+      "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "pickupdetailsview_pickupdetailsview",
+      "label": "PickupDetailsView()",
+      "norm_label": "pickupdetailsview()",
+      "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
       "norm_label": "handlesignout()",
@@ -48790,7 +48928,7 @@
       "source_location": "L100"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -48799,7 +48937,7 @@
       "source_location": "L95"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -48808,7 +48946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -48817,7 +48955,7 @@
       "source_location": "L35"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -48826,7 +48964,7 @@
       "source_location": "L31"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -48835,7 +48973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -48844,7 +48982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -48853,7 +48991,7 @@
       "source_location": "L20"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -48862,7 +49000,7 @@
       "source_location": "L26"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -48871,7 +49009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -48880,7 +49018,7 @@
       "source_location": "L65"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -48889,7 +49027,7 @@
       "source_location": "L20"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -48898,7 +49036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -48907,7 +49045,7 @@
       "source_location": "L16"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -48916,7 +49054,7 @@
       "source_location": "L60"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -48925,7 +49063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -48934,7 +49072,7 @@
       "source_location": "L45"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -48943,7 +49081,7 @@
       "source_location": "L19"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -48952,7 +49090,7 @@
       "source_location": "L128"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -48961,7 +49099,7 @@
       "source_location": "L40"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -48970,7 +49108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -48979,7 +49117,7 @@
       "source_location": "L24"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -48988,7 +49126,7 @@
       "source_location": "L20"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -48997,7 +49135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -49006,7 +49144,7 @@
       "source_location": "L25"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -49015,40 +49153,13 @@
       "source_location": "L17"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
       "norm_label": "currency-provider.tsx",
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
-      "label": "ServiceIntakeView.tsx",
-      "norm_label": "serviceintakeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "serviceintakeview_handlecreateintake",
-      "label": "handleCreateIntake()",
-      "norm_label": "handlecreateintake()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
-      "source_location": "L238"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "serviceintakeview_serviceintakeviewcontent",
-      "label": "ServiceIntakeViewContent()",
-      "norm_label": "serviceintakeviewcontent()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
-      "source_location": "L69"
     },
     {
       "community": 27,
@@ -49170,6 +49281,33 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
+      "label": "ServiceIntakeView.tsx",
+      "norm_label": "serviceintakeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "serviceintakeview_handlecreateintake",
+      "label": "handleCreateIntake()",
+      "norm_label": "handlecreateintake()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
+      "source_location": "L238"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "serviceintakeview_serviceintakeviewcontent",
+      "label": "ServiceIntakeViewContent()",
+      "norm_label": "serviceintakeviewcontent()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
+      "source_location": "L69"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
       "norm_label": "singlelineerror.tsx",
@@ -49177,7 +49315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -49186,7 +49324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -49195,7 +49333,7 @@
       "source_location": "L3"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -49204,7 +49342,7 @@
       "source_location": "L9"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -49213,7 +49351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -49222,7 +49360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -49231,7 +49369,7 @@
       "source_location": "L3"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -49240,7 +49378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -49249,7 +49387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -49258,7 +49396,7 @@
       "source_location": "L3"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -49267,7 +49405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -49276,7 +49414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -49285,7 +49423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -49294,7 +49432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -49303,7 +49441,7 @@
       "source_location": "L3"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -49312,7 +49450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -49321,7 +49459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -49330,7 +49468,7 @@
       "source_location": "L3"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -49339,7 +49477,7 @@
       "source_location": "L4"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -49348,7 +49486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -49357,7 +49495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -49366,7 +49504,7 @@
       "source_location": "L104"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -49375,7 +49513,7 @@
       "source_location": "L36"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -49384,7 +49522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -49393,7 +49531,7 @@
       "source_location": "L20"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -49402,39 +49540,12 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
       "norm_label": "app-context-menu.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "badge_badge",
-      "label": "Badge()",
-      "norm_label": "badge()",
-      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_badge_tsx",
-      "label": "badge.tsx",
-      "norm_label": "badge.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/badge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
-      "label": "badge.tsx",
-      "norm_label": "badge.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L1"
     },
     {
@@ -49557,6 +49668,33 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "badge_badge",
+      "label": "Badge()",
+      "norm_label": "badge()",
+      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_badge_tsx",
+      "label": "badge.tsx",
+      "norm_label": "badge.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/badge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
+      "label": "badge.tsx",
+      "norm_label": "badge.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
       "norm_label": "loadingbutton()",
@@ -49564,7 +49702,7 @@
       "source_location": "L9"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -49573,7 +49711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -49582,7 +49720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -49591,7 +49729,7 @@
       "source_location": "L38"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -49600,7 +49738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -49609,7 +49747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -49618,7 +49756,7 @@
       "source_location": "L20"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -49627,7 +49765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -49636,7 +49774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -49645,7 +49783,7 @@
       "source_location": "L12"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -49654,7 +49792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -49663,7 +49801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -49672,7 +49810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -49681,7 +49819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -49690,7 +49828,7 @@
       "source_location": "L3"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -49699,7 +49837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -49708,7 +49846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -49717,7 +49855,7 @@
       "source_location": "L6"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -49726,7 +49864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -49735,7 +49873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -49744,7 +49882,7 @@
       "source_location": "L3"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -49753,7 +49891,7 @@
       "source_location": "L44"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -49762,7 +49900,7 @@
       "source_location": "L19"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -49771,7 +49909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -49780,7 +49918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -49789,40 +49927,13 @@
       "source_location": "L159"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
       "norm_label": "loadmore()",
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L195"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
-      "label": "UserActivity.tsx",
-      "norm_label": "useractivity.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "useractivity_activityheader",
-      "label": "ActivityHeader()",
-      "norm_label": "activityheader()",
-      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "useractivity_useractivity",
-      "label": "UserActivity()",
-      "norm_label": "useractivity()",
-      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
-      "source_location": "L45"
     },
     {
       "community": 29,
@@ -49944,6 +50055,33 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
+      "label": "UserActivity.tsx",
+      "norm_label": "useractivity.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "useractivity_activityheader",
+      "label": "ActivityHeader()",
+      "norm_label": "activityheader()",
+      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "useractivity_useractivity",
+      "label": "UserActivity()",
+      "norm_label": "useractivity()",
+      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
       "norm_label": "onlineorderprovider()",
@@ -49951,7 +50089,7 @@
       "source_location": "L24"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -49960,7 +50098,7 @@
       "source_location": "L38"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -49969,7 +50107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -49978,7 +50116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -49987,7 +50125,7 @@
       "source_location": "L23"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -49996,7 +50134,7 @@
       "source_location": "L51"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -50005,7 +50143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -50014,7 +50152,7 @@
       "source_location": "L54"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -50023,7 +50161,7 @@
       "source_location": "L282"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -50032,7 +50170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -50041,7 +50179,7 @@
       "source_location": "L12"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -50050,7 +50188,7 @@
       "source_location": "L37"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -50059,7 +50197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -50068,7 +50206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -50077,7 +50215,7 @@
       "source_location": "L4"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -50086,7 +50224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -50095,7 +50233,7 @@
       "source_location": "L9"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -50104,7 +50242,7 @@
       "source_location": "L50"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -50113,7 +50251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -50122,7 +50260,7 @@
       "source_location": "L6"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -50131,7 +50269,7 @@
       "source_location": "L31"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -50140,7 +50278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -50149,7 +50287,7 @@
       "source_location": "L5"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -50158,7 +50296,7 @@
       "source_location": "L31"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
@@ -50167,7 +50305,7 @@
       "source_location": "L7"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -50176,39 +50314,12 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
       "norm_label": "maintenanceutils.ts",
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "displayamounts_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "displayamounts_parsedisplayamountinput",
-      "label": "parseDisplayAmountInput()",
-      "norm_label": "parsedisplayamountinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
-      "label": "displayAmounts.ts",
-      "norm_label": "displayamounts.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
       "source_location": "L1"
     },
     {
@@ -50601,6 +50712,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "displayamounts_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "displayamounts_parsedisplayamountinput",
+      "label": "parseDisplayAmountInput()",
+      "norm_label": "parsedisplayamountinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
+      "label": "displayAmounts.ts",
+      "norm_label": "displayamounts.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
       "norm_label": "useconvexcommandgateway()",
@@ -50608,7 +50746,7 @@
       "source_location": "L16"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -50617,7 +50755,7 @@
       "source_location": "L53"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -50626,7 +50764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -50635,7 +50773,7 @@
       "source_location": "L31"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -50644,7 +50782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -50653,7 +50791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -50662,7 +50800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -50671,7 +50809,7 @@
       "source_location": "L28"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -50680,7 +50818,7 @@
       "source_location": "L46"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -50689,7 +50827,7 @@
       "source_location": "L18"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -50698,7 +50836,7 @@
       "source_location": "L38"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -50707,7 +50845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -50716,7 +50854,7 @@
       "source_location": "L127"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -50725,7 +50863,7 @@
       "source_location": "L106"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -50734,7 +50872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -50743,7 +50881,7 @@
       "source_location": "L66"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -50752,7 +50890,7 @@
       "source_location": "L20"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -50761,7 +50899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -50770,7 +50908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -50779,7 +50917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -50788,7 +50926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -50797,7 +50935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -50806,7 +50944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -50815,7 +50953,7 @@
       "source_location": "L16"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -50824,7 +50962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -50833,7 +50971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -50842,403 +50980,7 @@
       "source_location": "L19"
     },
     {
-      "community": 309,
-      "file_type": "code",
-      "id": "auth_logout",
-      "label": "logout()",
-      "norm_label": "logout()",
-      "source_file": "packages/storefront-webapp/src/api/auth.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "auth_verifyuseraccount",
-      "label": "verifyUserAccount()",
-      "norm_label": "verifyuseraccount()",
-      "source_file": "packages/storefront-webapp/src/api/auth.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/storefront-webapp/src/api/auth.ts",
-      "source_location": "L1"
-    },
-    {
       "community": 31,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 310,
-      "file_type": "code",
-      "id": "color_getallcolors",
-      "label": "getAllColors()",
-      "norm_label": "getallcolors()",
-      "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 310,
-      "file_type": "code",
-      "id": "color_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 310,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_color_ts",
-      "label": "color.ts",
-      "norm_label": "color.ts",
-      "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 311,
-      "file_type": "code",
-      "id": "organization_getallorganizations",
-      "label": "getAllOrganizations()",
-      "norm_label": "getallorganizations()",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 311,
-      "file_type": "code",
-      "id": "organization_getorganization",
-      "label": "getOrganization()",
-      "norm_label": "getorganization()",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 311,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 312,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 312,
-      "file_type": "code",
-      "id": "upsells_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 312,
-      "file_type": "code",
-      "id": "upsells_getlastviewedproduct",
-      "label": "getLastViewedProduct()",
-      "norm_label": "getlastviewedproduct()",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 313,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 313,
-      "file_type": "code",
-      "id": "useroffers_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 313,
-      "file_type": "code",
-      "id": "useroffers_getuserofferseligibility",
-      "label": "getUserOffersEligibility()",
-      "norm_label": "getuserofferseligibility()",
-      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 314,
-      "file_type": "code",
-      "id": "customerdetails_enteredcustomerdetails",
-      "label": "EnteredCustomerDetails()",
-      "norm_label": "enteredcustomerdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 314,
-      "file_type": "code",
-      "id": "customerdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 314,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
-      "label": "CustomerDetails.tsx",
-      "norm_label": "customerdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 315,
-      "file_type": "code",
-      "id": "deliveryoptionsselector_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 315,
-      "file_type": "code",
-      "id": "deliveryoptionsselector_storeselector",
-      "label": "StoreSelector()",
-      "norm_label": "storeselector()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 315,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
-      "label": "DeliveryOptionsSelector.tsx",
-      "norm_label": "deliveryoptionsselector.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 316,
-      "file_type": "code",
-      "id": "deliverysection_deliverydetails",
-      "label": "DeliveryDetails()",
-      "norm_label": "deliverydetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 316,
-      "file_type": "code",
-      "id": "deliverysection_deliveryoptions",
-      "label": "DeliveryOptions()",
-      "norm_label": "deliveryoptions()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 316,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
-      "label": "DeliverySection.tsx",
-      "norm_label": "deliverysection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "mobilebagsummary_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "mobilebagsummary_handleredeempromocode",
-      "label": "handleRedeemPromoCode()",
-      "norm_label": "handleredeempromocode()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
-      "label": "MobileBagSummary.tsx",
-      "norm_label": "mobilebagsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "checkoutstorage_loadcheckoutstate",
-      "label": "loadCheckoutState()",
-      "norm_label": "loadcheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "checkoutstorage_savecheckoutstate",
-      "label": "saveCheckoutState()",
-      "norm_label": "savecheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
-      "label": "checkoutStorage.ts",
-      "norm_label": "checkoutstorage.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "footer_enablecategories",
-      "label": "enableCategories()",
-      "norm_label": "enablecategories()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "footer_linkgroup",
-      "label": "LinkGroup()",
-      "norm_label": "linkgroup()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
-      "label": "Footer.tsx",
-      "norm_label": "footer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 32,
       "file_type": "code",
       "id": "adjustments_applystockadjustmentbatchwithctx",
       "label": "applyStockAdjustmentBatchWithCtx()",
@@ -51247,7 +50989,7 @@
       "source_location": "L139"
     },
     {
-      "community": 32,
+      "community": 31,
       "file_type": "code",
       "id": "adjustments_assertdistinctstockadjustmentlineitems",
       "label": "assertDistinctStockAdjustmentLineItems()",
@@ -51256,7 +50998,7 @@
       "source_location": "L63"
     },
     {
-      "community": 32,
+      "community": 31,
       "file_type": "code",
       "id": "adjustments_assertnormalizedlineitem",
       "label": "assertNormalizedLineItem()",
@@ -51265,7 +51007,7 @@
       "source_location": "L93"
     },
     {
-      "community": 32,
+      "community": 31,
       "file_type": "code",
       "id": "adjustments_buildresolvedstockadjustmentstatus",
       "label": "buildResolvedStockAdjustmentStatus()",
@@ -51274,7 +51016,7 @@
       "source_location": "L197"
     },
     {
-      "community": 32,
+      "community": 31,
       "file_type": "code",
       "id": "adjustments_buildstockadjustmentdecisioneventtype",
       "label": "buildStockAdjustmentDecisionEventType()",
@@ -51283,7 +51025,7 @@
       "source_location": "L187"
     },
     {
-      "community": 32,
+      "community": 31,
       "file_type": "code",
       "id": "adjustments_buildstockadjustmentsourceid",
       "label": "buildStockAdjustmentSourceId()",
@@ -51292,7 +51034,7 @@
       "source_location": "L79"
     },
     {
-      "community": 32,
+      "community": 31,
       "file_type": "code",
       "id": "adjustments_buildstockadjustmenttitle",
       "label": "buildStockAdjustmentTitle()",
@@ -51301,7 +51043,7 @@
       "source_location": "L83"
     },
     {
-      "community": 32,
+      "community": 31,
       "file_type": "code",
       "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
@@ -51310,7 +51052,7 @@
       "source_location": "L203"
     },
     {
-      "community": 32,
+      "community": 31,
       "file_type": "code",
       "id": "adjustments_submitstockadjustmentbatchwithctx",
       "label": "submitStockAdjustmentBatchWithCtx()",
@@ -51319,7 +51061,7 @@
       "source_location": "L337"
     },
     {
-      "community": 32,
+      "community": 31,
       "file_type": "code",
       "id": "adjustments_trimoptional",
       "label": "trimOptional()",
@@ -51328,7 +51070,7 @@
       "source_location": "L58"
     },
     {
-      "community": 32,
+      "community": 31,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "label": "adjustments.ts",
@@ -51337,277 +51079,277 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 310,
       "file_type": "code",
-      "id": "featuredproductssection_featuredproductssection",
-      "label": "FeaturedProductsSection()",
-      "norm_label": "featuredproductssection()",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L20"
+      "id": "auth_logout",
+      "label": "logout()",
+      "norm_label": "logout()",
+      "source_file": "packages/storefront-webapp/src/api/auth.ts",
+      "source_location": "L32"
     },
     {
-      "community": 320,
+      "community": 310,
       "file_type": "code",
-      "id": "featuredproductssection_featuredsection",
-      "label": "FeaturedSection()",
-      "norm_label": "featuredsection()",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L46"
+      "id": "auth_verifyuseraccount",
+      "label": "verifyUserAccount()",
+      "norm_label": "verifyuseraccount()",
+      "source_file": "packages/storefront-webapp/src/api/auth.ts",
+      "source_location": "L3"
     },
     {
-      "community": 320,
+      "community": 310,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
-      "label": "FeaturedProductsSection.tsx",
-      "norm_label": "featuredproductssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "id": "packages_storefront_webapp_src_api_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 311,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
-      "label": "PromoAlert.tsx",
-      "norm_label": "promoalert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "id": "color_getallcolors",
+      "label": "getAllColors()",
+      "norm_label": "getallcolors()",
+      "source_file": "packages/storefront-webapp/src/api/color.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "color_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/color.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_color_ts",
+      "label": "color.ts",
+      "norm_label": "color.ts",
+      "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 312,
       "file_type": "code",
-      "id": "promoalert_getpromoalertcopy",
-      "label": "getPromoAlertCopy()",
-      "norm_label": "getpromoalertcopy()",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L20"
+      "id": "organization_getallorganizations",
+      "label": "getAllOrganizations()",
+      "norm_label": "getallorganizations()",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L6"
     },
     {
-      "community": 321,
+      "community": 312,
       "file_type": "code",
-      "id": "promoalert_promoalert",
-      "label": "PromoAlert()",
-      "norm_label": "promoalert()",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L59"
+      "id": "organization_getorganization",
+      "label": "getOrganization()",
+      "norm_label": "getorganization()",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L18"
     },
     {
-      "community": 322,
+      "community": 312,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
-      "label": "RewardsAlert.tsx",
-      "norm_label": "rewardsalert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "id": "packages_storefront_webapp_src_api_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 313,
       "file_type": "code",
-      "id": "rewardsalert_handleshopnow",
-      "label": "handleShopNow()",
-      "norm_label": "handleshopnow()",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "rewardsalert_onrewardsalertclose",
-      "label": "onRewardsAlertClose()",
-      "norm_label": "onrewardsalertclose()",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 323,
-      "file_type": "code",
-      "id": "navigationbar_navigationbar",
-      "label": "NavigationBar()",
-      "norm_label": "navigationbar()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 323,
-      "file_type": "code",
-      "id": "navigationbar_storecategoriessubmenu",
-      "label": "StoreCategoriesSubmenu()",
-      "norm_label": "storecategoriessubmenu()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 323,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
-      "label": "NavigationBar.tsx",
-      "norm_label": "navigationbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "id": "packages_storefront_webapp_src_api_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 313,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
-      "label": "ProductAttribute.tsx",
-      "norm_label": "productattribute.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "id": "upsells_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 313,
+      "file_type": "code",
+      "id": "upsells_getlastviewedproduct",
+      "label": "getLastViewedProduct()",
+      "norm_label": "getlastviewedproduct()",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 314,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 314,
       "file_type": "code",
-      "id": "productattribute_findsize",
-      "label": "findSize()",
-      "norm_label": "findsize()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L61"
+      "id": "useroffers_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
+      "source_location": "L18"
     },
     {
-      "community": 324,
+      "community": 314,
       "file_type": "code",
-      "id": "productattribute_handleclick",
-      "label": "handleClick()",
-      "norm_label": "handleclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L65"
+      "id": "useroffers_getuserofferseligibility",
+      "label": "getUserOffersEligibility()",
+      "norm_label": "getuserofferseligibility()",
+      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
+      "source_location": "L23"
     },
     {
-      "community": 325,
+      "community": 315,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
-      "label": "ReviewEditor.tsx",
-      "norm_label": "revieweditor.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "id": "customerdetails_enteredcustomerdetails",
+      "label": "EnteredCustomerDetails()",
+      "norm_label": "enteredcustomerdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 315,
+      "file_type": "code",
+      "id": "customerdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 315,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
+      "label": "CustomerDetails.tsx",
+      "norm_label": "customerdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 316,
       "file_type": "code",
-      "id": "revieweditor_handleformdatachange",
-      "label": "handleFormDataChange()",
-      "norm_label": "handleformdatachange()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L150"
+      "id": "deliveryoptionsselector_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L77"
     },
     {
-      "community": 325,
+      "community": 316,
       "file_type": "code",
-      "id": "revieweditor_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L157"
+      "id": "deliveryoptionsselector_storeselector",
+      "label": "StoreSelector()",
+      "norm_label": "storeselector()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L11"
     },
     {
-      "community": 326,
+      "community": 316,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
-      "label": "UpsellModalForm.tsx",
-      "norm_label": "upsellmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
+      "label": "DeliveryOptionsSelector.tsx",
+      "norm_label": "deliveryoptionsselector.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 317,
       "file_type": "code",
-      "id": "upsellmodalform_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
-      "source_location": "L63"
+      "id": "deliverysection_deliverydetails",
+      "label": "DeliveryDetails()",
+      "norm_label": "deliverydetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L11"
     },
     {
-      "community": 326,
+      "community": 317,
       "file_type": "code",
-      "id": "upsellmodalform_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
-      "source_location": "L48"
+      "id": "deliverysection_deliveryoptions",
+      "label": "DeliveryOptions()",
+      "norm_label": "deliveryoptions()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L22"
     },
     {
-      "community": 327,
+      "community": 317,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
-      "label": "WelcomeBackModal.tsx",
-      "norm_label": "welcomebackmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
+      "label": "DeliverySection.tsx",
+      "norm_label": "deliverysection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 318,
       "file_type": "code",
-      "id": "welcomebackmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L63"
+      "id": "mobilebagsummary_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L110"
     },
     {
-      "community": 327,
+      "community": 318,
       "file_type": "code",
-      "id": "welcomebackmodal_handlesuccess",
-      "label": "handleSuccess()",
-      "norm_label": "handlesuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L76"
+      "id": "mobilebagsummary_handleredeempromocode",
+      "label": "handleRedeemPromoCode()",
+      "norm_label": "handleredeempromocode()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L89"
     },
     {
-      "community": 328,
+      "community": 318,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
-      "label": "WelcomeBackModalForm.tsx",
-      "norm_label": "welcomebackmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
+      "label": "MobileBagSummary.tsx",
+      "norm_label": "mobilebagsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 319,
       "file_type": "code",
-      "id": "welcomebackmodalform_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L51"
+      "id": "checkoutstorage_loadcheckoutstate",
+      "label": "loadCheckoutState()",
+      "norm_label": "loadcheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L4"
     },
     {
-      "community": 328,
+      "community": 319,
       "file_type": "code",
-      "id": "welcomebackmodalform_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L36"
+      "id": "checkoutstorage_savecheckoutstate",
+      "label": "saveCheckoutState()",
+      "norm_label": "savecheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L24"
     },
     {
-      "community": 329,
+      "community": 319,
       "file_type": "code",
-      "id": "navigationbarprovider_navigationbarprovider",
-      "label": "NavigationBarProvider()",
-      "norm_label": "navigationbarprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "navigationbarprovider_usenavigationbarcontext",
-      "label": "useNavigationBarContext()",
-      "norm_label": "usenavigationbarcontext()",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L39"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
-      "label": "NavigationBarProvider.tsx",
-      "norm_label": "navigationbarprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
+      "label": "checkoutStorage.ts",
+      "norm_label": "checkoutstorage.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L1"
     },
     {
-      "community": 33,
+      "community": 32,
       "file_type": "code",
       "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
       "label": "OrdersTableToolbarProvider()",
@@ -51616,7 +51358,7 @@
       "source_location": "L16"
     },
     {
-      "community": 33,
+      "community": 32,
       "file_type": "code",
       "id": "data_table_toolbar_provider_useorderstabletoolbar",
       "label": "useOrdersTableToolbar()",
@@ -51625,7 +51367,7 @@
       "source_location": "L46"
     },
     {
-      "community": 33,
+      "community": 32,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -51634,7 +51376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 33,
+      "community": 32,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -51643,7 +51385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 33,
+      "community": 32,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -51652,7 +51394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 33,
+      "community": 32,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -51661,7 +51403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 33,
+      "community": 32,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -51670,7 +51412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 33,
+      "community": 32,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -51679,7 +51421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 33,
+      "community": 32,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -51688,7 +51430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 33,
+      "community": 32,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -51697,7 +51439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 33,
+      "community": 32,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
       "label": "data-table-toolbar-provider.tsx",
@@ -51706,277 +51448,277 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 320,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
-      "label": "StoreContext.tsx",
-      "norm_label": "storecontext.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "id": "footer_enablecategories",
+      "label": "enableCategories()",
+      "norm_label": "enablecategories()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "footer_linkgroup",
+      "label": "LinkGroup()",
+      "norm_label": "linkgroup()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
+      "label": "Footer.tsx",
+      "norm_label": "footer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 321,
       "file_type": "code",
-      "id": "storecontext_storeprovider",
-      "label": "StoreProvider()",
-      "norm_label": "storeprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 330,
-      "file_type": "code",
-      "id": "storecontext_usestorecontext",
-      "label": "useStoreContext()",
-      "norm_label": "usestorecontext()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 331,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
-      "label": "StorefrontObservabilityProvider.tsx",
-      "norm_label": "storefrontobservabilityprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 331,
-      "file_type": "code",
-      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "label": "StorefrontObservabilityProvider()",
-      "norm_label": "storefrontobservabilityprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "id": "featuredproductssection_featuredproductssection",
+      "label": "FeaturedProductsSection()",
+      "norm_label": "featuredproductssection()",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L20"
     },
     {
-      "community": 331,
+      "community": 321,
       "file_type": "code",
-      "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "label": "useStorefrontObservability()",
-      "norm_label": "usestorefrontobservability()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 332,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
-      "label": "useProductDiscount.ts",
-      "norm_label": "useproductdiscount.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 332,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscount",
-      "label": "useProductDiscount()",
-      "norm_label": "useproductdiscount()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 332,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscounts",
-      "label": "useProductDiscounts()",
-      "norm_label": "useproductdiscounts()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 333,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
-      "label": "useShoppingBag.ts",
-      "norm_label": "useshoppingbag.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 333,
-      "file_type": "code",
-      "id": "useshoppingbag_isunavailableproductlist",
-      "label": "isUnavailableProductList()",
-      "norm_label": "isunavailableproductlist()",
-      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
-      "source_location": "L556"
-    },
-    {
-      "community": 333,
-      "file_type": "code",
-      "id": "useshoppingbag_useshoppingbag",
-      "label": "useShoppingBag()",
-      "norm_label": "useshoppingbag()",
-      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 334,
-      "file_type": "code",
-      "id": "index_getordermessage",
-      "label": "getOrderMessage()",
-      "norm_label": "getordermessage()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L429"
-    },
-    {
-      "community": 334,
-      "file_type": "code",
-      "id": "index_getpaymenttext",
-      "label": "getPaymentText()",
-      "norm_label": "getpaymenttext()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 334,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 335,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
-      "label": "review.tsx",
-      "norm_label": "review.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 335,
-      "file_type": "code",
-      "id": "review_getordermessage",
-      "label": "getOrderMessage()",
-      "norm_label": "getordermessage()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L250"
-    },
-    {
-      "community": 335,
-      "file_type": "code",
-      "id": "review_ordernavigation",
-      "label": "OrderNavigation()",
-      "norm_label": "ordernavigation()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "id": "featuredproductssection_featuredsection",
+      "label": "FeaturedSection()",
+      "norm_label": "featuredsection()",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L46"
     },
     {
-      "community": 336,
+      "community": 321,
       "file_type": "code",
-      "id": "account_accountbeforeload",
-      "label": "accountBeforeLoad()",
-      "norm_label": "accountbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L17"
+      "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
+      "label": "FeaturedProductsSection.tsx",
+      "norm_label": "featuredproductssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 322,
       "file_type": "code",
-      "id": "account_handleonsubmitform",
-      "label": "handleOnSubmitForm()",
-      "norm_label": "handleonsubmitform()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
+      "label": "PromoAlert.tsx",
+      "norm_label": "promoalert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "promoalert_getpromoalertcopy",
+      "label": "getPromoAlertCopy()",
+      "norm_label": "getpromoalertcopy()",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "promoalert_promoalert",
+      "label": "PromoAlert()",
+      "norm_label": "promoalert()",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
+      "label": "RewardsAlert.tsx",
+      "norm_label": "rewardsalert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "rewardsalert_handleshopnow",
+      "label": "handleShopNow()",
+      "norm_label": "handleshopnow()",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "rewardsalert_onrewardsalertclose",
+      "label": "onRewardsAlertClose()",
+      "norm_label": "onrewardsalertclose()",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "navigationbar_navigationbar",
+      "label": "NavigationBar()",
+      "norm_label": "navigationbar()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "navigationbar_storecategoriessubmenu",
+      "label": "StoreCategoriesSubmenu()",
+      "norm_label": "storecategoriessubmenu()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
+      "label": "NavigationBar.tsx",
+      "norm_label": "navigationbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 325,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
+      "label": "ProductAttribute.tsx",
+      "norm_label": "productattribute.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 325,
+      "file_type": "code",
+      "id": "productattribute_findsize",
+      "label": "findSize()",
+      "norm_label": "findsize()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 325,
+      "file_type": "code",
+      "id": "productattribute_handleclick",
+      "label": "handleClick()",
+      "norm_label": "handleclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 326,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
+      "label": "ReviewEditor.tsx",
+      "norm_label": "revieweditor.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 326,
+      "file_type": "code",
+      "id": "revieweditor_handleformdatachange",
+      "label": "handleFormDataChange()",
+      "norm_label": "handleformdatachange()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 326,
+      "file_type": "code",
+      "id": "revieweditor_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L157"
+    },
+    {
+      "community": 327,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
+      "label": "UpsellModalForm.tsx",
+      "norm_label": "upsellmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 327,
+      "file_type": "code",
+      "id": "upsellmodalform_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L63"
     },
     {
-      "community": 336,
+      "community": 327,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
-      "label": "account.tsx",
-      "norm_label": "account.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "id": "upsellmodalform_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 328,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
+      "label": "WelcomeBackModal.tsx",
+      "norm_label": "welcomebackmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 328,
       "file_type": "code",
-      "id": "login_loginbeforeload",
-      "label": "loginBeforeLoad()",
-      "norm_label": "loginbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L47"
+      "id": "welcomebackmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L63"
     },
     {
-      "community": 337,
+      "community": 328,
       "file_type": "code",
-      "id": "login_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L141"
+      "id": "welcomebackmodal_handlesuccess",
+      "label": "handleSuccess()",
+      "norm_label": "handlesuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L76"
     },
     {
-      "community": 337,
+      "community": 329,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "label": "login.tsx",
-      "norm_label": "login.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
+      "label": "WelcomeBackModalForm.tsx",
+      "norm_label": "welcomebackmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 329,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
-      "label": "verify.index.tsx",
-      "norm_label": "verify.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L1"
+      "id": "welcomebackmodalform_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L51"
     },
     {
-      "community": 338,
+      "community": 329,
       "file_type": "code",
-      "id": "verify_index_verify",
-      "label": "Verify()",
-      "norm_label": "verify()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L21"
+      "id": "welcomebackmodalform_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L36"
     },
     {
-      "community": 338,
-      "file_type": "code",
-      "id": "verify_index_verifycheckoutsessionpayment",
-      "label": "VerifyCheckoutSessionPayment()",
-      "norm_label": "verifycheckoutsessionpayment()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L107"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_signup_tsx",
-      "label": "signup.tsx",
-      "norm_label": "signup.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "signup_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "signup_signupbeforeload",
-      "label": "signupBeforeLoad()",
-      "norm_label": "signupbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 34,
+      "community": 33,
       "file_type": "code",
       "id": "backend_test_completesession",
       "label": "completeSession()",
@@ -51985,7 +51727,7 @@
       "source_location": "L629"
     },
     {
-      "community": 34,
+      "community": 33,
       "file_type": "code",
       "id": "backend_test_createtransaction",
       "label": "createTransaction()",
@@ -51994,7 +51736,7 @@
       "source_location": "L391"
     },
     {
-      "community": 34,
+      "community": 33,
       "file_type": "code",
       "id": "backend_test_createtransactionitems",
       "label": "createTransactionItems()",
@@ -52003,7 +51745,7 @@
       "source_location": "L467"
     },
     {
-      "community": 34,
+      "community": 33,
       "file_type": "code",
       "id": "backend_test_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -52012,7 +51754,7 @@
       "source_location": "L374"
     },
     {
-      "community": 34,
+      "community": 33,
       "file_type": "code",
       "id": "backend_test_handledatabaseerror",
       "label": "handleDatabaseError()",
@@ -52021,7 +51763,7 @@
       "source_location": "L671"
     },
     {
-      "community": 34,
+      "community": 33,
       "file_type": "code",
       "id": "backend_test_rollbackinventory",
       "label": "rollbackInventory()",
@@ -52030,7 +51772,7 @@
       "source_location": "L692"
     },
     {
-      "community": 34,
+      "community": 33,
       "file_type": "code",
       "id": "backend_test_updateinventory",
       "label": "updateInventory()",
@@ -52039,7 +51781,7 @@
       "source_location": "L422"
     },
     {
-      "community": 34,
+      "community": 33,
       "file_type": "code",
       "id": "backend_test_validateinventory",
       "label": "validateInventory()",
@@ -52048,7 +51790,7 @@
       "source_location": "L58"
     },
     {
-      "community": 34,
+      "community": 33,
       "file_type": "code",
       "id": "backend_test_validatesession",
       "label": "validateSession()",
@@ -52057,7 +51799,7 @@
       "source_location": "L553"
     },
     {
-      "community": 34,
+      "community": 33,
       "file_type": "code",
       "id": "backend_test_validatesessioninventory",
       "label": "validateSessionInventory()",
@@ -52066,7 +51808,7 @@
       "source_location": "L593"
     },
     {
-      "community": 34,
+      "community": 33,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
       "label": "backend.test.ts",
@@ -52075,7 +51817,403 @@
       "source_location": "L1"
     },
     {
+      "community": 330,
+      "file_type": "code",
+      "id": "navigationbarprovider_navigationbarprovider",
+      "label": "NavigationBarProvider()",
+      "norm_label": "navigationbarprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "navigationbarprovider_usenavigationbarcontext",
+      "label": "useNavigationBarContext()",
+      "norm_label": "usenavigationbarcontext()",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
+      "label": "NavigationBarProvider.tsx",
+      "norm_label": "navigationbarprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
+      "label": "StoreContext.tsx",
+      "norm_label": "storecontext.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "storecontext_storeprovider",
+      "label": "StoreProvider()",
+      "norm_label": "storeprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "storecontext_usestorecontext",
+      "label": "useStoreContext()",
+      "norm_label": "usestorecontext()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
+      "label": "StorefrontObservabilityProvider.tsx",
+      "norm_label": "storefrontobservabilityprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
+      "label": "StorefrontObservabilityProvider()",
+      "norm_label": "storefrontobservabilityprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_usestorefrontobservability",
+      "label": "useStorefrontObservability()",
+      "norm_label": "usestorefrontobservability()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 333,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
+      "label": "useProductDiscount.ts",
+      "norm_label": "useproductdiscount.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 333,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscount",
+      "label": "useProductDiscount()",
+      "norm_label": "useproductdiscount()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 333,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscounts",
+      "label": "useProductDiscounts()",
+      "norm_label": "useproductdiscounts()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 334,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
+      "label": "useShoppingBag.ts",
+      "norm_label": "useshoppingbag.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 334,
+      "file_type": "code",
+      "id": "useshoppingbag_isunavailableproductlist",
+      "label": "isUnavailableProductList()",
+      "norm_label": "isunavailableproductlist()",
+      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
+      "source_location": "L556"
+    },
+    {
+      "community": 334,
+      "file_type": "code",
+      "id": "useshoppingbag_useshoppingbag",
+      "label": "useShoppingBag()",
+      "norm_label": "useshoppingbag()",
+      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 335,
+      "file_type": "code",
+      "id": "index_getordermessage",
+      "label": "getOrderMessage()",
+      "norm_label": "getordermessage()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L429"
+    },
+    {
+      "community": 335,
+      "file_type": "code",
+      "id": "index_getpaymenttext",
+      "label": "getPaymentText()",
+      "norm_label": "getpaymenttext()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 335,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 336,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
+      "label": "review.tsx",
+      "norm_label": "review.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 336,
+      "file_type": "code",
+      "id": "review_getordermessage",
+      "label": "getOrderMessage()",
+      "norm_label": "getordermessage()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L250"
+    },
+    {
+      "community": 336,
+      "file_type": "code",
+      "id": "review_ordernavigation",
+      "label": "OrderNavigation()",
+      "norm_label": "ordernavigation()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 337,
+      "file_type": "code",
+      "id": "account_accountbeforeload",
+      "label": "accountBeforeLoad()",
+      "norm_label": "accountbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 337,
+      "file_type": "code",
+      "id": "account_handleonsubmitform",
+      "label": "handleOnSubmitForm()",
+      "norm_label": "handleonsubmitform()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 337,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
+      "label": "account.tsx",
+      "norm_label": "account.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 338,
+      "file_type": "code",
+      "id": "login_loginbeforeload",
+      "label": "loginBeforeLoad()",
+      "norm_label": "loginbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 338,
+      "file_type": "code",
+      "id": "login_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 338,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_login_tsx",
+      "label": "login.tsx",
+      "norm_label": "login.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 339,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
+      "label": "verify.index.tsx",
+      "norm_label": "verify.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 339,
+      "file_type": "code",
+      "id": "verify_index_verify",
+      "label": "Verify()",
+      "norm_label": "verify()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 339,
+      "file_type": "code",
+      "id": "verify_index_verifycheckoutsessionpayment",
+      "label": "VerifyCheckoutSessionPayment()",
+      "norm_label": "verifycheckoutsessionpayment()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L107"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
+    },
+    {
       "community": 340,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_signup_tsx",
+      "label": "signup.tsx",
+      "norm_label": "signup.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "signup_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "signup_signupbeforeload",
+      "label": "signupBeforeLoad()",
+      "norm_label": "signupbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 341,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -52084,7 +52222,7 @@
       "source_location": "L11"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -52093,7 +52231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -52102,7 +52240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -52111,7 +52249,7 @@
       "source_location": "L16"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -52120,7 +52258,7 @@
       "source_location": "L10"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -52129,7 +52267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -52138,7 +52276,7 @@
       "source_location": "L17"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -52147,7 +52285,7 @@
       "source_location": "L11"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -52156,7 +52294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -52165,7 +52303,7 @@
       "source_location": "L21"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -52174,7 +52312,7 @@
       "source_location": "L15"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -52183,7 +52321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -52192,7 +52330,7 @@
       "source_location": "L48"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -52201,7 +52339,7 @@
       "source_location": "L42"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -52210,7 +52348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -52219,7 +52357,7 @@
       "source_location": "L16"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -52228,7 +52366,7 @@
       "source_location": "L10"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -52237,7 +52375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -52246,7 +52384,7 @@
       "source_location": "L19"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -52255,7 +52393,7 @@
       "source_location": "L13"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -52264,7 +52402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -52273,7 +52411,7 @@
       "source_location": "L16"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -52282,7 +52420,7 @@
       "source_location": "L10"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -52291,7 +52429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -52300,7 +52438,7 @@
       "source_location": "L20"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -52309,39 +52447,12 @@
       "source_location": "L14"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
       "norm_label": "harness-test.test.ts",
       "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "scripts_pre_commit_generated_artifacts_test_ts",
-      "label": "pre-commit-generated-artifacts.test.ts",
-      "norm_label": "pre-commit-generated-artifacts.test.ts",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
       "source_location": "L1"
     },
     {
@@ -52446,6 +52557,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_test_ts",
+      "label": "pre-commit-generated-artifacts.test.ts",
+      "norm_label": "pre-commit-generated-artifacts.test.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
       "norm_label": "runprecommitgeneratedartifacts()",
@@ -52453,7 +52591,7 @@
       "source_location": "L45"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
       "label": "stageTrackedGraphifyArtifacts()",
@@ -52462,7 +52600,7 @@
       "source_location": "L20"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -52471,7 +52609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -52480,7 +52618,7 @@
       "source_location": "L8"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -52489,7 +52627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -52498,7 +52636,7 @@
       "source_location": "L9"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -52507,7 +52645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -52516,7 +52654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -52525,7 +52663,7 @@
       "source_location": "L12"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -52534,7 +52672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -52543,7 +52681,7 @@
       "source_location": "L8"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -52552,7 +52690,7 @@
       "source_location": "L10"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -52561,7 +52699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -52570,7 +52708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -52579,7 +52717,7 @@
       "source_location": "L18"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -52588,7 +52726,7 @@
       "source_location": "L10"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -52597,7 +52735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -52606,31 +52744,13 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
       "norm_label": "readprojectfile()",
       "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "cashier_authenticatehandler",
-      "label": "authenticateHandler()",
-      "norm_label": "authenticatehandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/cashier.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_cashier_ts",
-      "label": "cashier.ts",
-      "norm_label": "cashier.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/cashier.ts",
-      "source_location": "L1"
     },
     {
       "community": 36,
@@ -52725,6 +52845,24 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "cashier_authenticatehandler",
+      "label": "authenticateHandler()",
+      "norm_label": "authenticatehandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/cashier.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_cashier_ts",
+      "label": "cashier.ts",
+      "norm_label": "cashier.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/cashier.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
       "norm_label": "posquerycleanup.test.ts",
@@ -52732,7 +52870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -52741,7 +52879,7 @@
       "source_location": "L8"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -52750,7 +52888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -52759,7 +52897,7 @@
       "source_location": "L6"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -52768,7 +52906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -52777,7 +52915,7 @@
       "source_location": "L27"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -52786,7 +52924,7 @@
       "source_location": "L4"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -52795,7 +52933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -52804,7 +52942,7 @@
       "source_location": "L3"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -52813,7 +52951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -52822,7 +52960,7 @@
       "source_location": "L3"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -52831,7 +52969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -52840,7 +52978,7 @@
       "source_location": "L6"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -52849,7 +52987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -52858,7 +52996,7 @@
       "source_location": "L3"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -52867,7 +53005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -52876,30 +53014,12 @@
       "source_location": "L18"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
       "norm_label": "approvalrequests.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequests.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "eventbuilders_buildoperationaleventmessage",
-      "label": "buildOperationalEventMessage()",
-      "norm_label": "buildoperationaleventmessage()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
-      "label": "eventBuilders.ts",
-      "norm_label": "eventbuilders.ts",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
       "source_location": "L1"
     },
     {
@@ -52995,6 +53115,24 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "eventbuilders_buildoperationaleventmessage",
+      "label": "buildOperationalEventMessage()",
+      "norm_label": "buildoperationaleventmessage()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
+      "label": "eventBuilders.ts",
+      "norm_label": "eventbuilders.ts",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
       "norm_label": "serviceintake.test.ts",
@@ -53002,7 +53140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -53011,7 +53149,7 @@
       "source_location": "L7"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -53020,7 +53158,7 @@
       "source_location": "L9"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -53029,7 +53167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
@@ -53038,7 +53176,7 @@
       "source_location": "L31"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
@@ -53047,7 +53185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -53056,7 +53194,7 @@
       "source_location": "L6"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -53065,7 +53203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -53074,7 +53212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -53083,7 +53221,7 @@
       "source_location": "L88"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -53092,7 +53230,7 @@
       "source_location": "L8"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -53101,7 +53239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -53110,7 +53248,7 @@
       "source_location": "L4"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -53119,7 +53257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -53128,7 +53266,7 @@
       "source_location": "L6"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
@@ -53137,7 +53275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
@@ -53146,31 +53284,13 @@
       "source_location": "L6"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
       "norm_label": "access.ts",
       "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
-      "label": "purchaseOrders.test.ts",
-      "norm_label": "purchaseorders.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "purchaseorders_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
-      "source_location": "L8"
     },
     {
       "community": 38,
@@ -53265,6 +53385,24 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
+      "label": "purchaseOrders.test.ts",
+      "norm_label": "purchaseorders.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "purchaseorders_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
       "norm_label": "receiving.test.ts",
@@ -53272,7 +53410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -53281,7 +53419,7 @@
       "source_location": "L13"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -53290,7 +53428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -53299,7 +53437,7 @@
       "source_location": "L5"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -53308,7 +53446,7 @@
       "source_location": "L15"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -53317,7 +53455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -53326,7 +53464,7 @@
       "source_location": "L8"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -53335,7 +53473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -53344,7 +53482,7 @@
       "source_location": "L17"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -53353,7 +53491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -53362,7 +53500,7 @@
       "source_location": "L6"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -53371,7 +53509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -53380,7 +53518,7 @@
       "source_location": "L5"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -53389,7 +53527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -53398,7 +53536,7 @@
       "source_location": "L25"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -53407,7 +53545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -53416,31 +53554,13 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
       "norm_label": "getstorefrontactorbyid()",
       "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
       "source_location": "L17"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "rewards_formatpointslabel",
-      "label": "formatPointsLabel()",
-      "norm_label": "formatpointslabel()",
-      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
-      "source_location": "L7"
     },
     {
       "community": 39,
@@ -53535,6 +53655,24 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "rewards_formatpointslabel",
+      "label": "formatPointsLabel()",
+      "norm_label": "formatpointslabel()",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
       "norm_label": "savedbag.ts",
@@ -53542,7 +53680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -53551,7 +53689,7 @@
       "source_location": "L14"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -53560,7 +53698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -53569,7 +53707,7 @@
       "source_location": "L8"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -53578,7 +53716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -53587,7 +53725,7 @@
       "source_location": "L3"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -53596,7 +53734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -53605,7 +53743,7 @@
       "source_location": "L5"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -53614,7 +53752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -53623,7 +53761,7 @@
       "source_location": "L16"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -53632,7 +53770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -53641,7 +53779,25 @@
       "source_location": "L30"
     },
     {
-      "community": 396,
+      "community": 397,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
+      "label": "schemaIndexes.test.ts",
+      "norm_label": "schemaindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 397,
+      "file_type": "code",
+      "id": "schemaindexes_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -53650,7 +53806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 398,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -53659,7 +53815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 399,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -53668,49 +53824,13 @@
       "source_location": "L7"
     },
     {
-      "community": 397,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
       "norm_label": "organizationview.tsx",
       "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "organizationsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organizationsview_tsx",
-      "label": "OrganizationsView.tsx",
-      "norm_label": "organizationsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_permissiongate_tsx",
-      "label": "PermissionGate.tsx",
-      "norm_label": "permissiongate.tsx",
-      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "permissiongate_permissiongate",
-      "label": "PermissionGate()",
-      "norm_label": "permissiongate()",
-      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
-      "source_location": "L11"
     },
     {
       "community": 4,
@@ -54057,6 +54177,42 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "organizationsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organizationsview_tsx",
+      "label": "OrganizationsView.tsx",
+      "norm_label": "organizationsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_permissiongate_tsx",
+      "label": "PermissionGate.tsx",
+      "norm_label": "permissiongate.tsx",
+      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "permissiongate_permissiongate",
+      "label": "PermissionGate()",
+      "norm_label": "permissiongate()",
+      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
       "norm_label": "protectedroute.tsx",
@@ -54064,7 +54220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 400,
+      "community": 402,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -54073,7 +54229,7 @@
       "source_location": "L11"
     },
     {
-      "community": 401,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -54082,7 +54238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 403,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -54091,7 +54247,7 @@
       "source_location": "L3"
     },
     {
-      "community": 402,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -54100,7 +54256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 404,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -54109,7 +54265,7 @@
       "source_location": "L12"
     },
     {
-      "community": 403,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -54118,7 +54274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 405,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -54127,7 +54283,7 @@
       "source_location": "L42"
     },
     {
-      "community": 404,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -54136,7 +54292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 406,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -54145,7 +54301,7 @@
       "source_location": "L13"
     },
     {
-      "community": 405,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -54154,7 +54310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 407,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -54163,7 +54319,7 @@
       "source_location": "L42"
     },
     {
-      "community": 406,
+      "community": 408,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -54172,7 +54328,7 @@
       "source_location": "L31"
     },
     {
-      "community": 406,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -54181,7 +54337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -54190,49 +54346,13 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 409,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
       "norm_label": "processingfeesview()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
       "source_location": "L10"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
-      "label": "ProductAttributes.tsx",
-      "norm_label": "productattributes.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "productattributes_isallowedattribute",
-      "label": "isAllowedAttribute()",
-      "norm_label": "isallowedattribute()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
-      "label": "ProductAvailabilityToggleGroup.tsx",
-      "norm_label": "productavailabilitytogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
-      "label": "ProductAvailabilityToggleGroup()",
-      "norm_label": "productavailabilitytogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
-      "source_location": "L5"
     },
     {
       "community": 41,
@@ -54327,6 +54447,42 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
+      "label": "ProductAttributes.tsx",
+      "norm_label": "productattributes.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "productattributes_isallowedattribute",
+      "label": "isAllowedAttribute()",
+      "norm_label": "isallowedattribute()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
+      "label": "ProductAvailabilityToggleGroup.tsx",
+      "norm_label": "productavailabilitytogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
+      "label": "ProductAvailabilityToggleGroup()",
+      "norm_label": "productavailabilitytogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 412,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
       "norm_label": "productdetails.tsx",
@@ -54334,7 +54490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 412,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -54343,7 +54499,7 @@
       "source_location": "L10"
     },
     {
-      "community": 411,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -54352,7 +54508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 413,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -54361,7 +54517,7 @@
       "source_location": "L15"
     },
     {
-      "community": 412,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -54370,7 +54526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 414,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -54379,7 +54535,7 @@
       "source_location": "L13"
     },
     {
-      "community": 413,
+      "community": 415,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -54388,7 +54544,7 @@
       "source_location": "L116"
     },
     {
-      "community": 413,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -54397,7 +54553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -54406,7 +54562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 416,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -54415,7 +54571,7 @@
       "source_location": "L47"
     },
     {
-      "community": 415,
+      "community": 417,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -54424,7 +54580,7 @@
       "source_location": "L151"
     },
     {
-      "community": 415,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -54433,7 +54589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 418,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -54442,7 +54598,7 @@
       "source_location": "L6"
     },
     {
-      "community": 416,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -54451,7 +54607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 419,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -54460,48 +54616,12 @@
       "source_location": "L19"
     },
     {
-      "community": 417,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
       "norm_label": "analyticsproducts.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "analyticsusers_analyticsusers",
-      "label": "AnalyticsUsers()",
-      "norm_label": "analyticsusers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
-      "label": "AnalyticsUsers.tsx",
-      "norm_label": "analyticsusers.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "enhancedanalyticsview_getdaterangemilliseconds",
-      "label": "getDateRangeMilliseconds()",
-      "norm_label": "getdaterangemilliseconds()",
-      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
-      "label": "EnhancedAnalyticsView.tsx",
-      "norm_label": "enhancedanalyticsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L1"
     },
     {
@@ -54597,6 +54717,42 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "analyticsusers_analyticsusers",
+      "label": "AnalyticsUsers()",
+      "norm_label": "analyticsusers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
+      "label": "AnalyticsUsers.tsx",
+      "norm_label": "analyticsusers.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "enhancedanalyticsview_getdaterangemilliseconds",
+      "label": "getDateRangeMilliseconds()",
+      "norm_label": "getdaterangemilliseconds()",
+      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
+      "label": "EnhancedAnalyticsView.tsx",
+      "norm_label": "enhancedanalyticsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
       "norm_label": "storeinsights.tsx",
@@ -54604,7 +54760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 422,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -54613,7 +54769,7 @@
       "source_location": "L66"
     },
     {
-      "community": 421,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -54622,7 +54778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 423,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -54631,7 +54787,7 @@
       "source_location": "L18"
     },
     {
-      "community": 422,
+      "community": 424,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -54640,7 +54796,7 @@
       "source_location": "L6"
     },
     {
-      "community": 422,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -54649,7 +54805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 425,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -54658,7 +54814,7 @@
       "source_location": "L10"
     },
     {
-      "community": 423,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -54667,7 +54823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 426,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -54676,7 +54832,7 @@
       "source_location": "L27"
     },
     {
-      "community": 424,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -54685,7 +54841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -54694,7 +54850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 427,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -54703,7 +54859,7 @@
       "source_location": "L12"
     },
     {
-      "community": 426,
+      "community": 428,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -54712,7 +54868,7 @@
       "source_location": "L3"
     },
     {
-      "community": 426,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -54721,7 +54877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 429,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -54730,48 +54886,12 @@
       "source_location": "L5"
     },
     {
-      "community": 427,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "bulkoperationsfilters_handleloadproducts",
-      "label": "handleLoadProducts()",
-      "norm_label": "handleloadproducts()",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
-      "label": "BulkOperationsFilters.tsx",
-      "norm_label": "bulkoperationsfilters.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "bulkoperationspreview_test_makerow",
-      "label": "makeRow()",
-      "norm_label": "makerow()",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
-      "label": "BulkOperationsPreview.test.tsx",
-      "norm_label": "bulkoperationspreview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L1"
     },
     {
@@ -54867,6 +54987,42 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "bulkoperationsfilters_handleloadproducts",
+      "label": "handleLoadProducts()",
+      "norm_label": "handleloadproducts()",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
+      "label": "BulkOperationsFilters.tsx",
+      "norm_label": "bulkoperationsfilters.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "bulkoperationspreview_test_makerow",
+      "label": "makeRow()",
+      "norm_label": "makerow()",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
+      "label": "BulkOperationsPreview.test.tsx",
+      "norm_label": "bulkoperationspreview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
       "norm_label": "formatprice()",
@@ -54874,7 +55030,7 @@
       "source_location": "L50"
     },
     {
-      "community": 430,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -54883,7 +55039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 433,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -54892,7 +55048,7 @@
       "source_location": "L13"
     },
     {
-      "community": 431,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -54901,7 +55057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 434,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -54910,7 +55066,7 @@
       "source_location": "L11"
     },
     {
-      "community": 432,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -54919,7 +55075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -54928,7 +55084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 435,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -54937,7 +55093,7 @@
       "source_location": "L7"
     },
     {
-      "community": 434,
+      "community": 436,
       "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
@@ -54946,7 +55102,7 @@
       "source_location": "L32"
     },
     {
-      "community": 434,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -54955,7 +55111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 437,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -54964,7 +55120,7 @@
       "source_location": "L29"
     },
     {
-      "community": 435,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -54973,7 +55129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 438,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -54982,7 +55138,7 @@
       "source_location": "L37"
     },
     {
-      "community": 436,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -54991,7 +55147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 439,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -55000,49 +55156,13 @@
       "source_location": "L25"
     },
     {
-      "community": 437,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
       "norm_label": "home.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "landingpagereelversion_handleupdateconfig",
-      "label": "handleUpdateConfig()",
-      "norm_label": "handleupdateconfig()",
-      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
-      "label": "LandingPageReelVersion.tsx",
-      "norm_label": "landingpagereelversion.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
-      "label": "ShopLookDialog.tsx",
-      "norm_label": "shoplookdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "shoplookdialog_handleaddfeatureditem",
-      "label": "handleAddFeaturedItem()",
-      "norm_label": "handleaddfeatureditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
-      "source_location": "L35"
     },
     {
       "community": 44,
@@ -55137,6 +55257,42 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "landingpagereelversion_handleupdateconfig",
+      "label": "handleUpdateConfig()",
+      "norm_label": "handleupdateconfig()",
+      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
+      "label": "LandingPageReelVersion.tsx",
+      "norm_label": "landingpagereelversion.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
+      "label": "ShopLookDialog.tsx",
+      "norm_label": "shoplookdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "shoplookdialog_handleaddfeatureditem",
+      "label": "handleAddFeaturedItem()",
+      "norm_label": "handleaddfeatureditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
       "norm_label": "shoplookimageuploader.tsx",
@@ -55144,7 +55300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 442,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -55153,7 +55309,7 @@
       "source_location": "L28"
     },
     {
-      "community": 441,
+      "community": 443,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -55162,7 +55318,7 @@
       "source_location": "L11"
     },
     {
-      "community": 441,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -55171,7 +55327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 444,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -55180,7 +55336,7 @@
       "source_location": "L13"
     },
     {
-      "community": 442,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -55189,7 +55345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 445,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -55198,7 +55354,7 @@
       "source_location": "L41"
     },
     {
-      "community": 443,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -55207,7 +55363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 446,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -55216,7 +55372,7 @@
       "source_location": "L33"
     },
     {
-      "community": 444,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -55225,7 +55381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 447,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -55234,7 +55390,7 @@
       "source_location": "L68"
     },
     {
-      "community": 445,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -55243,7 +55399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 448,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -55252,7 +55408,7 @@
       "source_location": "L35"
     },
     {
-      "community": 446,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -55261,7 +55417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -55270,49 +55426,13 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 449,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
       "norm_label": "handlerefundorder()",
       "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
       "source_location": "L79"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
-      "label": "useGetActiveOnlineOrder.ts",
-      "norm_label": "usegetactiveonlineorder.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "usegetactiveonlineorder_usegetactiveonlineorder",
-      "label": "useGetActiveOnlineOrder()",
-      "norm_label": "usegetactiveonlineorder()",
-      "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "data_table_toolbar_handleclearfilters",
-      "label": "handleClearFilters()",
-      "norm_label": "handleclearfilters()",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
-      "source_location": "L34"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
     },
     {
       "community": 45,
@@ -55407,6 +55527,42 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
+      "label": "useGetActiveOnlineOrder.ts",
+      "norm_label": "usegetactiveonlineorder.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "usegetactiveonlineorder_usegetactiveonlineorder",
+      "label": "useGetActiveOnlineOrder()",
+      "norm_label": "usegetactiveonlineorder()",
+      "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "data_table_toolbar_handleclearfilters",
+      "label": "handleClearFilters()",
+      "norm_label": "handleclearfilters()",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
+      "source_location": "L34"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
       "norm_label": "if()",
@@ -55414,7 +55570,7 @@
       "source_location": "L89"
     },
     {
-      "community": 450,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -55423,7 +55579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 453,
       "file_type": "code",
       "id": "cashierview_cashierview",
       "label": "CashierView()",
@@ -55432,7 +55588,7 @@
       "source_location": "L8"
     },
     {
-      "community": 451,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -55441,7 +55597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 454,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -55450,7 +55606,7 @@
       "source_location": "L5"
     },
     {
-      "community": 452,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -55459,7 +55615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 455,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -55468,7 +55624,7 @@
       "source_location": "L7"
     },
     {
-      "community": 453,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -55477,7 +55633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -55486,7 +55642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -55495,7 +55651,7 @@
       "source_location": "L13"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -55504,7 +55660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
@@ -55513,7 +55669,7 @@
       "source_location": "L35"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -55522,7 +55678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -55531,7 +55687,7 @@
       "source_location": "L3"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -55540,49 +55696,13 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
       "norm_label": "productcard()",
       "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
-      "label": "ProductEntry.tsx",
-      "norm_label": "productentry.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "productentry_handleclearsearch",
-      "label": "handleClearSearch()",
-      "norm_label": "handleclearsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L86"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
-      "label": "SessionDemo.tsx",
-      "norm_label": "sessiondemo.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "sessiondemo_sessiondemo",
-      "label": "SessionDemo()",
-      "norm_label": "sessiondemo()",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
-      "source_location": "L15"
     },
     {
       "community": 46,
@@ -55677,6 +55797,42 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
+      "label": "ProductEntry.tsx",
+      "norm_label": "productentry.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "productentry_handleclearsearch",
+      "label": "handleClearSearch()",
+      "norm_label": "handleclearsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L86"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
+      "label": "SessionDemo.tsx",
+      "norm_label": "sessiondemo.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "sessiondemo_sessiondemo",
+      "label": "SessionDemo()",
+      "norm_label": "sessiondemo()",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
       "norm_label": "totalsdisplay.tsx",
@@ -55684,7 +55840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 462,
       "file_type": "code",
       "id": "totalsdisplay_totalsdisplay",
       "label": "TotalsDisplay()",
@@ -55693,7 +55849,7 @@
       "source_location": "L14"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -55702,7 +55858,7 @@
       "source_location": "L18"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -55711,7 +55867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -55720,7 +55876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -55729,7 +55885,7 @@
       "source_location": "L8"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -55738,7 +55894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
@@ -55747,7 +55903,7 @@
       "source_location": "L8"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -55756,7 +55912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
@@ -55765,7 +55921,7 @@
       "source_location": "L22"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
@@ -55774,7 +55930,7 @@
       "source_location": "L14"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -55783,7 +55939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -55792,7 +55948,7 @@
       "source_location": "L6"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -55801,7 +55957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -55810,49 +55966,13 @@
       "source_location": "L38"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
       "norm_label": "imagesview.tsx",
       "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
-      "label": "SKUSelector.tsx",
-      "norm_label": "skuselector.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "skuselector_skuselector",
-      "label": "SKUSelector()",
-      "norm_label": "skuselector()",
-      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_actions_tsx",
-      "label": "product-actions.tsx",
-      "norm_label": "product-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "product_actions_usedeleteproduct",
-      "label": "useDeleteProduct()",
-      "norm_label": "usedeleteproduct()",
-      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
-      "source_location": "L6"
     },
     {
       "community": 47,
@@ -55947,6 +56067,42 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
+      "label": "SKUSelector.tsx",
+      "norm_label": "skuselector.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "skuselector_skuselector",
+      "label": "SKUSelector()",
+      "norm_label": "skuselector()",
+      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_actions_tsx",
+      "label": "product-actions.tsx",
+      "norm_label": "product-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "product_actions_usedeleteproduct",
+      "label": "useDeleteProduct()",
+      "norm_label": "usedeleteproduct()",
+      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
       "norm_label": "productsview.tsx",
@@ -55954,7 +56110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 472,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -55963,7 +56119,7 @@
       "source_location": "L5"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -55972,7 +56128,7 @@
       "source_location": "L17"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -55981,7 +56137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -55990,7 +56146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -55999,7 +56155,7 @@
       "source_location": "L4"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -56008,7 +56164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -56017,7 +56173,7 @@
       "source_location": "L84"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -56026,7 +56182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -56035,7 +56191,7 @@
       "source_location": "L22"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -56044,7 +56200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -56053,7 +56209,7 @@
       "source_location": "L9"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -56062,7 +56218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -56071,7 +56227,7 @@
       "source_location": "L23"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -56080,48 +56236,12 @@
       "source_location": "L5"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
       "norm_label": "discounttypetogglegroup.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
-      "label": "PromoCodeSpanToggleGroup.tsx",
-      "norm_label": "promocodespantogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "promocodespantogglegroup_promocodespantogglegroup",
-      "label": "PromoCodeSpanToggleGroup()",
-      "norm_label": "promocodespantogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "capturedemails_capturedemails",
-      "label": "CapturedEmails()",
-      "norm_label": "capturedemails()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
-      "label": "CapturedEmails.tsx",
-      "norm_label": "capturedemails.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
       "source_location": "L1"
     },
     {
@@ -56217,6 +56337,42 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
+      "label": "PromoCodeSpanToggleGroup.tsx",
+      "norm_label": "promocodespantogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "promocodespantogglegroup_promocodespantogglegroup",
+      "label": "PromoCodeSpanToggleGroup()",
+      "norm_label": "promocodespantogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "capturedemails_capturedemails",
+      "label": "CapturedEmails()",
+      "norm_label": "capturedemails()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
+      "label": "CapturedEmails.tsx",
+      "norm_label": "capturedemails.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
       "norm_label": "promo-code-modal.tsx",
@@ -56224,7 +56380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 482,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -56233,7 +56389,7 @@
       "source_location": "L29"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -56242,7 +56398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -56251,7 +56407,7 @@
       "source_location": "L20"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -56260,7 +56416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -56269,7 +56425,7 @@
       "source_location": "L171"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -56278,7 +56434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -56287,7 +56443,7 @@
       "source_location": "L52"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -56296,7 +56452,7 @@
       "source_location": "L29"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -56305,7 +56461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -56314,7 +56470,7 @@
       "source_location": "L3"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -56323,7 +56479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -56332,7 +56488,7 @@
       "source_location": "L4"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -56341,7 +56497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -56350,48 +56506,12 @@
       "source_location": "L4"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
       "norm_label": "notfoundview.tsx",
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "contactview_contactview",
-      "label": "ContactView()",
-      "norm_label": "contactview()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
-      "label": "ContactView.tsx",
-      "norm_label": "contactview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "header_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
-      "label": "Header.tsx",
-      "norm_label": "header.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1"
     },
     {
@@ -56478,6 +56598,42 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "contactview_contactview",
+      "label": "ContactView()",
+      "norm_label": "contactview()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
+      "label": "ContactView.tsx",
+      "norm_label": "contactview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "header_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
+      "label": "Header.tsx",
+      "norm_label": "header.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
       "norm_label": "maintenanceview()",
@@ -56485,7 +56641,7 @@
       "source_location": "L13"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -56494,7 +56650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -56503,7 +56659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -56512,7 +56668,7 @@
       "source_location": "L25"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -56521,7 +56677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -56530,7 +56686,7 @@
       "source_location": "L19"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -56539,7 +56695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -56548,7 +56704,7 @@
       "source_location": "L63"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -56557,7 +56713,7 @@
       "source_location": "L7"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -56566,7 +56722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -56575,7 +56731,7 @@
       "source_location": "L25"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -56584,7 +56740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -56593,7 +56749,7 @@
       "source_location": "L15"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -56602,7 +56758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -56611,48 +56767,12 @@
       "source_location": "L21"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
       "norm_label": "copy-wrapper.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "date_time_picker_datetimepicker",
-      "label": "DateTimePicker()",
-      "norm_label": "datetimepicker()",
-      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
-      "label": "date-time-picker.tsx",
-      "norm_label": "date-time-picker.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "label_label",
-      "label": "Label()",
-      "norm_label": "label()",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
       "source_location": "L1"
     },
     {
@@ -56991,6 +57111,42 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "date_time_picker_datetimepicker",
+      "label": "DateTimePicker()",
+      "norm_label": "datetimepicker()",
+      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
+      "label": "date-time-picker.tsx",
+      "norm_label": "date-time-picker.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "label_label",
+      "label": "Label()",
+      "norm_label": "label()",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
       "norm_label": "custommodal()",
@@ -56998,7 +57154,7 @@
       "source_location": "L25"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -57007,7 +57163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -57016,7 +57172,7 @@
       "source_location": "L49"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -57025,7 +57181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -57034,7 +57190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -57043,7 +57199,7 @@
       "source_location": "L63"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -57052,7 +57208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -57061,7 +57217,7 @@
       "source_location": "L5"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -57070,7 +57226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -57079,7 +57235,7 @@
       "source_location": "L12"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -57088,7 +57244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -57097,7 +57253,7 @@
       "source_location": "L15"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -57106,7 +57262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -57115,7 +57271,7 @@
       "source_location": "L3"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -57124,48 +57280,12 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
       "norm_label": "webpimage()",
       "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "bagitems_bagitems",
-      "label": "BagItems()",
-      "norm_label": "bagitems()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
-      "label": "BagItems.tsx",
-      "norm_label": "bagitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "bagitemsview_bagitemsview",
-      "label": "BagItemsView()",
-      "norm_label": "bagitemsview()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
-      "label": "BagItemsView.tsx",
-      "norm_label": "bagitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
       "source_location": "L1"
     },
     {
@@ -57252,6 +57372,42 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "bagitems_bagitems",
+      "label": "BagItems()",
+      "norm_label": "bagitems()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
+      "label": "BagItems.tsx",
+      "norm_label": "bagitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "bagitemsview_bagitemsview",
+      "label": "BagItemsView()",
+      "norm_label": "bagitemsview()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
+      "label": "BagItemsView.tsx",
+      "norm_label": "bagitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
       "norm_label": "bags()",
@@ -57259,7 +57415,7 @@
       "source_location": "L4"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -57268,7 +57424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -57277,7 +57433,7 @@
       "source_location": "L110"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -57286,7 +57442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -57295,7 +57451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -57304,7 +57460,7 @@
       "source_location": "L13"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -57313,7 +57469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -57322,7 +57478,7 @@
       "source_location": "L7"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -57331,7 +57487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -57340,7 +57496,7 @@
       "source_location": "L11"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -57349,7 +57505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -57358,7 +57514,7 @@
       "source_location": "L7"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -57367,7 +57523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -57376,7 +57532,7 @@
       "source_location": "L45"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -57385,49 +57541,13 @@
       "source_location": "L13"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
       "norm_label": "customerjourneystage.tsx",
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
-      "label": "use-image-upload.ts",
-      "norm_label": "use-image-upload.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "use_image_upload_useimageupload",
-      "label": "useImageUpload()",
-      "norm_label": "useimageupload()",
-      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
-      "label": "use-mobile.tsx",
-      "norm_label": "use-mobile.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "use_mobile_useismobile",
-      "label": "useIsMobile()",
-      "norm_label": "useismobile()",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L5"
     },
     {
       "community": 52,
@@ -57513,6 +57633,42 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
+      "label": "use-image-upload.ts",
+      "norm_label": "use-image-upload.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "use_image_upload_useimageupload",
+      "label": "useImageUpload()",
+      "norm_label": "useimageupload()",
+      "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
+      "label": "use-mobile.tsx",
+      "norm_label": "use-mobile.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "use_mobile_useismobile",
+      "label": "useIsMobile()",
+      "norm_label": "useismobile()",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
       "norm_label": "use-navigate-back.ts",
@@ -57520,7 +57676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 520,
+      "community": 522,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -57529,7 +57685,7 @@
       "source_location": "L5"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -57538,7 +57694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -57547,7 +57703,7 @@
       "source_location": "L7"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -57556,7 +57712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -57565,7 +57721,7 @@
       "source_location": "L9"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -57574,7 +57730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -57583,7 +57739,7 @@
       "source_location": "L6"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -57592,7 +57748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -57601,7 +57757,7 @@
       "source_location": "L168"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -57610,7 +57766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -57619,7 +57775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -57628,7 +57784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -57637,7 +57793,7 @@
       "source_location": "L6"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -57646,49 +57802,13 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
       "norm_label": "usedebounce()",
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
-      "label": "useExpenseOperations.ts",
-      "norm_label": "useexpenseoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "useexpenseoperations_useexpenseoperations",
-      "label": "useExpenseOperations()",
-      "norm_label": "useexpenseoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
-      "label": "useGetActiveProduct.ts",
-      "norm_label": "usegetactiveproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "usegetactiveproduct_usegetactiveproduct",
-      "label": "useGetActiveProduct()",
-      "norm_label": "usegetactiveproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L6"
     },
     {
       "community": 53,
@@ -57774,6 +57894,42 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
+      "label": "useExpenseOperations.ts",
+      "norm_label": "useexpenseoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "useexpenseoperations_useexpenseoperations",
+      "label": "useExpenseOperations()",
+      "norm_label": "useexpenseoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
+      "label": "useGetActiveProduct.ts",
+      "norm_label": "usegetactiveproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "usegetactiveproduct_usegetactiveproduct",
+      "label": "useGetActiveProduct()",
+      "norm_label": "usegetactiveproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
       "norm_label": "usegetautheduser.ts",
@@ -57781,7 +57937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 532,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -57790,7 +57946,7 @@
       "source_location": "L4"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -57799,7 +57955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -57808,7 +57964,7 @@
       "source_location": "L5"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -57817,7 +57973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -57826,7 +57982,7 @@
       "source_location": "L5"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -57835,7 +57991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -57844,7 +58000,7 @@
       "source_location": "L4"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -57853,7 +58009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -57862,7 +58018,7 @@
       "source_location": "L5"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -57871,7 +58027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -57880,7 +58036,7 @@
       "source_location": "L5"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -57889,7 +58045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -57898,7 +58054,7 @@
       "source_location": "L8"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -57907,49 +58063,13 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
       "norm_label": "usepermissions()",
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L13"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useprint_ts",
-      "label": "usePrint.ts",
-      "norm_label": "useprint.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "useprint_useprint",
-      "label": "usePrint()",
-      "norm_label": "useprint()",
-      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
-      "label": "useProductSearchResults.ts",
-      "norm_label": "useproductsearchresults.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "useproductsearchresults_useproductsearchresults",
-      "label": "useProductSearchResults()",
-      "norm_label": "useproductsearchresults()",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L26"
     },
     {
       "community": 54,
@@ -58035,6 +58155,42 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useprint_ts",
+      "label": "usePrint.ts",
+      "norm_label": "useprint.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "useprint_useprint",
+      "label": "usePrint()",
+      "norm_label": "useprint()",
+      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
+      "label": "useProductSearchResults.ts",
+      "norm_label": "useproductsearchresults.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "useproductsearchresults_useproductsearchresults",
+      "label": "useProductSearchResults()",
+      "norm_label": "useproductsearchresults()",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
       "norm_label": "useproductwithnoimagesnotification.tsx",
@@ -58042,7 +58198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 542,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -58051,7 +58207,7 @@
       "source_location": "L7"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -58060,7 +58216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -58069,7 +58225,7 @@
       "source_location": "L17"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -58078,7 +58234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -58087,7 +58243,7 @@
       "source_location": "L12"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -58096,7 +58252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -58105,7 +58261,7 @@
       "source_location": "L12"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -58114,7 +58270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -58123,7 +58279,7 @@
       "source_location": "L5"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -58132,7 +58288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -58141,7 +58297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -58150,7 +58306,7 @@
       "source_location": "L5"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
@@ -58159,7 +58315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
@@ -58168,49 +58324,13 @@
       "source_location": "L6"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
       "norm_label": "bootstrapregister.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "holdsession_holdsession",
-      "label": "holdSession()",
-      "norm_label": "holdsession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
-      "label": "holdSession.ts",
-      "norm_label": "holdsession.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
-      "label": "startSession.ts",
-      "norm_label": "startsession.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "startsession_startsession",
-      "label": "startSession()",
-      "norm_label": "startsession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts",
-      "source_location": "L5"
     },
     {
       "community": 55,
@@ -58296,6 +58416,42 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "holdsession_holdsession",
+      "label": "holdSession()",
+      "norm_label": "holdsession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
+      "label": "holdSession.ts",
+      "norm_label": "holdsession.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
+      "label": "startSession.ts",
+      "norm_label": "startsession.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "startsession_startsession",
+      "label": "startSession()",
+      "norm_label": "startsession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
       "norm_label": "calculatecarttotals()",
@@ -58303,7 +58459,7 @@
       "source_location": "L10"
     },
     {
-      "community": 550,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -58312,7 +58468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -58321,7 +58477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -58330,7 +58486,7 @@
       "source_location": "L12"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "closeouts_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -58339,7 +58495,7 @@
       "source_location": "L10"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_closeouts_index_tsx",
       "label": "closeouts.index.tsx",
@@ -58348,7 +58504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -58357,7 +58513,7 @@
       "source_location": "L6"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
@@ -58366,7 +58522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
@@ -58375,7 +58531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -58384,7 +58540,7 @@
       "source_location": "L6"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
@@ -58393,7 +58549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -58402,7 +58558,7 @@
       "source_location": "L6"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -58411,7 +58567,7 @@
       "source_location": "L13"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -58420,7 +58576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -58429,49 +58585,13 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
       "norm_label": "routecomponent()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "index_index",
-      "label": "Index()",
-      "norm_label": "index()",
-      "source_file": "packages/athena-webapp/src/routes/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "layout_index_athenaloginreadyview",
-      "label": "AthenaLoginReadyView()",
-      "norm_label": "athenaloginreadyview()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
-      "label": "_layout.index.tsx",
-      "norm_label": "_layout.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 56,
@@ -58557,6 +58677,42 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "index_index",
+      "label": "Index()",
+      "norm_label": "index()",
+      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "layout_index_athenaloginreadyview",
+      "label": "AthenaLoginReadyView()",
+      "norm_label": "athenaloginreadyview()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
+      "label": "_layout.index.tsx",
+      "norm_label": "_layout.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
       "norm_label": "organizationsettingsaccordion()",
@@ -58564,7 +58720,7 @@
       "source_location": "L13"
     },
     {
-      "community": 560,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -58573,7 +58729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -58582,7 +58738,7 @@
       "source_location": "L5"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -58591,7 +58747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -58600,7 +58756,7 @@
       "source_location": "L17"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -58609,7 +58765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -58618,7 +58774,7 @@
       "source_location": "L15"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -58627,7 +58783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -58636,7 +58792,7 @@
       "source_location": "L12"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -58645,7 +58801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -58654,7 +58810,7 @@
       "source_location": "L5"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -58663,7 +58819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -58672,7 +58828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -58681,7 +58837,7 @@
       "source_location": "L13"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -58690,49 +58846,13 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
       "norm_label": "sheetshowcase()",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
-      "label": "Tooltip.stories.tsx",
-      "norm_label": "tooltip.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "tooltip_stories_tooltipshowcase",
-      "label": "TooltipShowcase()",
-      "norm_label": "tooltipshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "overview_stories_templatesoverview",
-      "label": "TemplatesOverview()",
-      "norm_label": "templatesoverview()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
-      "source_location": "L1"
     },
     {
       "community": 57,
@@ -58818,6 +58938,42 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
+      "label": "Tooltip.stories.tsx",
+      "norm_label": "tooltip.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "tooltip_stories_tooltipshowcase",
+      "label": "TooltipShowcase()",
+      "norm_label": "tooltipshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "overview_stories_templatesoverview",
+      "label": "TemplatesOverview()",
+      "norm_label": "templatesoverview()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
       "norm_label": "storybook-theme-decorator.tsx",
@@ -58825,7 +58981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 572,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -58834,7 +58990,7 @@
       "source_location": "L17"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -58843,7 +58999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -58852,7 +59008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -58861,7 +59017,7 @@
       "source_location": "L4"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -58870,7 +59026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -58879,7 +59035,7 @@
       "source_location": "L27"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -58888,7 +59044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -58897,7 +59053,7 @@
       "source_location": "L4"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -58906,7 +59062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -58915,7 +59071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -58924,7 +59080,7 @@
       "source_location": "L5"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -58933,7 +59089,7 @@
       "source_location": "L10"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -58942,7 +59098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -58951,49 +59107,13 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
       "norm_label": "productcardloadingskeleton()",
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L10"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "auth_authcomponent",
-      "label": "AuthComponent()",
-      "norm_label": "authcomponent()",
-      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
-      "label": "Auth.tsx",
-      "norm_label": "auth.tsx",
-      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "bagsummary_tobagsummaryitems",
-      "label": "toBagSummaryItems()",
-      "norm_label": "tobagsummaryitems()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
-      "source_location": "L39"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
-      "label": "BagSummary.tsx",
-      "norm_label": "bagsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
-      "source_location": "L1"
     },
     {
       "community": 58,
@@ -59070,6 +59190,42 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "auth_authcomponent",
+      "label": "AuthComponent()",
+      "norm_label": "authcomponent()",
+      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
+      "label": "Auth.tsx",
+      "norm_label": "auth.tsx",
+      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "bagsummary_tobagsummaryitems",
+      "label": "toBagSummaryItems()",
+      "norm_label": "tobagsummaryitems()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
+      "label": "BagSummary.tsx",
+      "norm_label": "bagsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
       "norm_label": "checkoutform()",
@@ -59077,7 +59233,7 @@
       "source_location": "L18"
     },
     {
-      "community": 580,
+      "community": 582,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -59086,7 +59242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -59095,7 +59251,7 @@
       "source_location": "L71"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -59104,7 +59260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -59113,7 +59269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -59122,7 +59278,7 @@
       "source_location": "L12"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -59131,7 +59287,7 @@
       "source_location": "L6"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -59140,7 +59296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -59149,7 +59305,7 @@
       "source_location": "L18"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -59158,7 +59314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -59167,7 +59323,7 @@
       "source_location": "L10"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -59176,7 +59332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -59185,7 +59341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -59194,7 +59350,7 @@
       "source_location": "L8"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -59203,49 +59359,13 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
       "norm_label": "paymentsection()",
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
       "source_location": "L27"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "deliveryfees_calculatedeliveryfee",
-      "label": "calculateDeliveryFee()",
-      "norm_label": "calculatedeliveryfee()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
-      "label": "deliveryFees.ts",
-      "norm_label": "deliveryfees.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "derivecheckoutstate_derivecheckoutstate",
-      "label": "deriveCheckoutState()",
-      "norm_label": "derivecheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
-      "label": "deriveCheckoutState.ts",
-      "norm_label": "derivecheckoutstate.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L1"
     },
     {
       "community": 59,
@@ -59322,6 +59442,42 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "deliveryfees_calculatedeliveryfee",
+      "label": "calculateDeliveryFee()",
+      "norm_label": "calculatedeliveryfee()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
+      "label": "deliveryFees.ts",
+      "norm_label": "deliveryfees.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "derivecheckoutstate_derivecheckoutstate",
+      "label": "deriveCheckoutState()",
+      "norm_label": "derivecheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
+      "label": "deriveCheckoutState.ts",
+      "norm_label": "derivecheckoutstate.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
       "norm_label": "getissuemap()",
@@ -59329,7 +59485,7 @@
       "source_location": "L8"
     },
     {
-      "community": 590,
+      "community": 592,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -59338,7 +59494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -59347,7 +59503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -59356,7 +59512,7 @@
       "source_location": "L12"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -59365,7 +59521,7 @@
       "source_location": "L77"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -59374,7 +59530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 595,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -59383,7 +59539,7 @@
       "source_location": "L161"
     },
     {
-      "community": 593,
+      "community": 595,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -59392,7 +59548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 596,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -59401,7 +59557,7 @@
       "source_location": "L3"
     },
     {
-      "community": 594,
+      "community": 596,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -59410,7 +59566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 597,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -59419,7 +59575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 597,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -59428,7 +59584,7 @@
       "source_location": "L4"
     },
     {
-      "community": 596,
+      "community": 598,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -59437,7 +59593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 598,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -59446,7 +59602,7 @@
       "source_location": "L14"
     },
     {
-      "community": 597,
+      "community": 599,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -59455,48 +59611,12 @@
       "source_location": "L27"
     },
     {
-      "community": 597,
+      "community": 599,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
       "norm_label": "filter.tsx",
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "bestsellerssection_bestsellerssection",
-      "label": "BestSellersSection()",
-      "norm_label": "bestsellerssection()",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
-      "label": "BestSellersSection.tsx",
-      "norm_label": "bestsellerssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "homepagecontent_resolvehomepagecontent",
-      "label": "resolveHomepageContent()",
-      "norm_label": "resolvehomepagecontent()",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
-      "label": "homePageContent.ts",
-      "norm_label": "homepagecontent.ts",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
       "source_location": "L1"
     },
     {
@@ -59808,6 +59928,42 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "bestsellerssection_bestsellerssection",
+      "label": "BestSellersSection()",
+      "norm_label": "bestsellerssection()",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
+      "label": "BestSellersSection.tsx",
+      "norm_label": "bestsellerssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "homepagecontent_resolvehomepagecontent",
+      "label": "resolveHomepageContent()",
+      "norm_label": "resolvehomepagecontent()",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
+      "label": "homePageContent.ts",
+      "norm_label": "homepagecontent.ts",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
       "norm_label": "handleonlinkclick()",
@@ -59815,7 +59971,7 @@
       "source_location": "L47"
     },
     {
-      "community": 600,
+      "community": 602,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -59824,7 +59980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 603,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -59833,7 +59989,7 @@
       "source_location": "L7"
     },
     {
-      "community": 601,
+      "community": 603,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -59842,7 +59998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 604,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -59851,7 +60007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 604,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -59860,7 +60016,7 @@
       "source_location": "L17"
     },
     {
-      "community": 603,
+      "community": 605,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -59869,7 +60025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 605,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -59878,7 +60034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 606,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -59887,7 +60043,7 @@
       "source_location": "L12"
     },
     {
-      "community": 604,
+      "community": 606,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -59896,7 +60052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 607,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -59905,7 +60061,7 @@
       "source_location": "L7"
     },
     {
-      "community": 605,
+      "community": 607,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -59914,7 +60070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 608,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -59923,7 +60079,7 @@
       "source_location": "L45"
     },
     {
-      "community": 606,
+      "community": 608,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -59932,7 +60088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 609,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -59941,49 +60097,13 @@
       "source_location": "L5"
     },
     {
-      "community": 607,
+      "community": 609,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
       "norm_label": "onsaleproduct.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
-      "label": "ProductActions.tsx",
-      "norm_label": "productactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "productactions_productactions",
-      "label": "ProductActions()",
-      "norm_label": "productactions()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
-      "label": "ProductAttributes.tsx",
-      "norm_label": "productattributes.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "productattributes_productattributes",
-      "label": "ProductAttributes()",
-      "norm_label": "productattributes()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
-      "source_location": "L3"
     },
     {
       "community": 61,
@@ -60060,6 +60180,42 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
+      "label": "ProductActions.tsx",
+      "norm_label": "productactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "productactions_productactions",
+      "label": "ProductActions()",
+      "norm_label": "productactions()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
+      "label": "ProductAttributes.tsx",
+      "norm_label": "productattributes.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "productattributes_productattributes",
+      "label": "ProductAttributes()",
+      "norm_label": "productattributes()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
       "norm_label": "productpage.tsx",
@@ -60067,7 +60223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 612,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -60076,7 +60232,7 @@
       "source_location": "L78"
     },
     {
-      "community": 611,
+      "community": 613,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -60085,7 +60241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 613,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -60094,7 +60250,7 @@
       "source_location": "L87"
     },
     {
-      "community": 612,
+      "community": 614,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -60103,7 +60259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 614,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -60112,7 +60268,7 @@
       "source_location": "L8"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -60121,7 +60277,7 @@
       "source_location": "L12"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -60130,7 +60286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -60139,7 +60295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -60148,7 +60304,7 @@
       "source_location": "L18"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -60157,7 +60313,7 @@
       "source_location": "L10"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -60166,7 +60322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -60175,7 +60331,7 @@
       "source_location": "L11"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -60184,7 +60340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -60193,49 +60349,13 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
       "norm_label": "handleclaimpoints()",
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L59"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
-      "label": "RewardsPanel.tsx",
-      "norm_label": "rewardspanel.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "rewardspanel_handleredeemreward",
-      "label": "handleRedeemReward()",
-      "norm_label": "handleredeemreward()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "bagitem_bagitem",
-      "label": "BagItem()",
-      "norm_label": "bagitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
-      "label": "BagItem.tsx",
-      "norm_label": "bagitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
-      "source_location": "L1"
     },
     {
       "community": 62,
@@ -60312,6 +60432,42 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
+      "label": "RewardsPanel.tsx",
+      "norm_label": "rewardspanel.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "rewardspanel_handleredeemreward",
+      "label": "handleRedeemReward()",
+      "norm_label": "handleredeemreward()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "bagitem_bagitem",
+      "label": "BagItem()",
+      "norm_label": "bagitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
+      "label": "BagItem.tsx",
+      "norm_label": "bagitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
       "norm_label": "checkoutunavailable()",
@@ -60319,7 +60475,7 @@
       "source_location": "L4"
     },
     {
-      "community": 620,
+      "community": 622,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -60328,7 +60484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -60337,7 +60493,7 @@
       "source_location": "L22"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -60346,7 +60502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -60355,7 +60511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -60364,7 +60520,7 @@
       "source_location": "L11"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -60373,7 +60529,7 @@
       "source_location": "L3"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -60382,7 +60538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 626,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -60391,7 +60547,7 @@
       "source_location": "L3"
     },
     {
-      "community": 624,
+      "community": 626,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -60400,7 +60556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 627,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -60409,7 +60565,7 @@
       "source_location": "L9"
     },
     {
-      "community": 625,
+      "community": 627,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -60418,7 +60574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 628,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -60427,7 +60583,7 @@
       "source_location": "L66"
     },
     {
-      "community": 626,
+      "community": 628,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -60436,7 +60592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 629,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -60445,49 +60601,13 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 629,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
       "norm_label": "upsellmodalsuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
       "source_location": "L19"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
-      "label": "WelcomeBackModalSuccess.tsx",
-      "norm_label": "welcomebackmodalsuccess.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
-      "label": "WelcomeBackModalSuccess()",
-      "norm_label": "welcomebackmodalsuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "leavereviewmodalconfig_getmodalconfig",
-      "label": "getModalConfig()",
-      "norm_label": "getmodalconfig()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
-      "label": "leaveReviewModalConfig.tsx",
-      "norm_label": "leavereviewmodalconfig.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
-      "source_location": "L1"
     },
     {
       "community": 63,
@@ -60564,6 +60684,42 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
+      "label": "WelcomeBackModalSuccess.tsx",
+      "norm_label": "welcomebackmodalsuccess.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
+      "label": "WelcomeBackModalSuccess()",
+      "norm_label": "welcomebackmodalsuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "leavereviewmodalconfig_getmodalconfig",
+      "label": "getModalConfig()",
+      "norm_label": "getmodalconfig()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
+      "label": "leaveReviewModalConfig.tsx",
+      "norm_label": "leavereviewmodalconfig.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
       "norm_label": "welcomebackmodalconfig.tsx",
@@ -60571,7 +60727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 630,
+      "community": 632,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -60580,7 +60736,7 @@
       "source_location": "L46"
     },
     {
-      "community": 631,
+      "community": 633,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -60589,7 +60745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 633,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -60598,7 +60754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 634,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -60607,7 +60763,7 @@
       "source_location": "L15"
     },
     {
-      "community": 632,
+      "community": 634,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -60616,7 +60772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 635,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -60625,7 +60781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 635,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -60634,7 +60790,7 @@
       "source_location": "L5"
     },
     {
-      "community": 634,
+      "community": 636,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -60643,7 +60799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 636,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -60652,7 +60808,7 @@
       "source_location": "L14"
     },
     {
-      "community": 635,
+      "community": 637,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -60661,7 +60817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 637,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -60670,7 +60826,7 @@
       "source_location": "L29"
     },
     {
-      "community": 636,
+      "community": 638,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -60679,7 +60835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 638,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -60688,7 +60844,7 @@
       "source_location": "L5"
     },
     {
-      "community": 637,
+      "community": 639,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -60697,49 +60853,13 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 639,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
       "norm_label": "usegetproductquery()",
       "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
-      "label": "useGetProductFilters.ts",
-      "norm_label": "usegetproductfilters.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "usegetproductfilters_usegetproductfilters",
-      "label": "useGetProductFilters()",
-      "norm_label": "usegetproductfilters()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
-      "label": "useGetProductReviews.ts",
-      "norm_label": "usegetproductreviews.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "usegetproductreviews_usegetproductreviewsquery",
-      "label": "useGetProductReviewsQuery()",
-      "norm_label": "usegetproductreviewsquery()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
-      "source_location": "L4"
     },
     {
       "community": 64,
@@ -60816,6 +60936,42 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
+      "label": "useGetProductFilters.ts",
+      "norm_label": "usegetproductfilters.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "usegetproductfilters_usegetproductfilters",
+      "label": "useGetProductFilters()",
+      "norm_label": "usegetproductfilters()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
+      "label": "useGetProductReviews.ts",
+      "norm_label": "usegetproductreviews.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "usegetproductreviews_usegetproductreviewsquery",
+      "label": "useGetProductReviewsQuery()",
+      "norm_label": "usegetproductreviewsquery()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
       "norm_label": "usegetstore.ts",
@@ -60823,7 +60979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 642,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -60832,7 +60988,7 @@
       "source_location": "L4"
     },
     {
-      "community": 641,
+      "community": 643,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -60841,7 +60997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 643,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -60850,7 +61006,7 @@
       "source_location": "L9"
     },
     {
-      "community": 642,
+      "community": 644,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -60859,7 +61015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 644,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -60868,7 +61024,7 @@
       "source_location": "L17"
     },
     {
-      "community": 643,
+      "community": 645,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -60877,7 +61033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 645,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -60886,7 +61042,7 @@
       "source_location": "L5"
     },
     {
-      "community": 644,
+      "community": 646,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -60895,7 +61051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 646,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -60904,7 +61060,7 @@
       "source_location": "L15"
     },
     {
-      "community": 645,
+      "community": 647,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -60913,7 +61069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 647,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -60922,7 +61078,7 @@
       "source_location": "L18"
     },
     {
-      "community": 646,
+      "community": 648,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -60931,7 +61087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 648,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -60940,7 +61096,7 @@
       "source_location": "L9"
     },
     {
-      "community": 647,
+      "community": 649,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -60949,49 +61105,13 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 649,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
       "norm_label": "usepromoalert()",
       "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
       "source_location": "L16"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
-      "label": "useQueryEnabled.ts",
-      "norm_label": "usequeryenabled.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "usequeryenabled_usequeryenabled",
-      "label": "useQueryEnabled()",
-      "norm_label": "usequeryenabled()",
-      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
-      "label": "useRewardsAlert.tsx",
-      "norm_label": "userewardsalert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "userewardsalert_userewardsalert",
-      "label": "useRewardsAlert()",
-      "norm_label": "userewardsalert()",
-      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
-      "source_location": "L11"
     },
     {
       "community": 65,
@@ -61068,6 +61188,42 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
+      "label": "useQueryEnabled.ts",
+      "norm_label": "usequeryenabled.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "usequeryenabled_usequeryenabled",
+      "label": "useQueryEnabled()",
+      "norm_label": "usequeryenabled()",
+      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
+      "label": "useRewardsAlert.tsx",
+      "norm_label": "userewardsalert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "userewardsalert_userewardsalert",
+      "label": "useRewardsAlert()",
+      "norm_label": "userewardsalert()",
+      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
       "norm_label": "usescrolltotop.ts",
@@ -61075,7 +61231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 652,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -61084,7 +61240,7 @@
       "source_location": "L3"
     },
     {
-      "community": 651,
+      "community": 653,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -61093,7 +61249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 653,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -61102,7 +61258,7 @@
       "source_location": "L7"
     },
     {
-      "community": 652,
+      "community": 654,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -61111,7 +61267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 654,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -61120,7 +61276,7 @@
       "source_location": "L4"
     },
     {
-      "community": 653,
+      "community": 655,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -61129,7 +61285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 655,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -61138,7 +61294,7 @@
       "source_location": "L14"
     },
     {
-      "community": 654,
+      "community": 656,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -61147,7 +61303,7 @@
       "source_location": "L4"
     },
     {
-      "community": 654,
+      "community": 656,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -61156,7 +61312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 657,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -61165,7 +61321,7 @@
       "source_location": "L7"
     },
     {
-      "community": 655,
+      "community": 657,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -61174,7 +61330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 658,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -61183,7 +61339,7 @@
       "source_location": "L6"
     },
     {
-      "community": 656,
+      "community": 658,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -61192,7 +61348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 659,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -61201,48 +61357,12 @@
       "source_location": "L10"
     },
     {
-      "community": 657,
+      "community": 659,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
       "norm_label": "checkout.ts",
       "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "inventory_useinventoryqueries",
-      "label": "useInventoryQueries()",
-      "norm_label": "useinventoryqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
-      "label": "inventory.ts",
-      "norm_label": "inventory.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "onlineorder_useonlineorderqueries",
-      "label": "useOnlineOrderQueries()",
-      "norm_label": "useonlineorderqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -61320,6 +61440,42 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "inventory_useinventoryqueries",
+      "label": "useInventoryQueries()",
+      "norm_label": "useinventoryqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
+      "label": "inventory.ts",
+      "norm_label": "inventory.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "onlineorder_useonlineorderqueries",
+      "label": "useOnlineOrderQueries()",
+      "norm_label": "useonlineorderqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
@@ -61327,7 +61483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 660,
+      "community": 662,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -61336,7 +61492,7 @@
       "source_location": "L14"
     },
     {
-      "community": 661,
+      "community": 663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -61345,7 +61501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 663,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -61354,7 +61510,7 @@
       "source_location": "L9"
     },
     {
-      "community": 662,
+      "community": 664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -61363,7 +61519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 664,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -61372,7 +61528,7 @@
       "source_location": "L10"
     },
     {
-      "community": 663,
+      "community": 665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -61381,7 +61537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 665,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -61390,7 +61546,7 @@
       "source_location": "L11"
     },
     {
-      "community": 664,
+      "community": 666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -61399,7 +61555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 666,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -61408,7 +61564,7 @@
       "source_location": "L6"
     },
     {
-      "community": 665,
+      "community": 667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -61417,7 +61573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 667,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -61426,7 +61582,7 @@
       "source_location": "L5"
     },
     {
-      "community": 666,
+      "community": 668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -61435,7 +61591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 668,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -61444,7 +61600,7 @@
       "source_location": "L6"
     },
     {
-      "community": 667,
+      "community": 669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -61453,49 +61609,13 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 669,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
       "norm_label": "buildv2config()",
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
-      "label": "storefrontObservability.test.ts",
-      "norm_label": "storefrontobservability.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "storefrontobservability_test_creatememorystorage",
-      "label": "createMemoryStorage()",
-      "norm_label": "creatememorystorage()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "email_validateemail",
-      "label": "validateEmail()",
-      "norm_label": "validateemail()",
-      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_validations_email_ts",
-      "label": "email.ts",
-      "norm_label": "email.ts",
-      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
-      "source_location": "L1"
     },
     {
       "community": 67,
@@ -61572,6 +61692,42 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
+      "label": "storefrontObservability.test.ts",
+      "norm_label": "storefrontobservability.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "storefrontobservability_test_creatememorystorage",
+      "label": "createMemoryStorage()",
+      "norm_label": "creatememorystorage()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "email_validateemail",
+      "label": "validateEmail()",
+      "norm_label": "validateemail()",
+      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_validations_email_ts",
+      "label": "email.ts",
+      "norm_label": "email.ts",
+      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
       "norm_label": "router.tsx",
@@ -61579,7 +61735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 670,
+      "community": 672,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -61588,7 +61744,7 @@
       "source_location": "L6"
     },
     {
-      "community": 671,
+      "community": 673,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -61597,7 +61753,7 @@
       "source_location": "L13"
     },
     {
-      "community": 671,
+      "community": 673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -61606,7 +61762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 674,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -61615,7 +61771,7 @@
       "source_location": "L8"
     },
     {
-      "community": 672,
+      "community": 674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -61624,7 +61780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 675,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -61633,7 +61789,7 @@
       "source_location": "L14"
     },
     {
-      "community": 673,
+      "community": 675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -61642,7 +61798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 676,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -61651,7 +61807,7 @@
       "source_location": "L13"
     },
     {
-      "community": 674,
+      "community": 676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -61660,7 +61816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -61669,7 +61825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 677,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -61678,7 +61834,7 @@
       "source_location": "L9"
     },
     {
-      "community": 676,
+      "community": 678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -61687,7 +61843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 678,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -61696,7 +61852,7 @@
       "source_location": "L15"
     },
     {
-      "community": 677,
+      "community": 679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -61705,49 +61861,13 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 679,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
       "norm_label": "component()",
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L16"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "layout_layoutcomponent",
-      "label": "LayoutComponent()",
-      "norm_label": "layoutcomponent()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_tsx",
-      "label": "_layout.tsx",
-      "norm_label": "_layout.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "index_homeroute",
-      "label": "HomeRoute()",
-      "norm_label": "homeroute()",
-      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 68,
@@ -61824,6 +61944,42 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "layout_layoutcomponent",
+      "label": "LayoutComponent()",
+      "norm_label": "layoutcomponent()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_tsx",
+      "label": "_layout.tsx",
+      "norm_label": "_layout.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "index_homeroute",
+      "label": "HomeRoute()",
+      "norm_label": "homeroute()",
+      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
       "norm_label": "checkoutcanceledview()",
@@ -61831,7 +61987,7 @@
       "source_location": "L21"
     },
     {
-      "community": 680,
+      "community": 682,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -61840,7 +61996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 683,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -61849,7 +62005,7 @@
       "source_location": "L33"
     },
     {
-      "community": 681,
+      "community": 683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -61858,7 +62014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -61867,7 +62023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 684,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -61876,7 +62032,7 @@
       "source_location": "L193"
     },
     {
-      "community": 683,
+      "community": 685,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -61885,7 +62041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 685,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -61894,7 +62050,7 @@
       "source_location": "L7"
     },
     {
-      "community": 684,
+      "community": 686,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -61903,7 +62059,7 @@
       "source_location": "L10"
     },
     {
-      "community": 684,
+      "community": 686,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -61912,7 +62068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 687,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -61921,7 +62077,7 @@
       "source_location": "L32"
     },
     {
-      "community": 685,
+      "community": 687,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -61930,7 +62086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 688,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -61939,7 +62095,7 @@
       "source_location": "L211"
     },
     {
-      "community": 686,
+      "community": 688,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -61948,7 +62104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 689,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -61957,39 +62113,12 @@
       "source_location": "L85"
     },
     {
-      "community": 687,
+      "community": 689,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
       "norm_label": "sample-app.ts",
       "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "harness_runtime_trends_test_buildreportline",
-      "label": "buildReportLine()",
-      "norm_label": "buildreportline()",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "scripts_harness_runtime_trends_test_ts",
-      "label": "harness-runtime-trends.test.ts",
-      "norm_label": "harness-runtime-trends.test.ts",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_api_d_ts",
-      "label": "api.d.ts",
-      "norm_label": "api.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
       "source_location": "L1"
     },
     {
@@ -62067,6 +62196,33 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "harness_runtime_trends_test_buildreportline",
+      "label": "buildReportLine()",
+      "norm_label": "buildreportline()",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "scripts_harness_runtime_trends_test_ts",
+      "label": "harness-runtime-trends.test.ts",
+      "norm_label": "harness-runtime-trends.test.ts",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_api_d_ts",
+      "label": "api.d.ts",
+      "norm_label": "api.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
       "norm_label": "api.js",
@@ -62074,7 +62230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 693,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -62083,7 +62239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 694,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -62092,7 +62248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -62101,7 +62257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -62110,7 +62266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -62119,7 +62275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -62128,30 +62284,12 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
       "norm_label": "registersessions.test.ts",
       "source_file": "packages/athena-webapp/convex/cashControls/registerSessions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_email_ts",
-      "label": "email.ts",
-      "norm_label": "email.ts",
-      "source_file": "packages/athena-webapp/convex/constants/email.ts",
       "source_location": "L1"
     },
     {
@@ -62445,6 +62583,24 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_email_ts",
+      "label": "email.ts",
+      "norm_label": "email.ts",
+      "source_file": "packages/athena-webapp/convex/constants/email.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
       "norm_label": "ghana.ts",
@@ -62452,7 +62608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -62461,7 +62617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -62470,7 +62626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -62479,7 +62635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -62488,7 +62644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -62497,7 +62653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -62506,30 +62662,12 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
       "norm_label": "env.ts",
       "source_file": "packages/athena-webapp/convex/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts",
       "source_location": "L1"
     },
     {
@@ -62598,6 +62736,24 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
@@ -62605,7 +62761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 713,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -62614,7 +62770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 714,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -62623,7 +62779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 715,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -62632,7 +62788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 716,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
@@ -62641,7 +62797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 717,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
@@ -62650,7 +62806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 718,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
       "label": "stores.ts",
@@ -62659,30 +62815,12 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 719,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
       "label": "subcategories.ts",
       "norm_label": "subcategories.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
       "source_location": "L1"
     },
     {
@@ -62751,6 +62889,24 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
@@ -62758,7 +62914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 723,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
@@ -62767,7 +62923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 724,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
@@ -62776,7 +62932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 725,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
@@ -62785,7 +62941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -62794,7 +62950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
@@ -62803,7 +62959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
       "label": "reviews.ts",
@@ -62812,30 +62968,12 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
-      "label": "security.test.ts",
-      "norm_label": "security.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
       "source_location": "L1"
     },
     {
@@ -62904,6 +63042,24 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
+      "label": "security.test.ts",
+      "norm_label": "security.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 732,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
       "norm_label": "storefront.ts",
@@ -62911,7 +63067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 733,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
@@ -62920,7 +63076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -62929,7 +63085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -62938,7 +63094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -62947,7 +63103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -62956,7 +63112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -62965,30 +63121,12 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
       "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
-      "label": "bestSeller.ts",
-      "norm_label": "bestseller.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.ts",
       "source_location": "L1"
     },
     {
@@ -63057,6 +63195,24 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
+      "label": "bestSeller.ts",
+      "norm_label": "bestseller.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 742,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
       "norm_label": "categories.ts",
@@ -63064,7 +63220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 743,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -63073,7 +63229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -63082,7 +63238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -63091,7 +63247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -63100,7 +63256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -63109,7 +63265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -63118,30 +63274,12 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
       "norm_label": "organizationmembers.ts",
       "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 748,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_organizations_ts",
-      "label": "organizations.ts",
-      "norm_label": "organizations.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_pos_ts",
-      "label": "pos.ts",
-      "norm_label": "pos.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L1"
     },
     {
@@ -63210,6 +63348,24 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_organizations_ts",
+      "label": "organizations.ts",
+      "norm_label": "organizations.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_pos_ts",
+      "label": "pos.ts",
+      "norm_label": "pos.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 752,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
       "norm_label": "poscustomers.ts",
@@ -63217,7 +63373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 753,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -63226,7 +63382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -63235,7 +63391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -63244,7 +63400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -63253,7 +63409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -63262,7 +63418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -63271,30 +63427,12 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
       "norm_label": "storeconfigv2.test.ts",
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 758,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
-      "label": "subcategories.ts",
-      "norm_label": "subcategories.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/subcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_test_ts",
-      "label": "currency.test.ts",
-      "norm_label": "currency.test.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
       "source_location": "L1"
     },
     {
@@ -63363,6 +63501,24 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
+      "label": "subcategories.ts",
+      "norm_label": "subcategories.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/subcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_test_ts",
+      "label": "currency.test.ts",
+      "norm_label": "currency.test.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 762,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
       "norm_label": "storeinsights.ts",
@@ -63370,7 +63526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -63379,7 +63535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -63388,7 +63544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -63397,7 +63553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -63406,7 +63562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -63415,7 +63571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -63424,30 +63580,12 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
       "norm_label": "customerprofiles.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/customerProfiles.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 768,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
-      "label": "inventoryMovements.test.ts",
-      "norm_label": "inventorymovements.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
-      "label": "paymentAllocations.test.ts",
-      "norm_label": "paymentallocations.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.test.ts",
       "source_location": "L1"
     },
     {
@@ -63516,6 +63654,24 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
+      "label": "inventoryMovements.test.ts",
+      "norm_label": "inventorymovements.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
+      "label": "paymentAllocations.test.ts",
+      "norm_label": "paymentallocations.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 772,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
       "norm_label": "staffprofiles.test.ts",
@@ -63523,7 +63679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 773,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -63532,7 +63688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -63541,7 +63697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
@@ -63550,7 +63706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
@@ -63559,7 +63715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -63568,7 +63724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -63577,30 +63733,12 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
       "norm_label": "catalog.ts",
       "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 778,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_customers_ts",
-      "label": "customers.ts",
-      "norm_label": "customers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/customers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_ts",
-      "label": "register.ts",
-      "norm_label": "register.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.ts",
       "source_location": "L1"
     },
     {
@@ -63669,6 +63807,24 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_customers_ts",
+      "label": "customers.ts",
+      "norm_label": "customers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/customers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_register_ts",
+      "label": "register.ts",
+      "norm_label": "register.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 782,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
       "norm_label": "terminals.ts",
@@ -63676,7 +63832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -63685,7 +63841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -63694,7 +63850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -63703,7 +63859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -63712,7 +63868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -63721,7 +63877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -63730,30 +63886,12 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
       "label": "cashier.ts",
       "norm_label": "cashier.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/cashier.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 788,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
-      "label": "color.ts",
-      "norm_label": "color.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
       "source_location": "L1"
     },
     {
@@ -63822,6 +63960,24 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
+      "label": "color.ts",
+      "norm_label": "color.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 792,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
       "norm_label": "complimentaryproduct.ts",
@@ -63829,7 +63985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -63838,7 +63994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -63847,7 +64003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -63856,7 +64012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -63865,7 +64021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -63874,7 +64030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -63883,30 +64039,12 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
       "norm_label": "promocode.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
-      "label": "redeemedPromoCode.ts",
-      "norm_label": "redeemedpromocode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
       "source_location": "L1"
     },
     {
@@ -64173,6 +64311,24 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
+      "label": "redeemedPromoCode.ts",
+      "norm_label": "redeemedpromocode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 802,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -64180,7 +64336,43 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 803,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/observability/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 804,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
+      "label": "workflowTrace.ts",
+      "norm_label": "workflowtrace.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTrace.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 805,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
+      "label": "workflowTraceEvent.ts",
+      "norm_label": "workflowtraceevent.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 806,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
+      "label": "workflowTraceLookup.ts",
+      "norm_label": "workflowtracelookup.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceLookup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -64189,7 +64381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -64198,66 +64390,12 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 804,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
-      "label": "inventoryMovement.ts",
-      "norm_label": "inventorymovement.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/inventoryMovement.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 805,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
-      "label": "operationalEvent.ts",
-      "norm_label": "operationalevent.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalEvent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 806,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
-      "label": "operationalWorkItem.ts",
-      "norm_label": "operationalworkitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalWorkItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 807,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
-      "label": "paymentAllocation.ts",
-      "norm_label": "paymentallocation.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/paymentAllocation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 808,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
-      "label": "registerSession.ts",
-      "norm_label": "registersession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/registerSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
-      "label": "staffProfile.ts",
-      "norm_label": "staffprofile.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/staffProfile.ts",
       "source_location": "L1"
     },
     {
@@ -64326,6 +64464,60 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
+      "label": "inventoryMovement.ts",
+      "norm_label": "inventorymovement.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/inventoryMovement.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
+      "label": "operationalEvent.ts",
+      "norm_label": "operationalevent.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 812,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
+      "label": "operationalWorkItem.ts",
+      "norm_label": "operationalworkitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/operationalWorkItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 813,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
+      "label": "paymentAllocation.ts",
+      "norm_label": "paymentallocation.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/paymentAllocation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 814,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
+      "label": "registerSession.ts",
+      "norm_label": "registersession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/registerSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 815,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
+      "label": "staffProfile.ts",
+      "norm_label": "staffprofile.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/staffProfile.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 816,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
       "norm_label": "staffroleassignment.ts",
@@ -64333,7 +64525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -64342,7 +64534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -64351,66 +64543,12 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
       "norm_label": "expensesession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 814,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
-      "label": "expenseSessionItem.ts",
-      "norm_label": "expensesessionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 815,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
-      "label": "expenseTransaction.ts",
-      "norm_label": "expensetransaction.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 816,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
-      "label": "expenseTransactionItem.ts",
-      "norm_label": "expensetransactionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransactionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 817,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 818,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
-      "label": "posSession.ts",
-      "norm_label": "possession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
-      "label": "posSessionItem.ts",
-      "norm_label": "possessionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posSessionItem.ts",
       "source_location": "L1"
     },
     {
@@ -64479,6 +64617,60 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
+      "label": "expenseSessionItem.ts",
+      "norm_label": "expensesessionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
+      "label": "expenseTransaction.ts",
+      "norm_label": "expensetransaction.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 822,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
+      "label": "expenseTransactionItem.ts",
+      "norm_label": "expensetransactionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransactionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 823,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 824,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
+      "label": "posSession.ts",
+      "norm_label": "possession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 825,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
+      "label": "posSessionItem.ts",
+      "norm_label": "possessionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posSessionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 826,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
       "norm_label": "posterminal.ts",
@@ -64486,7 +64678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -64495,7 +64687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -64504,66 +64696,12 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/serviceOps/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 824,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
-      "label": "serviceAppointment.ts",
-      "norm_label": "serviceappointment.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceAppointment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 825,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
-      "label": "serviceCase.ts",
-      "norm_label": "servicecase.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCase.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 826,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
-      "label": "serviceCaseLineItem.ts",
-      "norm_label": "servicecaselineitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCaseLineItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 827,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
-      "label": "serviceCatalog.ts",
-      "norm_label": "servicecatalog.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCatalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 828,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
-      "label": "serviceInventoryUsage.ts",
-      "norm_label": "serviceinventoryusage.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceInventoryUsage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/index.ts",
       "source_location": "L1"
     },
     {
@@ -64632,6 +64770,60 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
+      "label": "serviceAppointment.ts",
+      "norm_label": "serviceappointment.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceAppointment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
+      "label": "serviceCase.ts",
+      "norm_label": "servicecase.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCase.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 832,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
+      "label": "serviceCaseLineItem.ts",
+      "norm_label": "servicecaselineitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCaseLineItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 833,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
+      "label": "serviceCatalog.ts",
+      "norm_label": "servicecatalog.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCatalog.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 834,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
+      "label": "serviceInventoryUsage.ts",
+      "norm_label": "serviceinventoryusage.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceInventoryUsage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 835,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 836,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
       "norm_label": "purchaseorder.ts",
@@ -64639,7 +64831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -64648,7 +64840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -64657,66 +64849,12 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
       "norm_label": "stockadjustmentbatch.ts",
       "source_file": "packages/athena-webapp/convex/schemas/stockOps/stockAdjustmentBatch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 834,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
-      "label": "vendor.ts",
-      "norm_label": "vendor.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/vendor.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 835,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 836,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 837,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 838,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
-      "label": "checkoutSessionItem.ts",
-      "norm_label": "checkoutsessionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
       "source_location": "L1"
     },
     {
@@ -64785,6 +64923,60 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
+      "label": "vendor.ts",
+      "norm_label": "vendor.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/vendor.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 842,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 843,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 844,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 845,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
+      "label": "checkoutSessionItem.ts",
+      "norm_label": "checkoutsessionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 846,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
       "label": "customer.ts",
       "norm_label": "customer.ts",
@@ -64792,7 +64984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -64801,7 +64993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -64810,66 +65002,12 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
       "norm_label": "offer.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 844,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 845,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
-      "label": "onlineOrderItem.ts",
-      "norm_label": "onlineorderitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrderItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 846,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
-      "label": "review.ts",
-      "norm_label": "review.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/review.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 847,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 848,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
-      "label": "savedBagItem.ts",
-      "norm_label": "savedbagitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
       "source_location": "L1"
     },
     {
@@ -64938,6 +65076,60 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
+      "label": "onlineOrderItem.ts",
+      "norm_label": "onlineorderitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrderItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 852,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
+      "label": "review.ts",
+      "norm_label": "review.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/review.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 853,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 854,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 855,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
+      "label": "savedBagItem.ts",
+      "norm_label": "savedbagitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 856,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
       "norm_label": "storefrontsession.ts",
@@ -64945,7 +65137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -64954,7 +65146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -64963,66 +65155,12 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
       "norm_label": "supportticket.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 854,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
-      "label": "catalogAppointments.test.ts",
-      "norm_label": "catalogappointments.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 855,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 856,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/bagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 857,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customer_ts",
-      "label": "customer.ts",
-      "norm_label": "customer.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 858,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
-      "label": "onlineOrderUtilFns.ts",
-      "norm_label": "onlineorderutilfns.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
       "source_location": "L1"
     },
     {
@@ -65091,6 +65229,60 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
+      "label": "catalogAppointments.test.ts",
+      "norm_label": "catalogappointments.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 862,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 863,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_customer_ts",
+      "label": "customer.ts",
+      "norm_label": "customer.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 864,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 865,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
+      "label": "onlineOrderUtilFns.ts",
+      "norm_label": "onlineorderutilfns.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 866,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
       "norm_label": "orderoperations.test.ts",
@@ -65098,7 +65290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -65107,7 +65299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -65116,66 +65308,12 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
       "norm_label": "savedbagitem.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 864,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
-      "label": "supportTicket.ts",
-      "norm_label": "supportticket.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/supportTicket.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 865,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_users_ts",
-      "label": "users.ts",
-      "norm_label": "users.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/users.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 866,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_types_payment_ts",
-      "label": "payment.ts",
-      "norm_label": "payment.ts",
-      "source_file": "packages/athena-webapp/convex/types/payment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 867,
-      "file_type": "code",
-      "id": "packages_athena_webapp_eslint_config_js",
-      "label": "eslint.config.js",
-      "norm_label": "eslint.config.js",
-      "source_file": "packages/athena-webapp/eslint.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 868,
-      "file_type": "code",
-      "id": "packages_athena_webapp_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_postcss_config_js",
-      "label": "postcss.config.js",
-      "norm_label": "postcss.config.js",
-      "source_file": "packages/athena-webapp/postcss.config.js",
       "source_location": "L1"
     },
     {
@@ -65244,6 +65382,60 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
+      "label": "supportTicket.ts",
+      "norm_label": "supportticket.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/supportTicket.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_users_ts",
+      "label": "users.ts",
+      "norm_label": "users.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/users.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 872,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_types_payment_ts",
+      "label": "payment.ts",
+      "norm_label": "payment.ts",
+      "source_file": "packages/athena-webapp/convex/types/payment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 873,
+      "file_type": "code",
+      "id": "packages_athena_webapp_eslint_config_js",
+      "label": "eslint.config.js",
+      "norm_label": "eslint.config.js",
+      "source_file": "packages/athena-webapp/eslint.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 874,
+      "file_type": "code",
+      "id": "packages_athena_webapp_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 875,
+      "file_type": "code",
+      "id": "packages_athena_webapp_postcss_config_js",
+      "label": "postcss.config.js",
+      "norm_label": "postcss.config.js",
+      "source_file": "packages/athena-webapp/postcss.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 876,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
@@ -65251,7 +65443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -65260,7 +65452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -65269,66 +65461,12 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
       "norm_label": "storesaccordion.tsx",
       "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 874,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_themetoggle_tsx",
-      "label": "ThemeToggle.tsx",
-      "norm_label": "themetoggle.tsx",
-      "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 875,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
-      "label": "DefaultAttributesToggleGroup.tsx",
-      "norm_label": "defaultattributestogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 876,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
-      "label": "ProductAttributesView.tsx",
-      "norm_label": "productattributesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 877,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 878,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -65397,6 +65535,60 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_themetoggle_tsx",
+      "label": "ThemeToggle.tsx",
+      "norm_label": "themetoggle.tsx",
+      "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
+      "label": "DefaultAttributesToggleGroup.tsx",
+      "norm_label": "defaultattributestogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 882,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
+      "label": "ProductAttributesView.tsx",
+      "norm_label": "productattributesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 883,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 884,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 885,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 886,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -65404,7 +65596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -65413,7 +65605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -65422,66 +65614,12 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
       "norm_label": "revenuechart.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 884,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
-      "label": "analytics-columns.tsx",
-      "norm_label": "analytics-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 885,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 886,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 887,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 888,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -65541,6 +65679,60 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
+      "label": "analytics-columns.tsx",
+      "norm_label": "analytics-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 892,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 893,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 894,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 895,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 896,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -65548,7 +65740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -65557,7 +65749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -65566,66 +65758,12 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 894,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 895,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 896,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 897,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
-      "label": "chart.tsx",
-      "norm_label": "chart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -65874,6 +66012,60 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 902,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 903,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 904,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
+      "label": "chart.tsx",
+      "norm_label": "chart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 905,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 906,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -65881,7 +66073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -65890,7 +66082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -65899,66 +66091,12 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/analytics/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 904,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 905,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 906,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 907,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 908,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -66018,6 +66156,60 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 912,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 913,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 914,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 915,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 916,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -66025,7 +66217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -66034,7 +66226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -66043,66 +66235,12 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 914,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 915,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 916,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 917,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
-      "label": "app-sidebar.tsx",
-      "norm_label": "app-sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 918,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
-      "label": "assetsColumns.tsx",
-      "norm_label": "assetscolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -66162,6 +66300,60 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 922,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 923,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
+      "label": "app-sidebar.tsx",
+      "norm_label": "app-sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 924,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
+      "label": "assetsColumns.tsx",
+      "norm_label": "assetscolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 925,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 926,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -66169,7 +66361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66178,7 +66370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -66187,66 +66379,12 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 924,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
-      "label": "DefaultCatchBoundary.tsx",
-      "norm_label": "defaultcatchboundary.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 925,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
-      "label": "InputOTP.test.tsx",
-      "norm_label": "inputotp.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 926,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
-      "label": "LoginForm.test.tsx",
-      "norm_label": "loginform.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 927,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
-      "label": "LoginForm.tsx",
-      "norm_label": "loginform.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 928,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-column-header.tsx",
       "source_location": "L1"
     },
     {
@@ -66306,6 +66444,60 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
+      "label": "DefaultCatchBoundary.tsx",
+      "norm_label": "defaultcatchboundary.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
+      "label": "InputOTP.test.tsx",
+      "norm_label": "inputotp.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 932,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
+      "label": "LoginForm.test.tsx",
+      "norm_label": "loginform.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 933,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
+      "label": "LoginForm.tsx",
+      "norm_label": "loginform.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 934,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 935,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 936,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -66313,7 +66505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66322,7 +66514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -66331,66 +66523,12 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 934,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 935,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 936,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 937,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 938,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
-      "label": "BulkOperationsPage.tsx",
-      "norm_label": "bulkoperationspage.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
       "source_location": "L1"
     },
     {
@@ -66450,6 +66588,60 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 942,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 943,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 944,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 945,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
+      "label": "BulkOperationsPage.tsx",
+      "norm_label": "bulkoperationspage.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 946,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
       "norm_label": "cashcontrolsdashboard.test.tsx",
@@ -66457,7 +66649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
       "label": "RegisterCloseoutView.test.tsx",
@@ -66466,7 +66658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -66475,66 +66667,12 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/cashiers/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 944,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 945,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 946,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 947,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
-      "label": "MetricCard.tsx",
-      "norm_label": "metriccard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 948,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
-      "label": "OperationsQueueView.test.tsx",
-      "norm_label": "operationsqueueview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
-      "label": "StockAdjustmentWorkspace.test.tsx",
-      "norm_label": "stockadjustmentworkspace.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
       "source_location": "L1"
     },
     {
@@ -66594,6 +66732,60 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 952,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 953,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
+      "label": "MetricCard.tsx",
+      "norm_label": "metriccard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 954,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
+      "label": "OperationsQueueView.test.tsx",
+      "norm_label": "operationsqueueview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 955,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
+      "label": "StockAdjustmentWorkspace.test.tsx",
+      "norm_label": "stockadjustmentworkspace.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 956,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
       "norm_label": "orderstatus.test.tsx",
@@ -66601,7 +66793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -66610,7 +66802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -66619,66 +66811,12 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
       "norm_label": "orders.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 954,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
-      "label": "ReturnExchangeView.test.tsx",
-      "norm_label": "returnexchangeview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 955,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 956,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 957,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 958,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -66738,6 +66876,60 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
+      "label": "ReturnExchangeView.test.tsx",
+      "norm_label": "returnexchangeview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 962,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 963,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 964,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 965,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 966,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
@@ -66745,7 +66937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -66754,7 +66946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66763,66 +66955,12 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 964,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 965,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 966,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 967,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
-      "label": "inviteColumns.tsx",
-      "norm_label": "invitecolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 968,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -66882,6 +67020,60 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 972,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 973,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
+      "label": "inviteColumns.tsx",
+      "norm_label": "invitecolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 974,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 975,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 976,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -66889,7 +67081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -66898,7 +67090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -66907,66 +67099,12 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 974,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
-      "label": "membersColumns.tsx",
-      "norm_label": "memberscolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 975,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
-      "label": "organization-switcher.test.tsx",
-      "norm_label": "organization-switcher.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-switcher.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 976,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
-      "label": "CartItems.tsx",
-      "norm_label": "cartitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 977,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
-      "label": "CashierAuthDialog.tsx",
-      "norm_label": "cashierauthdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 978,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
-      "label": "POSRegisterView.tsx",
-      "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
-      "label": "ProductLookup.tsx",
-      "norm_label": "productlookup.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
       "source_location": "L1"
     },
     {
@@ -67026,6 +67164,60 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
+      "label": "membersColumns.tsx",
+      "norm_label": "memberscolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
+      "label": "organization-switcher.test.tsx",
+      "norm_label": "organization-switcher.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-switcher.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 982,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
+      "label": "CartItems.tsx",
+      "norm_label": "cartitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 983,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
+      "label": "CashierAuthDialog.tsx",
+      "norm_label": "cashierauthdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 984,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
+      "label": "POSRegisterView.tsx",
+      "norm_label": "posregisterview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 985,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
+      "label": "ProductLookup.tsx",
+      "norm_label": "productlookup.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 986,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
       "norm_label": "registeractions.tsx",
@@ -67033,7 +67225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -67042,7 +67234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -67051,66 +67243,12 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
       "norm_label": "totalsdisplay.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 984,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
-      "label": "ExpenseReportView.tsx",
-      "norm_label": "expensereportview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 985,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
-      "label": "expenseReportColumns.tsx",
-      "norm_label": "expensereportcolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 986,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
-      "label": "POSRegisterView.test.tsx",
-      "norm_label": "posregisterview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 987,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
-      "label": "POSRegisterView.tsx",
-      "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 988,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
-      "label": "RegisterActionBar.tsx",
-      "norm_label": "registeractionbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
-      "label": "RegisterCheckoutPanel.tsx",
-      "norm_label": "registercheckoutpanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx",
       "source_location": "L1"
     },
     {
@@ -67170,6 +67308,60 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
+      "label": "ExpenseReportView.tsx",
+      "norm_label": "expensereportview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
+      "label": "expenseReportColumns.tsx",
+      "norm_label": "expensereportcolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 992,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
+      "label": "POSRegisterView.test.tsx",
+      "norm_label": "posregisterview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 993,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "label": "POSRegisterView.tsx",
+      "norm_label": "posregisterview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 994,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
+      "label": "RegisterActionBar.tsx",
+      "norm_label": "registeractionbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 995,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
+      "label": "RegisterCheckoutPanel.tsx",
+      "norm_label": "registercheckoutpanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 996,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
       "norm_label": "transactionview.tsx",
@@ -67177,7 +67369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -67186,7 +67378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -67195,66 +67387,12 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
       "norm_label": "receivingview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 994,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
-      "label": "AnalyticsInsights.tsx",
-      "norm_label": "analyticsinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 995,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
-      "label": "AttributesView.tsx",
-      "norm_label": "attributesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 996,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
-      "label": "DetailsView.tsx",
-      "norm_label": "detailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 997,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
-      "label": "ProductDetailView.tsx",
-      "norm_label": "productdetailview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
-      "label": "ProductStatus.tsx",
-      "norm_label": "productstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
-      "label": "CategoryListView.tsx",
-      "norm_label": "categorylistview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1418
-- Graph nodes: 3487
-- Graph edges: 2989
-- Communities: 1333
+- Code files discovered: 1425
+- Graph nodes: 3497
+- Graph edges: 2993
+- Communities: 1340
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -73,6 +73,11 @@ import {
   staffRoleAssignmentSchema,
 } from "./schemas/operations";
 import {
+  workflowTraceEventSchema,
+  workflowTraceLookupSchema,
+  workflowTraceSchema,
+} from "./schemas/observability";
+import {
   serviceAppointmentSchema,
   serviceCatalogSchema,
   serviceCaseLineItemSchema,
@@ -261,6 +266,26 @@ const schema = defineSchema({
   promoCodeItem: defineTable(promoCodeItemSchema)
     .index("by_promoCodeId", ["promoCodeId"])
     .index("by_productSkuId", ["productSkuId"]),
+  workflowTrace: defineTable(workflowTraceSchema)
+    .index("by_storeId_traceId", ["storeId", "traceId"])
+    .index("by_storeId_workflowType_primaryLookup", [
+      "storeId",
+      "workflowType",
+      "primaryLookupType",
+      "primaryLookupValue",
+    ])
+    .index("by_primarySubject", ["primarySubjectType", "primarySubjectId"]),
+  workflowTraceEvent: defineTable(workflowTraceEventSchema)
+    .index("by_storeId_traceId_occurredAt", ["storeId", "traceId", "occurredAt"])
+    .index("by_traceId_sequence", ["traceId", "sequence"]),
+  workflowTraceLookup: defineTable(workflowTraceLookupSchema)
+    .index("by_storeId_workflowType_lookup", [
+      "storeId",
+      "workflowType",
+      "lookupType",
+      "lookupValue",
+    ])
+    .index("by_traceId", ["traceId"]),
   operationalEvent: defineTable(operationalEventSchema)
     .index("by_storeId", ["storeId"])
     .index("by_storeId_subject", ["storeId", "subjectType", "subjectId"])

--- a/packages/athena-webapp/convex/schemas/observability/index.ts
+++ b/packages/athena-webapp/convex/schemas/observability/index.ts
@@ -1,0 +1,3 @@
+export * from "./workflowTrace";
+export * from "./workflowTraceEvent";
+export * from "./workflowTraceLookup";

--- a/packages/athena-webapp/convex/schemas/observability/workflowTrace.ts
+++ b/packages/athena-webapp/convex/schemas/observability/workflowTrace.ts
@@ -1,0 +1,29 @@
+import { v } from "convex/values";
+
+export const workflowTraceSchema = v.object({
+  storeId: v.id("store"),
+  organizationId: v.optional(v.id("organization")),
+  traceId: v.string(),
+  workflowType: v.string(),
+  title: v.string(),
+  status: v.union(
+    v.literal("started"),
+    v.literal("succeeded"),
+    v.literal("failed"),
+    v.literal("blocked"),
+    v.literal("info")
+  ),
+  health: v.union(
+    v.literal("healthy"),
+    v.literal("partial"),
+    v.literal("degraded")
+  ),
+  startedAt: v.number(),
+  completedAt: v.optional(v.number()),
+  primaryLookupType: v.string(),
+  primaryLookupValue: v.string(),
+  primarySubjectType: v.optional(v.string()),
+  primarySubjectId: v.optional(v.string()),
+  summary: v.optional(v.string()),
+  details: v.optional(v.record(v.string(), v.any())),
+});

--- a/packages/athena-webapp/convex/schemas/observability/workflowTraceEvent.ts
+++ b/packages/athena-webapp/convex/schemas/observability/workflowTraceEvent.ts
@@ -1,0 +1,27 @@
+import { v } from "convex/values";
+
+export const workflowTraceEventSchema = v.object({
+  storeId: v.id("store"),
+  traceId: v.string(),
+  workflowType: v.string(),
+  sequence: v.number(),
+  kind: v.union(
+    v.literal("milestone"),
+    v.literal("system_action"),
+    v.literal("gap")
+  ),
+  step: v.string(),
+  status: v.union(
+    v.literal("started"),
+    v.literal("succeeded"),
+    v.literal("failed"),
+    v.literal("blocked"),
+    v.literal("info")
+  ),
+  message: v.string(),
+  occurredAt: v.number(),
+  details: v.optional(v.record(v.string(), v.any())),
+  source: v.string(),
+  subjectRefs: v.optional(v.record(v.string(), v.string())),
+  actorRefs: v.optional(v.record(v.string(), v.string())),
+});

--- a/packages/athena-webapp/convex/schemas/observability/workflowTraceLookup.ts
+++ b/packages/athena-webapp/convex/schemas/observability/workflowTraceLookup.ts
@@ -1,0 +1,9 @@
+import { v } from "convex/values";
+
+export const workflowTraceLookupSchema = v.object({
+  storeId: v.id("store"),
+  workflowType: v.string(),
+  lookupType: v.string(),
+  lookupValue: v.string(),
+  traceId: v.string(),
+});

--- a/packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts
+++ b/packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import schema from "../schema";
+
+function getTableIndexes(tableName: string) {
+  return ((schema as any).tables[tableName]?.indexes ?? []) as Array<{
+    indexDescriptor: string;
+    fields: string[];
+  }>;
+}
+
+describe("workflow trace schema indexes", () => {
+  it("registers workflow trace, event, and lookup tables with additive indexes", () => {
+    expect(getTableIndexes("workflowTrace")).toContainEqual({
+      indexDescriptor: "by_storeId_traceId",
+      fields: ["storeId", "traceId"],
+    });
+    expect(getTableIndexes("workflowTrace")).toContainEqual({
+      indexDescriptor: "by_storeId_workflowType_primaryLookup",
+      fields: ["storeId", "workflowType", "primaryLookupType", "primaryLookupValue"],
+    });
+    expect(getTableIndexes("workflowTraceEvent")).toContainEqual({
+      indexDescriptor: "by_traceId_sequence",
+      fields: ["traceId", "sequence"],
+    });
+    expect(getTableIndexes("workflowTraceLookup")).toContainEqual({
+      indexDescriptor: "by_storeId_workflowType_lookup",
+      fields: ["storeId", "workflowType", "lookupType", "lookupValue"],
+    });
+  });
+});

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -12,15 +12,15 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 36 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 5 file(s); key children: OnlineOrderContext.tsx, PermissionsContext.tsx, ProductContext.tsx, ThemeContext.tsx, UserContext.tsx.
-- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 63 file(s); key children: aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts, countries.ts.
-- [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 3 file(s); key children: auth.ts, serviceIntake.ts, stockAdjustment.ts.
+- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 64 file(s); key children: aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts, countries.ts.
+- [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 4 file(s); key children: auth.ts, serviceIntake.ts, stockAdjustment.ts, workflowTrace.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 3 file(s); key children: formatNumber.ts, index.ts, versionChecker.ts.
 
 ## Backend and test surfaces
 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 12 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, purchaseOrders.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 317 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 322 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 6 file(s); key children: README.md, SUMMARY.md, pos.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -62,6 +62,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/storeFront/returnExchangeOperations.test.ts`](../../convex/storeFront/returnExchangeOperations.test.ts)
 - [`convex/storeFront/storefrontObservabilityReport.test.ts`](../../convex/storeFront/storefrontObservabilityReport.test.ts)
 - [`convex/storeFront/timeQueryRefactors.test.ts`](../../convex/storeFront/timeQueryRefactors.test.ts)
+- [`convex/workflowTraces/schemaIndexes.test.ts`](../../convex/workflowTraces/schemaIndexes.test.ts)
 
 ## Section `src`
 
@@ -100,6 +101,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/lib/pos/presentation/register/useRegisterViewModel.test.ts`](../../src/lib/pos/presentation/register/useRegisterViewModel.test.ts)
 - [`src/lib/productUtils.test.ts`](../../src/lib/productUtils.test.ts)
 - [`src/lib/storeConfig.test.ts`](../../src/lib/storeConfig.test.ts)
+- [`src/lib/traces/createWorkflowTraceId.test.ts`](../../src/lib/traces/createWorkflowTraceId.test.ts)
 - [`src/lib/utils.test.ts`](../../src/lib/utils.test.ts)
 - [`src/routeTree.browser-boundary.test.ts`](../../src/routeTree.browser-boundary.test.ts)
 - [`src/routes/login/_layout.index.test.tsx`](../../src/routes/login/_layout.index.test.tsx)

--- a/packages/athena-webapp/shared/workflowTrace.ts
+++ b/packages/athena-webapp/shared/workflowTrace.ts
@@ -1,0 +1,48 @@
+export const WORKFLOW_TRACE_KINDS = [
+  "milestone",
+  "system_action",
+  "gap",
+] as const;
+
+export const WORKFLOW_TRACE_STATUSES = [
+  "started",
+  "succeeded",
+  "failed",
+  "blocked",
+  "info",
+] as const;
+
+export const WORKFLOW_TRACE_HEALTHS = [
+  "healthy",
+  "partial",
+  "degraded",
+] as const;
+
+export type WorkflowTraceKind = (typeof WORKFLOW_TRACE_KINDS)[number];
+export type WorkflowTraceStatus = (typeof WORKFLOW_TRACE_STATUSES)[number];
+export type WorkflowTraceHealth = (typeof WORKFLOW_TRACE_HEALTHS)[number];
+
+export function normalizeWorkflowTraceLookupValue(value: string) {
+  const normalized = value.trim().toLowerCase();
+
+  if (!normalized) {
+    throw new Error("Workflow trace lookup values must not be empty.");
+  }
+
+  return normalized;
+}
+
+export function createWorkflowTraceId(args: {
+  workflowType: string;
+  primaryLookupValue: string;
+}) {
+  const workflowType = args.workflowType.trim().toLowerCase();
+
+  if (!workflowType) {
+    throw new Error("Workflow trace workflow types must not be empty.");
+  }
+
+  return `${workflowType}:${normalizeWorkflowTraceLookupValue(
+    args.primaryLookupValue
+  )}`;
+}

--- a/packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts
+++ b/packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { createWorkflowTraceId } from "~/shared/workflowTrace";
+
+describe("createWorkflowTraceId", () => {
+  it("normalizes workflow type and primary lookup value into a stable trace id", () => {
+    expect(
+      createWorkflowTraceId({
+        workflowType: "pos_sale",
+        primaryLookupValue: " POS-123456 ",
+      })
+    ).toBe("pos_sale:pos-123456");
+  });
+
+  it("rejects empty workflow types", () => {
+    expect(() =>
+      createWorkflowTraceId({
+        workflowType: "   ",
+        primaryLookupValue: "POS-123456",
+      })
+    ).toThrow("Workflow trace workflow types must not be empty.");
+  });
+
+  it("rejects empty lookup values", () => {
+    expect(() =>
+      createWorkflowTraceId({
+        workflowType: "pos_sale",
+        primaryLookupValue: "   ",
+      })
+    ).toThrow("Workflow trace lookup values must not be empty.");
+  });
+});


### PR DESCRIPTION
## Summary
- add the shared `workflowTrace` runtime helper for stable trace IDs, normalization, and shared status/kind unions
- register `workflowTrace`, `workflowTraceEvent`, and `workflowTraceLookup` in Athena Convex with the first trace indexes
- add focused tests for trace ID normalization and schema index registration
- include the repo-managed `graphify-out` refresh generated by the pre-commit hook

## Why
- Athena needs a reusable workflow-trace foundation before we layer POS sale tracing and the shared trace UI on top
- this ticket establishes the canonical trace ID contract and the first persisted observability tables without tying the design to POS-only code

## Validation
- `bun run --filter '@athena/webapp' test -- src/lib/traces/createWorkflowTraceId.test.ts`
- `bun run --filter '@athena/webapp' test -- convex/workflowTraces/schemaIndexes.test.ts`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `git diff --check`
- pre-push suite:
  - `bun run graphify:check`
  - `bun run harness:self-review --base origin/main`
  - `bun run architecture:check`
  - `bun run --filter '@athena/webapp' test`
  - `bun run --filter '@athena/webapp' audit:convex`
  - `bun run --filter '@athena/webapp' lint:convex:changed`
  - `bun scripts/harness-behavior.ts --scenario athena-convex-storefront-composition`
  - `bun scripts/harness-behavior.ts --scenario athena-convex-storefront-failure-visibility`
  - `bun run harness:inferential-review --base origin/main`

Linear: https://linear.app/v26-labs/issue/V26-311/add-workflow-trace-ids-and-shared-convex-schema-registration
