### PR TITLE
[V26-312]: Build the workflow trace core helpers and public query surface

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1425 files · ~0 words
+- 1430 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3497 nodes · 2993 edges · 1340 communities detected
+- 3510 nodes · 3003 edges · 1345 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1350,6 +1350,11 @@
 - [[_COMMUNITY_Community 1337|Community 1337]]
 - [[_COMMUNITY_Community 1338|Community 1338]]
 - [[_COMMUNITY_Community 1339|Community 1339]]
+- [[_COMMUNITY_Community 1340|Community 1340]]
+- [[_COMMUNITY_Community 1341|Community 1341]]
+- [[_COMMUNITY_Community 1342|Community 1342]]
+- [[_COMMUNITY_Community 1343|Community 1343]]
+- [[_COMMUNITY_Community 1344|Community 1344]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1690,60 +1695,60 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 78 - "Community 78"
+Cohesion: 0.38
+Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
+
+### Community 79 - "Community 79"
 Cohesion: 0.33
 Nodes (2): formatCurrency(), SummaryStrip()
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.52
 Nodes (6): buildCycleCountDrafts(), buildManualDrafts(), buildStockAdjustmentSubmissionKey(), handleModeChange(), handleSubmit(), trimOptional()
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.53
 Nodes (5): buildInStorePaymentAllocations(), isActiveRegisterSessionStatus(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 91 - "Community 91"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 92 - "Community 92"
 Cohesion: 0.33
@@ -1754,48 +1759,48 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 94 - "Community 94"
-Cohesion: 0.73
-Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
-
-### Community 95 - "Community 95"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 95 - "Community 95"
+Cohesion: 0.73
+Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 96 - "Community 96"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 97 - "Community 97"
-Cohesion: 0.4
-Nodes (2): appendTransition(), applyOnlineOrderUpdate()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 98 - "Community 98"
 Cohesion: 0.4
-Nodes (2): calculateCycleCountQuantityDelta(), resolveStockAdjustmentQuantityDelta()
+Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
 ### Community 99 - "Community 99"
+Cohesion: 0.4
+Nodes (2): calculateCycleCountQuantityDelta(), resolveStockAdjustmentQuantityDelta()
+
+### Community 100 - "Community 100"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.4
 Nodes (2): buildUsername(), normalizeNameSegment()
-
-### Community 102 - "Community 102"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 103 - "Community 103"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 104 - "Community 104"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 105 - "Community 105"
 Cohesion: 0.33
@@ -1850,23 +1855,23 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 118 - "Community 118"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+
+### Community 119 - "Community 119"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 121 - "Community 121"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 122 - "Community 122"
-Cohesion: 0.4
+Cohesion: 0.33
 Nodes (0):
 
 ### Community 123 - "Community 123"
@@ -1878,36 +1883,36 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 125 - "Community 125"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 126 - "Community 126"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.5
 Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.5
 Nodes (2): buildPaymentAllocation(), recordPaymentAllocationWithCtx()
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.6
 Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 132 - "Community 132"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 133 - "Community 133"
 Cohesion: 0.4
@@ -1915,7 +1920,7 @@ Nodes (0):
 
 ### Community 134 - "Community 134"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 135 - "Community 135"
 Cohesion: 0.4
@@ -1943,7 +1948,7 @@ Nodes (0):
 
 ### Community 141 - "Community 141"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 142 - "Community 142"
 Cohesion: 0.4
@@ -1966,40 +1971,40 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 147 - "Community 147"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 148 - "Community 148"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 148 - "Community 148"
-Cohesion: 0.4
-Nodes (1): MockImage
-
 ### Community 149 - "Community 149"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 150 - "Community 150"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 151 - "Community 151"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 152 - "Community 152"
 Cohesion: 0.6
 Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.5
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.5
 Nodes (2): hasCustomerDetails(), useRegisterViewModel()
-
-### Community 155 - "Community 155"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 156 - "Community 156"
 Cohesion: 0.4
@@ -2010,36 +2015,36 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 158 - "Community 158"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 159 - "Community 159"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 160 - "Community 160"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 161 - "Community 161"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 162 - "Community 162"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 163 - "Community 163"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 164 - "Community 164"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 165 - "Community 165"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 166 - "Community 166"
 Cohesion: 0.5
@@ -2058,44 +2063,44 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 170 - "Community 170"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 171 - "Community 171"
 Cohesion: 0.67
 Nodes (2): toDisplayAmount(), toPesewas()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 178 - "Community 178"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 179 - "Community 179"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 180 - "Community 180"
 Cohesion: 0.5
@@ -2106,16 +2111,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 182 - "Community 182"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 183 - "Community 183"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 184 - "Community 184"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 185 - "Community 185"
 Cohesion: 0.5
@@ -2138,24 +2143,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 190 - "Community 190"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 191 - "Community 191"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 191 - "Community 191"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 192 - "Community 192"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 193 - "Community 193"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 194 - "Community 194"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 194 - "Community 194"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 195 - "Community 195"
 Cohesion: 0.5
@@ -2178,20 +2183,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 200 - "Community 200"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 201 - "Community 201"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), parseDateTimeLocal()
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 202 - "Community 202"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 203 - "Community 203"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 204 - "Community 204"
 Cohesion: 0.5
@@ -2206,28 +2211,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 207 - "Community 207"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 208 - "Community 208"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.67
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 212 - "Community 212"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 213 - "Community 213"
 Cohesion: 0.5
@@ -2250,51 +2255,51 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 218 - "Community 218"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 219 - "Community 219"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 224 - "Community 224"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 225 - "Community 225"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 226 - "Community 226"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 227 - "Community 227"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 228 - "Community 228"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 229 - "Community 229"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 230 - "Community 230"
@@ -2310,32 +2315,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 233 - "Community 233"
-Cohesion: 1.0
-Nodes (2): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestWithCtx()
-
-### Community 234 - "Community 234"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 234 - "Community 234"
+Cohesion: 1.0
+Nodes (2): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestWithCtx()
 
 ### Community 235 - "Community 235"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 236 - "Community 236"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 237 - "Community 237"
 Cohesion: 1.0
 Nodes (2): buildRegisterState(), getRegisterState()
 
-### Community 237 - "Community 237"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 238 - "Community 238"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 239 - "Community 239"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 240 - "Community 240"
 Cohesion: 0.67
@@ -2346,28 +2351,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 242 - "Community 242"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 243 - "Community 243"
 Cohesion: 1.0
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 244 - "Community 244"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 245 - "Community 245"
 Cohesion: 1.0
-Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 246 - "Community 246"
-Cohesion: 0.67
-Nodes (1): View()
+Cohesion: 1.0
+Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 248 - "Community 248"
 Cohesion: 0.67
@@ -2382,16 +2387,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 251 - "Community 251"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 252 - "Community 252"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 253 - "Community 253"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 254 - "Community 254"
 Cohesion: 0.67
@@ -2399,11 +2404,11 @@ Nodes (0):
 
 ### Community 255 - "Community 255"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 256 - "Community 256"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 257 - "Community 257"
 Cohesion: 0.67
@@ -2411,11 +2416,11 @@ Nodes (0):
 
 ### Community 258 - "Community 258"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 259 - "Community 259"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 260 - "Community 260"
 Cohesion: 0.67
@@ -2463,75 +2468,75 @@ Nodes (0):
 
 ### Community 271 - "Community 271"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 272 - "Community 272"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 273 - "Community 273"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 274 - "Community 274"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 275 - "Community 275"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 277 - "Community 277"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 278 - "Community 278"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 279 - "Community 279"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (0):
 
 ### Community 280 - "Community 280"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): AppContextMenu()
 
 ### Community 281 - "Community 281"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): Badge()
 
 ### Community 282 - "Community 282"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 283 - "Community 283"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 284 - "Community 284"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 285 - "Community 285"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 286 - "Community 286"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 287 - "Community 287"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 288 - "Community 288"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 289 - "Community 289"
 Cohesion: 0.67
@@ -2559,11 +2564,11 @@ Nodes (0):
 
 ### Community 295 - "Community 295"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 296 - "Community 296"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 297 - "Community 297"
 Cohesion: 0.67
@@ -2575,11 +2580,11 @@ Nodes (0):
 
 ### Community 299 - "Community 299"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 300 - "Community 300"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 301 - "Community 301"
 Cohesion: 0.67
@@ -2587,59 +2592,59 @@ Nodes (0):
 
 ### Community 302 - "Community 302"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 303 - "Community 303"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 304 - "Community 304"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 305 - "Community 305"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 306 - "Community 306"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 307 - "Community 307"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 307 - "Community 307"
+### Community 308 - "Community 308"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.67
 Nodes (1): manualChunks()
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 312 - "Community 312"
+### Community 313 - "Community 313"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 313 - "Community 313"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 314 - "Community 314"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 315 - "Community 315"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 316 - "Community 316"
 Cohesion: 0.67
@@ -2650,12 +2655,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 318 - "Community 318"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 319 - "Community 319"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 319 - "Community 319"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 320 - "Community 320"
 Cohesion: 0.67
@@ -2666,12 +2671,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 322 - "Community 322"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 323 - "Community 323"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 323 - "Community 323"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 324 - "Community 324"
 Cohesion: 0.67
@@ -2750,16 +2755,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 343 - "Community 343"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 344 - "Community 344"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 345 - "Community 345"
+### Community 344 - "Community 344"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 345 - "Community 345"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 346 - "Community 346"
 Cohesion: 1.0
@@ -2774,20 +2779,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 349 - "Community 349"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 350 - "Community 350"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 351 - "Community 351"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 352 - "Community 352"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 353 - "Community 353"
 Cohesion: 1.0
@@ -6737,1096 +6742,1114 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1340 - "Community 1340"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1341 - "Community 1341"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1342 - "Community 1342"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1343 - "Community 1343"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1344 - "Community 1344"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 352`** (2 nodes): `getSource()`, `closeouts.test.ts`
+- **Thin community `Community 353`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 354`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 355`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 356`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 357`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 358`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 359`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 360`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (2 nodes): `authenticateHandler()`, `cashier.ts`
+- **Thin community `Community 361`** (2 nodes): `authenticateHandler()`, `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 362`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 363`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 364`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 365`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 366`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 367`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 368`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 369`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 370`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 371`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
+- **Thin community `Community 372`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 373`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 374`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 375`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 376`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 377`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 378`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 379`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 380`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 381`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `receiving.test.ts`, `getSource()`
+- **Thin community `Community 382`** (2 nodes): `receiving.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 383`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 384`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 385`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 386`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 387`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 388`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 389`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 390`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 391`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 392`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 393`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 394`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 395`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 396`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 397`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 398`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 399`** (2 nodes): `queryUsage.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 400`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 401`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 402`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 403`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 404`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 405`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 406`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 407`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 408`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 409`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 410`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 411`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 412`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 413`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 414`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 415`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 416`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 417`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 418`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 419`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 420`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 421`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 422`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 423`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 424`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 425`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 426`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 427`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 428`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 429`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 430`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 431`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 432`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 433`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 434`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 435`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 436`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 437`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 438`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 439`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 440`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 441`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 442`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 443`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 444`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 445`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 446`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 447`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
+- **Thin community `Community 448`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 449`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 450`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 451`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 452`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 453`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `CashierView()`, `CashierView.tsx`
+- **Thin community `Community 454`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 455`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 456`** (2 nodes): `CashierView()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 457`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 458`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 459`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 460`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 461`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 462`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 463`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 464`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 465`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 466`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 467`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 468`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 469`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 470`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 471`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 472`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 473`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 474`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 475`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 476`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 477`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 478`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 479`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 480`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 481`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 482`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 483`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 484`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
+- **Thin community `Community 485`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 486`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 487`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 488`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 489`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 490`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 491`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 492`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 493`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 494`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 495`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 496`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 497`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 498`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 499`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 500`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
+- **Thin community `Community 501`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 502`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 503`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 504`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 505`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 506`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 507`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 508`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 509`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 510`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 511`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 512`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 513`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 514`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 515`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 516`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 517`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 518`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 519`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 520`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 521`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 522`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 523`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 524`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 525`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 526`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 527`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 528`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 529`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 530`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 531`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 532`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 533`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 534`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 535`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 536`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 537`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 538`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 539`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 540`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 541`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 542`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 543`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 544`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 545`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 546`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 547`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 548`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 549`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 550`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 551`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 552`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 553`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 554`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
+- **Thin community `Community 555`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 556`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 557`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 558`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 559`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 560`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 561`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 562`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 563`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 564`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 565`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 566`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 567`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 568`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 569`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 570`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 571`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 572`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 573`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 574`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 575`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 576`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 577`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 578`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 579`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 580`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 581`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 582`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 583`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 584`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 585`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 586`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 587`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 588`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 589`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 590`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 591`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 592`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 593`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 594`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 595`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 596`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 597`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 598`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 599`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 600`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 601`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 602`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 603`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 604`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 605`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 606`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 607`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 608`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 609`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 610`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 611`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 612`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 613`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 614`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 615`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 616`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 617`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 618`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 619`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 620`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 621`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 622`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 623`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 624`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 625`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 626`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 627`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 628`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 629`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 630`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 631`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 632`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 633`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 634`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 635`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 636`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 637`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 638`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 639`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 640`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 641`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 642`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 643`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 644`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 645`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 646`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 647`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 648`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 649`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 650`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 651`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 652`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 653`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 654`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 655`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 656`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 657`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 658`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 659`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 660`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 661`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 662`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 663`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 664`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 665`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 666`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 667`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 668`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 669`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 670`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 671`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 672`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 673`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 674`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 675`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 676`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 677`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 678`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 679`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 680`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 681`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 682`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 683`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 684`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 685`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 686`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 687`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 688`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 689`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 690`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 691`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `api.d.ts`
+- **Thin community `Community 692`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `api.js`
+- **Thin community `Community 693`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 694`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `server.d.ts`
+- **Thin community `Community 695`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `server.js`
+- **Thin community `Community 696`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `app.ts`
+- **Thin community `Community 697`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `auth.config.js`
+- **Thin community `Community 698`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `auth.ts`
+- **Thin community `Community 699`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 700`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `countries.ts`
+- **Thin community `Community 701`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `email.ts`
+- **Thin community `Community 702`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `ghana.ts`
+- **Thin community `Community 703`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `payment.ts`
+- **Thin community `Community 704`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `crons.ts`
+- **Thin community `Community 705`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 706`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 707`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 708`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 709`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `env.ts`
+- **Thin community `Community 710`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `analytics.ts`
+- **Thin community `Community 711`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `auth.ts`
+- **Thin community `Community 712`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 713`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `categories.ts`
+- **Thin community `Community 714`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `colors.ts`
+- **Thin community `Community 715`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `index.ts`
+- **Thin community `Community 716`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `organizations.ts`
+- **Thin community `Community 717`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `products.ts`
+- **Thin community `Community 718`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `stores.ts`
+- **Thin community `Community 719`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 720`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `index.ts`
+- **Thin community `Community 721`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `bag.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `guest.ts`
+- **Thin community `Community 722`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 723`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `me.ts`
+- **Thin community `Community 724`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `offers.ts`
+- **Thin community `Community 725`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 726`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `paystack.ts`
+- **Thin community `Community 727`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `reviews.ts`
+- **Thin community `Community 728`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `rewards.ts`
+- **Thin community `Community 729`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 730`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `security.test.ts`
+- **Thin community `Community 731`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `storefront.ts`
+- **Thin community `Community 732`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `upsells.ts`
+- **Thin community `Community 733`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `user.ts`
+- **Thin community `Community 734`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 735`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `health.test.ts`
+- **Thin community `Community 736`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `http.ts`
+- **Thin community `Community 737`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 738`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `auth.ts`
+- **Thin community `Community 739`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 740`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 741`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `categories.ts`
+- **Thin community `Community 742`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `colors.ts`
+- **Thin community `Community 743`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 744`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 745`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 746`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 747`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 748`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 749`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `organizations.ts`
+- **Thin community `Community 750`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `pos.ts`
+- **Thin community `Community 751`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 752`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 753`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 754`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `productSku.ts`
+- **Thin community `Community 755`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 756`** (1 nodes): `posSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 757`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 758`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 759`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 760`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 761`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 762`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 763`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 764`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `client.test.ts`
+- **Thin community `Community 765`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `config.test.ts`
+- **Thin community `Community 766`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 767`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `types.ts`
+- **Thin community `Community 768`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 769`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 770`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 771`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `staffProfiles.test.ts`
+- **Thin community `Community 772`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 773`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `completeTransaction.test.ts`
+- **Thin community `Community 774`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `dto.ts`
+- **Thin community `Community 775`** (1 nodes): `staffProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 776`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `types.ts`
+- **Thin community `Community 777`** (1 nodes): `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 778`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `catalog.ts`
+- **Thin community `Community 779`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `customers.ts`
+- **Thin community `Community 780`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `register.ts`
+- **Thin community `Community 781`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `terminals.ts`
+- **Thin community `Community 782`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `transactions.ts`
+- **Thin community `Community 783`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `schema.ts`
+- **Thin community `Community 784`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 785`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 786`** (1 nodes): `transactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 787`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 788`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `cashier.ts`
+- **Thin community `Community 789`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `category.ts`
+- **Thin community `Community 790`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `color.ts`
+- **Thin community `Community 791`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 792`** (1 nodes): `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 793`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `index.ts`
+- **Thin community `Community 794`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 795`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `organization.ts`
+- **Thin community `Community 796`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 797`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `product.ts`
+- **Thin community `Community 798`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 799`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 800`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `store.ts`
+- **Thin community `Community 801`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 802`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `index.ts`
+- **Thin community `Community 803`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 804`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 805`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 806`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 807`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 808`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `index.ts`
+- **Thin community `Community 809`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 810`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 811`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 812`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 813`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 814`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 815`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 816`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 817`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `customer.ts`
+- **Thin community `Community 818`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 819`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 820`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 821`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 822`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `index.ts`
+- **Thin community `Community 823`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `posSession.ts`
+- **Thin community `Community 824`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 825`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 826`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 827`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 828`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `index.ts`
+- **Thin community `Community 829`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 830`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 831`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 832`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 833`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 834`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `index.ts`
+- **Thin community `Community 835`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 836`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 837`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 838`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 839`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `vendor.ts`
+- **Thin community `Community 840`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `analytics.ts`
+- **Thin community `Community 841`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `bag.ts`
+- **Thin community `Community 842`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 843`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 844`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 845`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `customer.ts`
+- **Thin community `Community 846`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `guest.ts`
+- **Thin community `Community 847`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `index.ts`
+- **Thin community `Community 848`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `offer.ts`
+- **Thin community `Community 849`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 850`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 851`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `review.ts`
+- **Thin community `Community 852`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `rewards.ts`
+- **Thin community `Community 853`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 854`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 855`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 856`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 857`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 858`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 859`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 860`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `bag.ts`
+- **Thin community `Community 861`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 862`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `customer.ts`
+- **Thin community `Community 863`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `guest.ts`
+- **Thin community `Community 864`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 865`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 866`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `payment.ts`
+- **Thin community `Community 867`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 868`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 869`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 870`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `users.ts`
+- **Thin community `Community 871`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `payment.ts`
+- **Thin community `Community 872`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 873`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `index.ts`
+- **Thin community `Community 874`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 875`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `auth.ts`
+- **Thin community `Community 876`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 877`** (1 nodes): `public.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 878`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 879`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 880`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 881`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 882`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `constants.ts`
+- **Thin community `Community 883`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 884`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 885`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 886`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `types.ts`
+- **Thin community `Community 887`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 888`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 889`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 890`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 891`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 892`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 893`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 894`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 895`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `columns.tsx`
+- **Thin community `Community 896`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 897`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -7838,881 +7861,891 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 901`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 902`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 903`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `chart.tsx`
+- **Thin community `Community 904`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `columns.tsx`
+- **Thin community `Community 905`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 906`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 907`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `columns.tsx`
+- **Thin community `Community 908`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `constants.ts`
+- **Thin community `Community 909`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 910`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 911`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 912`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `data.ts`
+- **Thin community `Community 913`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `columns.tsx`
+- **Thin community `Community 914`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 915`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 916`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `columns.tsx`
+- **Thin community `Community 917`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 918`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 919`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 920`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 921`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 922`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 923`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 924`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `constants.ts`
+- **Thin community `Community 925`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 926`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 927`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 928`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `data.ts`
+- **Thin community `Community 929`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 930`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 931`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 932`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 933`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `columns.tsx`
+- **Thin community `Community 934`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 935`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 936`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 937`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 938`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 939`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `columns.tsx`
+- **Thin community `Community 940`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `constants.ts`
+- **Thin community `Community 941`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 942`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 943`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 944`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 945`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 946`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `RegisterCloseoutView.test.tsx`
+- **Thin community `Community 947`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 948`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `index.tsx`
+- **Thin community `Community 949`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `columns.tsx`
+- **Thin community `Community 950`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 951`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 952`** (1 nodes): `RegisterCloseoutView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 953`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 954`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 955`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 956`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 957`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 958`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 959`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 960`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `constants.ts`
+- **Thin community `Community 961`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 962`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 963`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 964`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `data.ts`
+- **Thin community `Community 965`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 966`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `constants.ts`
+- **Thin community `Community 967`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 968`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 969`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 970`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 971`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `data.ts`
+- **Thin community `Community 972`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 973`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `constants.ts`
+- **Thin community `Community 974`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 975`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 976`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 977`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 978`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `data.ts`
+- **Thin community `Community 979`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 980`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 981`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 982`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 983`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 984`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 985`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 986`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 987`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 988`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 989`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 990`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 991`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 992`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 993`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 994`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 995`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 996`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `types.ts`
+- **Thin community `Community 997`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 998`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 999`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1000`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1001`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1002`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1003`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 1004`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1005`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1006`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1007`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1008`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1009`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1010`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1011`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1012`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1013`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1014`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1015`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1016`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `data.ts`
+- **Thin community `Community 1017`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1018`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `PromoCodePreview.tsx`
+- **Thin community `Community 1019`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1020`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1021`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1022`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1023`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1024`** (1 nodes): `PromoCodePreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1025`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1026`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1027`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1028`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1029`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `constants.ts`
+- **Thin community `Community 1030`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1031`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1032`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1033`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `data.ts`
+- **Thin community `Community 1034`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `types.ts`
+- **Thin community `Community 1035`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1036`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1037`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1038`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1039`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `ServiceAppointmentsView.test.tsx`
+- **Thin community `Community 1040`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `ServiceCasesView.test.tsx`
+- **Thin community `Community 1041`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `ServiceCatalogView.test.tsx`
+- **Thin community `Community 1042`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `ServiceIntakeView.test.tsx`
+- **Thin community `Community 1043`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1044`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `index.tsx`
+- **Thin community `Community 1045`** (1 nodes): `ServiceAppointmentsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1046`** (1 nodes): `ServiceCasesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1047`** (1 nodes): `ServiceCatalogView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `button.tsx`
+- **Thin community `Community 1048`** (1 nodes): `ServiceIntakeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1049`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `card.tsx`
+- **Thin community `Community 1050`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1051`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1052`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `command.tsx`
+- **Thin community `Community 1053`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1054`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1055`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1056`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `form.tsx`
+- **Thin community `Community 1057`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1058`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1059`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `input.tsx`
+- **Thin community `Community 1060`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1061`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1062`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1063`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1064`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1065`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `select.tsx`
+- **Thin community `Community 1066`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1067`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1068`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1069`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `table.tsx`
+- **Thin community `Community 1070`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1071`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1072`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1073`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1074`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1075`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1076`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1077`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1078`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `constants.ts`
+- **Thin community `Community 1079`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1080`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1081`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1082`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `data.ts`
+- **Thin community `Community 1083`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1084`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1085`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1086`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1087`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1088`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1089`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1090`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1091`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1092`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1093`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1094`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1095`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1096`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `index.ts`
+- **Thin community `Community 1097`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `config.ts`
+- **Thin community `Community 1098`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1099`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1100`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1101`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `aws.ts`
+- **Thin community `Community 1102`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `constants.ts`
+- **Thin community `Community 1103`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `countries.ts`
+- **Thin community `Community 1104`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1105`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1106`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `bootstrapRegister.test.ts`
+- **Thin community `Community 1107`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `dto.ts`
+- **Thin community `Community 1108`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `ports.ts`
+- **Thin community `Community 1109`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `constants.ts`
+- **Thin community `Community 1110`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1111`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1112`** (1 nodes): `bootstrapRegister.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `index.ts`
+- **Thin community `Community 1113`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1114`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `types.ts`
+- **Thin community `Community 1115`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1116`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1117`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1118`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `useRegisterViewModel.test.ts`
+- **Thin community `Community 1119`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1120`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `category.ts`
+- **Thin community `Community 1121`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `product.ts`
+- **Thin community `Community 1122`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `store.ts`
+- **Thin community `Community 1123`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1124`** (1 nodes): `useRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `user.ts`
+- **Thin community `Community 1125`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1126`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1127`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1128`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1129`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1130`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `index.tsx`
+- **Thin community `Community 1131`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `index.tsx`
+- **Thin community `Community 1132`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `index.tsx`
+- **Thin community `Community 1133`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1134`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1135`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1136`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1137`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1138`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `index.tsx`
+- **Thin community `Community 1139`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1140`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1141`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1142`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `home.tsx`
+- **Thin community `Community 1143`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1144`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1145`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1146`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `index.tsx`
+- **Thin community `Community 1147`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `index.tsx`
+- **Thin community `Community 1148`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1149`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1150`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1151`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1152`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1153`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1154`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1155`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1156`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1157`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1158`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1159`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `index.tsx`
+- **Thin community `Community 1160`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1161`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1162`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1163`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1164`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1165`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1166`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `index.tsx`
+- **Thin community `Community 1167`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `index.tsx`
+- **Thin community `Community 1168`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `new.tsx`
+- **Thin community `Community 1169`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `index.tsx`
+- **Thin community `Community 1170`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `new.tsx`
+- **Thin community `Community 1171`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1172`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1173`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `index.tsx`
+- **Thin community `Community 1174`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `new.tsx`
+- **Thin community `Community 1175`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `index.tsx`
+- **Thin community `Community 1176`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1177`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1178`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1179`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1180`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1181`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1182`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `index.tsx`
+- **Thin community `Community 1183`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1184`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1185`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1186`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1187`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1188`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1189`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1190`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1191`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1192`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1193`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1194`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1195`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1196`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1197`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1198`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1199`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1200`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `setup.ts`
+- **Thin community `Community 1201`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1202`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1203`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `types.ts`
+- **Thin community `Community 1204`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1205`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1206`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1207`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1208`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1209`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1210`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `types.ts`
+- **Thin community `Community 1211`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1212`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1213`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1214`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1215`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1216`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1217`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1218`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1219`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1220`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `schema.ts`
+- **Thin community `Community 1221`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1222`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1223`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1224`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1225`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1226`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1227`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1228`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1229`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1230`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `types.ts`
+- **Thin community `Community 1231`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1232`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1233`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1234`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1235`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1236`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1237`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1238`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `constants.ts`
+- **Thin community `Community 1239`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1240`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `About.tsx`
+- **Thin community `Community 1241`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1242`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1243`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1244`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1245`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1246`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1247`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1248`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1249`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1250`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `types.ts`
+- **Thin community `Community 1251`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1252`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1253`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1254`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1255`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1256`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1257`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1258`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1259`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1260`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1261`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `button.tsx`
+- **Thin community `Community 1262`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `card.tsx`
+- **Thin community `Community 1263`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1264`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `command.tsx`
+- **Thin community `Community 1265`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1266`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1267`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1268`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `form.tsx`
+- **Thin community `Community 1269`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1270`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1271`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1272`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1273`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `input.tsx`
+- **Thin community `Community 1274`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `label.tsx`
+- **Thin community `Community 1275`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1276`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1277`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1278`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `index.ts`
+- **Thin community `Community 1279`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `types.ts`
+- **Thin community `Community 1280`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1281`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1282`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1283`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1284`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `select.tsx`
+- **Thin community `Community 1285`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1286`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1287`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `table.tsx`
+- **Thin community `Community 1288`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1289`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1290`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1291`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1292`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1293`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `config.ts`
+- **Thin community `Community 1294`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1295`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1296`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1297`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `constants.ts`
+- **Thin community `Community 1298`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `countries.ts`
+- **Thin community `Community 1299`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1300`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1301`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1302`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1303`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `index.ts`
+- **Thin community `Community 1304`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `store.ts`
+- **Thin community `Community 1305`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `bag.ts`
+- **Thin community `Community 1306`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1307`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `category.ts`
+- **Thin community `Community 1308`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `organization.ts`
+- **Thin community `Community 1309`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `product.ts`
+- **Thin community `Community 1310`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `store.ts`
+- **Thin community `Community 1311`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1312`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `user.ts`
+- **Thin community `Community 1313`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `states.ts`
+- **Thin community `Community 1314`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1315`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1316`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1317`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1318`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1319`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1320`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1321`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `index.tsx`
+- **Thin community `Community 1322`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1323`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `index.tsx`
+- **Thin community `Community 1324`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1325`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1326`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1327`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1328`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1329`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `index.tsx`
+- **Thin community `Community 1330`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1331`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1332`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1333`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1334`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `index.js`
+- **Thin community `Community 1335`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1336`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1337`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1338`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1339`** (1 nodes): `vitest.setup.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1340`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1341`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1342`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1343`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1344`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3510 nodes · 3003 edges · 1345 communities detected
+- 3513 nodes · 3007 edges · 1345 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1719,16 +1719,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 84 - "Community 84"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 85 - "Community 85"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 86 - "Community 86"
+### Community 85 - "Community 85"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 86 - "Community 86"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 87 - "Community 87"
 Cohesion: 0.52
@@ -1803,60 +1803,60 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 105 - "Community 105"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 106 - "Community 106"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
-
-### Community 107 - "Community 107"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 107 - "Community 107"
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 108 - "Community 108"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 109 - "Community 109"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 110 - "Community 110"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 110 - "Community 110"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 111 - "Community 111"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 112 - "Community 112"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 113 - "Community 113"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 114 - "Community 114"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 115 - "Community 115"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
-
-### Community 116 - "Community 116"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 116 - "Community 116"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 117 - "Community 117"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 118 - "Community 118"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 119 - "Community 119"
 Cohesion: 0.53
@@ -1924,19 +1924,19 @@ Nodes (0):
 
 ### Community 135 - "Community 135"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 136 - "Community 136"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 137 - "Community 137"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 138 - "Community 138"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 138 - "Community 138"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 139 - "Community 139"
 Cohesion: 0.4
@@ -1948,7 +1948,7 @@ Nodes (0):
 
 ### Community 141 - "Community 141"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 142 - "Community 142"
 Cohesion: 0.4
@@ -2067,40 +2067,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 171 - "Community 171"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
-
-### Community 172 - "Community 172"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 173 - "Community 173"
+### Community 172 - "Community 172"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 174 - "Community 174"
+### Community 173 - "Community 173"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 175 - "Community 175"
+### Community 174 - "Community 174"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 176 - "Community 176"
+### Community 175 - "Community 175"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 177 - "Community 177"
+### Community 176 - "Community 176"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 178 - "Community 178"
+### Community 177 - "Community 177"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 179 - "Community 179"
+### Community 178 - "Community 178"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+
+### Community 179 - "Community 179"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 180 - "Community 180"
 Cohesion: 0.5
@@ -2111,16 +2111,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 182 - "Community 182"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 183 - "Community 183"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 184 - "Community 184"
+### Community 183 - "Community 183"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+
+### Community 184 - "Community 184"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 185 - "Community 185"
 Cohesion: 0.5
@@ -2143,24 +2143,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 190 - "Community 190"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 191 - "Community 191"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
+
+### Community 191 - "Community 191"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 192 - "Community 192"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 193 - "Community 193"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 194 - "Community 194"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), resetReplacementFields()
+
+### Community 194 - "Community 194"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 195 - "Community 195"
 Cohesion: 0.5
@@ -2183,20 +2183,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 200 - "Community 200"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 201 - "Community 201"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), parseDateTimeLocal()
 
-### Community 202 - "Community 202"
+### Community 201 - "Community 201"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 203 - "Community 203"
+### Community 202 - "Community 202"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
+
+### Community 203 - "Community 203"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 204 - "Community 204"
 Cohesion: 0.5
@@ -2211,28 +2211,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 207 - "Community 207"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 208 - "Community 208"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 209 - "Community 209"
+### Community 208 - "Community 208"
 Cohesion: 0.67
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 210 - "Community 210"
+### Community 209 - "Community 209"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 211 - "Community 211"
+### Community 210 - "Community 210"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 212 - "Community 212"
+### Community 211 - "Community 211"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+
+### Community 212 - "Community 212"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 213 - "Community 213"
 Cohesion: 0.5
@@ -2255,8 +2255,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 218 - "Community 218"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 219 - "Community 219"
 Cohesion: 0.67
@@ -2368,19 +2368,19 @@ Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 246 - "Community 246"
 Cohesion: 1.0
-Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 248 - "Community 248"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
 ### Community 249 - "Community 249"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 250 - "Community 250"
 Cohesion: 0.67
@@ -2391,24 +2391,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 252 - "Community 252"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 253 - "Community 253"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 254 - "Community 254"
 Cohesion: 1.0
 Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
-### Community 253 - "Community 253"
+### Community 255 - "Community 255"
 Cohesion: 1.0
 Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
-### Community 254 - "Community 254"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 255 - "Community 255"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 256 - "Community 256"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 257 - "Community 257"
 Cohesion: 0.67
@@ -2416,11 +2416,11 @@ Nodes (0):
 
 ### Community 258 - "Community 258"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 259 - "Community 259"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 260 - "Community 260"
 Cohesion: 0.67
@@ -2428,7 +2428,7 @@ Nodes (0):
 
 ### Community 261 - "Community 261"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.67
@@ -2472,79 +2472,79 @@ Nodes (0):
 
 ### Community 272 - "Community 272"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 273 - "Community 273"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 274 - "Community 274"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 275 - "Community 275"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 277 - "Community 277"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 278 - "Community 278"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TableSkeleton()
 
 ### Community 279 - "Community 279"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): TransactionsSkeleton()
 
 ### Community 280 - "Community 280"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): NotFound()
 
 ### Community 281 - "Community 281"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (0):
 
 ### Community 282 - "Community 282"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): AppContextMenu()
 
 ### Community 283 - "Community 283"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): Badge()
 
 ### Community 284 - "Community 284"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): LoadingButton()
 
 ### Community 285 - "Community 285"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): onChange()
 
 ### Community 286 - "Community 286"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): AlertModal()
 
 ### Community 287 - "Community 287"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): OverlayModal()
 
 ### Community 288 - "Community 288"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Skeleton()
 
 ### Community 289 - "Community 289"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 290 - "Community 290"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 291 - "Community 291"
 Cohesion: 0.67
@@ -2568,7 +2568,7 @@ Nodes (0):
 
 ### Community 296 - "Community 296"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 297 - "Community 297"
 Cohesion: 0.67
@@ -2576,7 +2576,7 @@ Nodes (0):
 
 ### Community 298 - "Community 298"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 299 - "Community 299"
 Cohesion: 0.67
@@ -2584,7 +2584,7 @@ Nodes (0):
 
 ### Community 300 - "Community 300"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 301 - "Community 301"
 Cohesion: 0.67
@@ -2592,47 +2592,47 @@ Nodes (0):
 
 ### Community 302 - "Community 302"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 303 - "Community 303"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 304 - "Community 304"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 305 - "Community 305"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): App()
 
 ### Community 306 - "Community 306"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 307 - "Community 307"
-Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 308 - "Community 308"
 Cohesion: 0.67
-Nodes (1): hashPassword()
+Nodes (0):
 
 ### Community 309 - "Community 309"
-Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 310 - "Community 310"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): hashPassword()
 
 ### Community 311 - "Community 311"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): createVersionChecker()
 
 ### Community 312 - "Community 312"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (1): manualChunks()
 
 ### Community 313 - "Community 313"
 Cohesion: 0.67
@@ -2640,51 +2640,51 @@ Nodes (0):
 
 ### Community 314 - "Community 314"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 315 - "Community 315"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 316 - "Community 316"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 317 - "Community 317"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 318 - "Community 318"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 319 - "Community 319"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 320 - "Community 320"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 321 - "Community 321"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 322 - "Community 322"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 323 - "Community 323"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 324 - "Community 324"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 326 - "Community 326"
 Cohesion: 0.67
@@ -2759,8 +2759,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 344 - "Community 344"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 345 - "Community 345"
 Cohesion: 0.67
@@ -2771,8 +2771,8 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 347 - "Community 347"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 348 - "Community 348"
 Cohesion: 1.0
@@ -2783,24 +2783,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 350 - "Community 350"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 351 - "Community 351"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 352 - "Community 352"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 352 - "Community 352"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
-
 ### Community 353 - "Community 353"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 354 - "Community 354"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 355 - "Community 355"
 Cohesion: 1.0
@@ -6763,1055 +6763,1051 @@ Cohesion: 1.0
 Nodes (0):
 
 ## Knowledge Gaps
-- **Thin community `Community 353`** (2 nodes): `getSource()`, `closeouts.test.ts`
+- **Thin community `Community 355`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 356`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 357`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 358`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 359`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 360`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 361`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 362`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (2 nodes): `authenticateHandler()`, `cashier.ts`
+- **Thin community `Community 363`** (2 nodes): `authenticateHandler()`, `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 364`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 365`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 366`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 367`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 368`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 369`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 370`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 371`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 372`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 373`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
+- **Thin community `Community 374`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 375`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 376`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 377`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 378`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 379`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 380`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 381`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 382`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 383`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `receiving.test.ts`, `getSource()`
+- **Thin community `Community 384`** (2 nodes): `receiving.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 385`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 386`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 387`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 388`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 389`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 390`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 391`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 392`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 393`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 394`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 395`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 396`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 397`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 398`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 399`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 400`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `queryUsage.test.ts`, `getSource()`
+- **Thin community `Community 401`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 402`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 403`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 404`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 405`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 406`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 407`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 408`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 409`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 410`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 411`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 412`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 413`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 414`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 415`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 416`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 417`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 418`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 419`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 420`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 421`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 422`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 423`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 424`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 425`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 426`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 427`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 428`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 429`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 430`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 431`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 432`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 433`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 434`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 435`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 436`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 437`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 438`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 439`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 440`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 441`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 442`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 443`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 444`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 445`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 446`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 447`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 448`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 449`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 450`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 451`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
+- **Thin community `Community 452`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 453`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 454`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 455`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 456`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 457`** (2 nodes): `CashierView()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `CashierView()`, `CashierView.tsx`
+- **Thin community `Community 458`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 459`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 460`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 461`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 462`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 463`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 464`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 465`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 466`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 467`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 468`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 469`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 470`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 471`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 472`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 473`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 474`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 475`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 476`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 477`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 478`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 479`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 480`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 481`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 482`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 483`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 484`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 485`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 486`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 487`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 488`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
+- **Thin community `Community 489`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 490`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 491`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 492`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 493`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 494`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 495`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 496`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 497`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 498`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 499`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 500`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 501`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 502`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 503`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 504`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
+- **Thin community `Community 505`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 506`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 507`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 508`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 509`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 510`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 511`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 512`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 513`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 514`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 515`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 516`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 517`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 518`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 519`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 520`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 521`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 522`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 523`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 524`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 525`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 526`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 527`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 528`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 529`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 530`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 531`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 532`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 533`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 534`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 535`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 536`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 537`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 538`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 539`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 540`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 541`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 542`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 543`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 544`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 545`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 546`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 547`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 548`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 549`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 550`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 551`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 552`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 553`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 554`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 555`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 556`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 557`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 558`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
+- **Thin community `Community 559`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 560`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 561`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 562`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 563`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 564`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 565`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 566`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 567`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 568`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 569`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 570`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 571`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 572`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 573`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 574`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 575`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 576`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 577`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 578`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 579`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 580`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 581`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 582`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 583`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 584`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 585`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 586`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 587`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 588`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 589`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 590`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 591`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 592`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 593`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 594`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 595`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 596`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 597`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 598`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 599`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 600`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 601`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 602`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 603`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 604`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 605`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 606`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 607`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 608`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 609`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 610`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 611`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 612`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 613`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 614`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 615`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 616`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 617`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 618`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 619`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 620`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 621`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 622`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 623`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 624`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 625`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 626`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 627`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 628`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 629`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 630`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 631`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 632`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 633`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 634`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 635`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 636`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 637`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 638`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 639`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 640`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 641`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 642`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 643`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 644`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 645`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 646`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 647`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 648`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 649`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 650`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 651`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 652`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 653`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 654`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 655`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 656`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 657`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 658`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 659`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 660`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 661`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 662`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 663`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 664`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 665`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 666`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 667`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 668`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 669`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 670`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 671`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 672`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 673`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 674`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 675`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 676`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 677`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 678`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 679`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 680`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 681`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 682`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 683`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 684`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 685`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 686`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 687`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 688`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 689`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 690`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 691`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 692`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 693`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 694`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 695`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `api.d.ts`
+- **Thin community `Community 696`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `api.js`
+- **Thin community `Community 697`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 698`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `server.d.ts`
+- **Thin community `Community 699`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `server.js`
+- **Thin community `Community 700`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `app.ts`
+- **Thin community `Community 701`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `auth.config.js`
+- **Thin community `Community 702`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `auth.ts`
+- **Thin community `Community 703`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 704`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `countries.ts`
+- **Thin community `Community 705`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `email.ts`
+- **Thin community `Community 706`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `ghana.ts`
+- **Thin community `Community 707`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `payment.ts`
+- **Thin community `Community 708`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `crons.ts`
+- **Thin community `Community 709`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 710`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 711`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 712`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 713`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `env.ts`
+- **Thin community `Community 714`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `analytics.ts`
+- **Thin community `Community 715`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `auth.ts`
+- **Thin community `Community 716`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 717`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `categories.ts`
+- **Thin community `Community 718`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `colors.ts`
+- **Thin community `Community 719`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `index.ts`
+- **Thin community `Community 720`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `organizations.ts`
+- **Thin community `Community 721`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `products.ts`
+- **Thin community `Community 722`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `stores.ts`
+- **Thin community `Community 723`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 724`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `index.ts`
+- **Thin community `Community 725`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `bag.ts`
+- **Thin community `Community 726`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `guest.ts`
+- **Thin community `Community 727`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `index.ts`
+- **Thin community `Community 728`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `me.ts`
+- **Thin community `Community 729`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `offers.ts`
+- **Thin community `Community 730`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 731`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `paystack.ts`
+- **Thin community `Community 732`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `reviews.ts`
+- **Thin community `Community 733`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `rewards.ts`
+- **Thin community `Community 734`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 735`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `security.test.ts`
+- **Thin community `Community 736`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `storefront.ts`
+- **Thin community `Community 737`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `upsells.ts`
+- **Thin community `Community 738`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `user.ts`
+- **Thin community `Community 739`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 740`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `health.test.ts`
+- **Thin community `Community 741`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `http.ts`
+- **Thin community `Community 742`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 743`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `auth.ts`
+- **Thin community `Community 744`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 745`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 746`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `categories.ts`
+- **Thin community `Community 747`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `colors.ts`
+- **Thin community `Community 748`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 749`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 750`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 751`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 752`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 753`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 754`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `organizations.ts`
+- **Thin community `Community 755`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `pos.ts`
+- **Thin community `Community 756`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 757`** (1 nodes): `posSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 758`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 759`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `productSku.ts`
+- **Thin community `Community 760`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 761`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 762`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 763`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 764`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 765`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 766`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 767`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 768`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 769`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `client.test.ts`
+- **Thin community `Community 770`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `config.test.ts`
+- **Thin community `Community 771`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 772`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `types.ts`
+- **Thin community `Community 773`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 774`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 775`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 776`** (1 nodes): `staffProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `staffProfiles.test.ts`
+- **Thin community `Community 777`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 778`** (1 nodes): `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `completeTransaction.test.ts`
+- **Thin community `Community 779`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `dto.ts`
+- **Thin community `Community 780`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 781`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `types.ts`
+- **Thin community `Community 782`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 783`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `catalog.ts`
+- **Thin community `Community 784`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `customers.ts`
+- **Thin community `Community 785`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `register.ts`
+- **Thin community `Community 786`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `terminals.ts`
+- **Thin community `Community 787`** (1 nodes): `transactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `transactions.ts`
+- **Thin community `Community 788`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `schema.ts`
+- **Thin community `Community 789`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 790`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 791`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 792`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 793`** (1 nodes): `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `cashier.ts`
+- **Thin community `Community 794`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `category.ts`
+- **Thin community `Community 795`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `color.ts`
+- **Thin community `Community 796`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 797`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 798`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `index.ts`
+- **Thin community `Community 799`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 800`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `organization.ts`
+- **Thin community `Community 801`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 802`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `product.ts`
+- **Thin community `Community 803`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 804`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 805`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `store.ts`
+- **Thin community `Community 806`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 807`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `index.ts`
+- **Thin community `Community 808`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 809`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 810`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 811`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 812`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 813`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `index.ts`
+- **Thin community `Community 814`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 815`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 816`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 817`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 818`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 819`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 820`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 821`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 822`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `customer.ts`
+- **Thin community `Community 823`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 824`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 825`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 826`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 827`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `index.ts`
+- **Thin community `Community 828`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `posSession.ts`
+- **Thin community `Community 829`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 830`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 831`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 832`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 833`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `index.ts`
+- **Thin community `Community 834`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 835`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 836`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 837`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 838`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 839`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `index.ts`
+- **Thin community `Community 840`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 841`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 842`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 843`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 844`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `vendor.ts`
+- **Thin community `Community 845`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `analytics.ts`
+- **Thin community `Community 846`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `bag.ts`
+- **Thin community `Community 847`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 848`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 849`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 850`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `customer.ts`
+- **Thin community `Community 851`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `guest.ts`
+- **Thin community `Community 852`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `index.ts`
+- **Thin community `Community 853`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `offer.ts`
+- **Thin community `Community 854`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 855`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 856`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `review.ts`
+- **Thin community `Community 857`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `rewards.ts`
+- **Thin community `Community 858`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 859`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 860`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 861`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 862`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 863`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 864`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 865`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `bag.ts`
+- **Thin community `Community 866`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 867`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `customer.ts`
+- **Thin community `Community 868`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `guest.ts`
+- **Thin community `Community 869`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 870`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 871`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `payment.ts`
+- **Thin community `Community 872`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 873`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 874`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 875`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `users.ts`
+- **Thin community `Community 876`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `payment.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `presentation.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `public.ts`
+- **Thin community `Community 877`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 878`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1096,6 +1096,30 @@
       "weight": 1
     },
     {
+      "_src": "core_createworkflowtracewithctx",
+      "_tgt": "core_getworkflowtracebyidwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "core_getworkflowtracebyidwithctx",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L87",
+      "target": "core_createworkflowtracewithctx",
+      "weight": 1
+    },
+    {
+      "_src": "core_getworkflowtracebylookupwithctx",
+      "_tgt": "core_getworkflowtracebyidwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "core_getworkflowtracebyidwithctx",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L59",
+      "target": "core_getworkflowtracebylookupwithctx",
+      "weight": 1
+    },
+    {
       "_src": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
       "_tgt": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
       "confidence": "EXTRACTED",
@@ -12913,6 +12937,102 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L5",
       "target": "utils_toslug",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "_tgt": "core_appendworkflowtraceeventwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L130",
+      "target": "core_appendworkflowtraceeventwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "_tgt": "core_createworkflowtracewithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L77",
+      "target": "core_createworkflowtracewithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "_tgt": "core_getworkflowtracebyidwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L17",
+      "target": "core_getworkflowtracebyidwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "_tgt": "core_getworkflowtracebylookupwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L32",
+      "target": "core_getworkflowtracebylookupwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "_tgt": "core_listworkflowtraceeventswithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L65",
+      "target": "core_listworkflowtraceeventswithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "_tgt": "core_registerworkflowtracelookupwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L100",
+      "target": "core_registerworkflowtracelookupwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
+      "_tgt": "presentation_buildworkflowtraceviewmodel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
+      "source_location": "L31",
+      "target": "presentation_buildworkflowtraceviewmodel",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
+      "_tgt": "queryusage_test_getsource",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L4",
+      "target": "queryusage_test_getsource",
       "weight": 1
     },
     {
@@ -36942,59 +37062,104 @@
     {
       "community": 100,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "id": "data_table_toolbar_datatabletoolbar",
+      "label": "DataTableToolbar()",
+      "norm_label": "datatabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1000,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
+      "label": "RegisterCheckoutPanel.tsx",
+      "norm_label": "registercheckoutpanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "label": "TransactionView.tsx",
+      "norm_label": "transactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1003,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
+      "label": "ProcurementView.test.tsx",
+      "norm_label": "procurementview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1004,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
+      "label": "ReceivingView.test.tsx",
+      "norm_label": "receivingview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -37003,7 +37168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -37012,7 +37177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -37021,7 +37186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -37030,7 +37195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -37039,7 +37204,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 1010,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -37048,7 +37267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1011,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -37057,7 +37276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -37066,7 +37285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -37075,7 +37294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1009,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -37084,61 +37303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 101,
-      "file_type": "code",
-      "id": "cashiermanagement_buildusername",
-      "label": "buildUsername()",
-      "norm_label": "buildusername()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "cashiermanagement_handledelete",
-      "label": "handleDelete()",
-      "norm_label": "handledelete()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L320"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "cashiermanagement_handlepinkeydown",
-      "label": "handlePinKeyDown()",
-      "norm_label": "handlepinkeydown()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L169"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "cashiermanagement_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L109"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "cashiermanagement_normalizenamesegment",
-      "label": "normalizeNameSegment()",
-      "norm_label": "normalizenamesegment()",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cashiers_cashiermanagement_tsx",
-      "label": "CashierManagement.tsx",
-      "norm_label": "cashiermanagement.tsx",
-      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1010,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -37147,7 +37312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -37156,7 +37321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -37165,7 +37330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -37174,7 +37339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -37183,7 +37348,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 102,
+      "file_type": "code",
+      "id": "cashiermanagement_buildusername",
+      "label": "buildUsername()",
+      "norm_label": "buildusername()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "cashiermanagement_handledelete",
+      "label": "handleDelete()",
+      "norm_label": "handledelete()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L320"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "cashiermanagement_handlepinkeydown",
+      "label": "handlePinKeyDown()",
+      "norm_label": "handlepinkeydown()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L169"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "cashiermanagement_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L109"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "cashiermanagement_normalizenamesegment",
+      "label": "normalizeNameSegment()",
+      "norm_label": "normalizenamesegment()",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cashiers_cashiermanagement_tsx",
+      "label": "CashierManagement.tsx",
+      "norm_label": "cashiermanagement.tsx",
+      "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1020,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -37192,7 +37411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1021,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -37201,7 +37420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -37210,7 +37429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -37219,7 +37438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1019,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -37228,61 +37447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 102,
-      "file_type": "code",
-      "id": "bannermessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L123"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleactivetoggle",
-      "label": "handleActiveToggle()",
-      "norm_label": "handleactivetoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleclear",
-      "label": "handleClear()",
-      "norm_label": "handleclear()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L113"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "label": "BannerMessageEditor.tsx",
-      "norm_label": "bannermessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1020,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -37291,7 +37456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -37300,7 +37465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -37309,7 +37474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -37318,7 +37483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -37327,7 +37492,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 103,
+      "file_type": "code",
+      "id": "bannermessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L123"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleactivetoggle",
+      "label": "handleActiveToggle()",
+      "norm_label": "handleactivetoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L113"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
+      "label": "BannerMessageEditor.tsx",
+      "norm_label": "bannermessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1030,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -37336,7 +37555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1031,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -37345,7 +37564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -37354,7 +37573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -37363,7 +37582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1029,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -37372,61 +37591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 103,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "label": "ReviewsView.tsx",
-      "norm_label": "reviewsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "reviewsview_handleapprove",
-      "label": "handleApprove()",
-      "norm_label": "handleapprove()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "reviewsview_handlepublish",
-      "label": "handlePublish()",
-      "norm_label": "handlepublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "reviewsview_handlereject",
-      "label": "handleReject()",
-      "norm_label": "handlereject()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "reviewsview_handleunpublish",
-      "label": "handleUnpublish()",
-      "norm_label": "handleunpublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "reviewsview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 1030,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -37435,7 +37600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -37444,7 +37609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -37453,7 +37618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -37462,7 +37627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -37471,7 +37636,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 104,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
+      "label": "ReviewsView.tsx",
+      "norm_label": "reviewsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "reviewsview_handleapprove",
+      "label": "handleApprove()",
+      "norm_label": "handleapprove()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "reviewsview_handlepublish",
+      "label": "handlePublish()",
+      "norm_label": "handlepublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "reviewsview_handlereject",
+      "label": "handleReject()",
+      "norm_label": "handlereject()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "reviewsview_handleunpublish",
+      "label": "handleUnpublish()",
+      "norm_label": "handleunpublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "reviewsview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 1040,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -37480,7 +37699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1041,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -37489,7 +37708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -37498,7 +37717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -37507,7 +37726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1039,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -37516,61 +37735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 104,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1040,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -37579,7 +37744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -37588,7 +37753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -37597,7 +37762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -37606,57 +37771,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
       "norm_label": "mtnmomoview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1045,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1046,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
-      "label": "accordion.tsx",
-      "norm_label": "accordion.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/accordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1047,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
-      "label": "button.test.tsx",
-      "norm_label": "button.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1048,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_button_tsx",
-      "label": "button.tsx",
-      "norm_label": "button.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
-      "label": "calendar.test.tsx",
-      "norm_label": "calendar.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
       "source_location": "L1"
     },
     {
@@ -37716,6 +37836,51 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
+      "label": "accordion.tsx",
+      "norm_label": "accordion.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/accordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1052,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
+      "label": "button.test.tsx",
+      "norm_label": "button.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1053,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_button_tsx",
+      "label": "button.tsx",
+      "norm_label": "button.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1054,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
+      "label": "calendar.test.tsx",
+      "norm_label": "calendar.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1055,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
       "norm_label": "card.tsx",
@@ -37723,7 +37888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -37732,7 +37897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -37741,7 +37906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -37750,57 +37915,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
       "norm_label": "context-menu.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1055,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1056,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
-      "label": "dropdown-menu.tsx",
-      "norm_label": "dropdown-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1057,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_form_tsx",
-      "label": "form.tsx",
-      "norm_label": "form.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1058,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_icons_tsx",
-      "label": "icons.tsx",
-      "norm_label": "icons.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/icons.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
-      "label": "input-otp.tsx",
-      "norm_label": "input-otp.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1"
     },
     {
@@ -37860,6 +37980,51 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
+      "label": "dropdown-menu.tsx",
+      "norm_label": "dropdown-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1062,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_form_tsx",
+      "label": "form.tsx",
+      "norm_label": "form.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1063,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_icons_tsx",
+      "label": "icons.tsx",
+      "norm_label": "icons.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/icons.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1064,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
+      "label": "input-otp.tsx",
+      "norm_label": "input-otp.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1065,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
       "norm_label": "input.tsx",
@@ -37867,7 +38032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -37876,7 +38041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -37885,7 +38050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -37894,57 +38059,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1065,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1066,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_select_tsx",
-      "label": "select.tsx",
-      "norm_label": "select.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1067,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_separator_tsx",
-      "label": "separator.tsx",
-      "norm_label": "separator.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1068,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
-      "label": "sheet.tsx",
-      "norm_label": "sheet.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
-      "label": "switch.tsx",
-      "norm_label": "switch.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
       "source_location": "L1"
     },
     {
@@ -38004,6 +38124,51 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_select_tsx",
+      "label": "select.tsx",
+      "norm_label": "select.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1072,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_separator_tsx",
+      "label": "separator.tsx",
+      "norm_label": "separator.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1073,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
+      "label": "sheet.tsx",
+      "norm_label": "sheet.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1074,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
+      "label": "switch.tsx",
+      "norm_label": "switch.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1075,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
       "norm_label": "table.tsx",
@@ -38011,7 +38176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -38020,7 +38185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -38029,7 +38194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -38038,57 +38203,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
       "norm_label": "toggle.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1075,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1076,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_upload_button_tsx",
-      "label": "upload-button.tsx",
-      "norm_label": "upload-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1077,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
-      "label": "BagView.tsx",
-      "norm_label": "bagview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1078,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -38148,6 +38268,51 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_upload_button_tsx",
+      "label": "upload-button.tsx",
+      "norm_label": "upload-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1082,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
+      "label": "BagView.tsx",
+      "norm_label": "bagview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1083,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1084,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1085,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -38155,7 +38320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -38164,7 +38329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -38173,7 +38338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -38182,57 +38347,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
       "norm_label": "bag-columns.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1085,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
-      "label": "bags-table.tsx",
-      "norm_label": "bags-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1086,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1087,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1088,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -38292,6 +38412,51 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
+      "label": "bags-table.tsx",
+      "norm_label": "bags-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1092,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1093,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1094,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1095,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
@@ -38299,7 +38464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -38308,7 +38473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -38317,7 +38482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -38326,57 +38491,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
       "norm_label": "usercheckoutsession.tsx",
       "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1095,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
-      "label": "UserInsightsSection.tsx",
-      "norm_label": "userinsightssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1096,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
-      "label": "UserBehaviorInsights.tsx",
-      "norm_label": "userbehaviorinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1097,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1098,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
-      "label": "ThemeContext.tsx",
-      "norm_label": "themecontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
       "source_location": "L1"
     },
     {
@@ -38616,6 +38736,51 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
+      "label": "UserInsightsSection.tsx",
+      "norm_label": "userinsightssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
+      "label": "UserBehaviorInsights.tsx",
+      "norm_label": "userbehaviorinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1102,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1103,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1104,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
+      "label": "ThemeContext.tsx",
+      "norm_label": "themecontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1105,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
       "norm_label": "use-store-modal.tsx",
@@ -38623,7 +38788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -38632,7 +38797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
@@ -38641,7 +38806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -38650,57 +38815,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
       "norm_label": "countries.ts",
       "source_file": "packages/athena-webapp/src/lib/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1105,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1106,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
-      "label": "ghanaRegions.ts",
-      "norm_label": "ghanaregions.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1107,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
-      "label": "bootstrapRegister.test.ts",
-      "norm_label": "bootstrapregister.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1108,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
-      "label": "dto.ts",
-      "norm_label": "dto.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
-      "label": "ports.ts",
-      "norm_label": "ports.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
       "source_location": "L1"
     },
     {
@@ -38760,6 +38880,51 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
+      "label": "ghanaRegions.ts",
+      "norm_label": "ghanaregions.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1112,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
+      "label": "bootstrapRegister.test.ts",
+      "norm_label": "bootstrapregister.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1113,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
+      "label": "dto.ts",
+      "norm_label": "dto.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1114,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
+      "label": "ports.ts",
+      "norm_label": "ports.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1115,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -38767,7 +38932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -38776,7 +38941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -38785,7 +38950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -38794,57 +38959,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
       "norm_label": "session.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/domain/session.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1115,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1116,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
-      "label": "registerGateway.test.ts",
-      "norm_label": "registergateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1117,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
-      "label": "loggerGateway.ts",
-      "norm_label": "loggergateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1118,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
-      "label": "registerUiState.ts",
-      "norm_label": "registeruistate.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
-      "label": "useRegisterViewModel.test.ts",
-      "norm_label": "useregisterviewmodel.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
       "source_location": "L1"
     },
     {
@@ -38904,6 +39024,51 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
+      "label": "registerGateway.test.ts",
+      "norm_label": "registergateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
+      "label": "loggerGateway.ts",
+      "norm_label": "loggergateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1123,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
+      "label": "registerUiState.ts",
+      "norm_label": "registeruistate.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1124,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
+      "label": "useRegisterViewModel.test.ts",
+      "norm_label": "useregisterviewmodel.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1125,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
       "norm_label": "productutils.test.ts",
@@ -38911,7 +39076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -38920,7 +39085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -38929,7 +39094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -38938,57 +39103,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
       "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1125,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1126,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
-      "label": "storeConfig.test.ts",
-      "norm_label": "storeconfig.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
-      "label": "createWorkflowTraceId.test.ts",
-      "norm_label": "createworkflowtraceid.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routetree_gen_ts",
-      "label": "routeTree.gen.ts",
-      "norm_label": "routetree.gen.ts",
-      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
       "source_location": "L1"
     },
     {
@@ -39048,6 +39168,51 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
+      "label": "storeConfig.test.ts",
+      "norm_label": "storeconfig.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1132,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
+      "label": "createWorkflowTraceId.test.ts",
+      "norm_label": "createworkflowtraceid.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1133,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1134,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routetree_gen_ts",
+      "label": "routeTree.gen.ts",
+      "norm_label": "routetree.gen.ts",
+      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1135,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
       "norm_label": "__root.tsx",
@@ -39055,7 +39220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -39064,7 +39229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -39073,7 +39238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -39082,57 +39247,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
       "norm_label": "$storeurlslug.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1135,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
-      "label": "analytics.tsx",
-      "norm_label": "analytics.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1136,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
-      "label": "assets.index.tsx",
-      "norm_label": "assets.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1137,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
-      "label": "bags.$bagId.tsx",
-      "norm_label": "bags.$bagid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1138,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
-      "label": "bags.index.tsx",
-      "norm_label": "bags.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
       "source_location": "L1"
     },
     {
@@ -39192,6 +39312,51 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
+      "label": "analytics.tsx",
+      "norm_label": "analytics.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
+      "label": "assets.index.tsx",
+      "norm_label": "assets.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1142,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
+      "label": "bags.$bagId.tsx",
+      "norm_label": "bags.$bagid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1143,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
+      "label": "bags.index.tsx",
+      "norm_label": "bags.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1144,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1145,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
       "norm_label": "checkout-sessions.index.tsx",
@@ -39199,7 +39364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -39208,7 +39373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -39217,7 +39382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -39226,57 +39391,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
       "norm_label": "logs.$logid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1145,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
-      "label": "logs.index.tsx",
-      "norm_label": "logs.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1146,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
-      "label": "members.index.tsx",
-      "norm_label": "members.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1147,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1148,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
-      "label": "all.index.tsx",
-      "norm_label": "all.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
       "source_location": "L1"
     },
     {
@@ -39336,6 +39456,51 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
+      "label": "logs.index.tsx",
+      "norm_label": "logs.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
+      "label": "members.index.tsx",
+      "norm_label": "members.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1152,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1153,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1154,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
+      "label": "all.index.tsx",
+      "norm_label": "all.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1155,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
       "norm_label": "cancelled.index.tsx",
@@ -39343,7 +39508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -39352,7 +39517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -39361,7 +39526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -39370,57 +39535,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
       "norm_label": "out-for-delivery.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1155,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
-      "label": "ready.index.tsx",
-      "norm_label": "ready.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1156,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
-      "label": "refunded.index.tsx",
-      "norm_label": "refunded.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1157,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
-      "label": "$reportId.tsx",
-      "norm_label": "$reportid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
-      "label": "expense-reports.index.tsx",
-      "norm_label": "expense-reports.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
-      "label": "expense.index.tsx",
-      "norm_label": "expense.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
       "source_location": "L1"
     },
     {
@@ -39480,6 +39600,51 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
+      "label": "ready.index.tsx",
+      "norm_label": "ready.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
+      "label": "refunded.index.tsx",
+      "norm_label": "refunded.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1162,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
+      "label": "$reportId.tsx",
+      "norm_label": "$reportid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1163,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
+      "label": "expense-reports.index.tsx",
+      "norm_label": "expense-reports.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1164,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
+      "label": "expense.index.tsx",
+      "norm_label": "expense.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1165,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -39487,7 +39652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -39496,7 +39661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -39505,7 +39670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -39514,57 +39679,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
       "norm_label": "transactions.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1165,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
-      "label": "procurement.index.tsx",
-      "norm_label": "procurement.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1166,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
-      "label": "edit.tsx",
-      "norm_label": "edit.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1167,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1168,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
       "source_location": "L1"
     },
     {
@@ -39624,6 +39744,51 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
+      "label": "procurement.index.tsx",
+      "norm_label": "procurement.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
+      "label": "edit.tsx",
+      "norm_label": "edit.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1172,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1173,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1174,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1175,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -39631,7 +39796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -39640,7 +39805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -39649,7 +39814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -39658,7 +39823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -39667,7 +39832,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 118,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1180,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -39676,7 +39895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1181,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -39685,7 +39904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -39694,7 +39913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -39703,7 +39922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1179,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -39712,61 +39931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 118,
-      "file_type": "code",
-      "id": "feeutils_getremainingforfreedelivery",
-      "label": "getRemainingForFreeDelivery()",
-      "norm_label": "getremainingforfreedelivery()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "feeutils_haswaiverconfigured",
-      "label": "hasWaiverConfigured()",
-      "norm_label": "haswaiverconfigured()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "feeutils_isanyfeewaived",
-      "label": "isAnyFeeWaived()",
-      "norm_label": "isanyfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "feeutils_isfeewaived",
-      "label": "isFeeWaived()",
-      "norm_label": "isfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "feeutils_meetsthreshold",
-      "label": "meetsThreshold()",
-      "norm_label": "meetsthreshold()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
-      "label": "feeUtils.ts",
-      "norm_label": "feeutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1180,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -39775,7 +39940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -39784,7 +39949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -39793,7 +39958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -39802,7 +39967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -39811,7 +39976,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 119,
+      "file_type": "code",
+      "id": "feeutils_getremainingforfreedelivery",
+      "label": "getRemainingForFreeDelivery()",
+      "norm_label": "getremainingforfreedelivery()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "feeutils_haswaiverconfigured",
+      "label": "hasWaiverConfigured()",
+      "norm_label": "haswaiverconfigured()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "feeutils_isanyfeewaived",
+      "label": "isAnyFeeWaived()",
+      "norm_label": "isanyfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "feeutils_isfeewaived",
+      "label": "isFeeWaived()",
+      "norm_label": "isfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "feeutils_meetsthreshold",
+      "label": "meetsThreshold()",
+      "norm_label": "meetsthreshold()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
+      "label": "feeUtils.ts",
+      "norm_label": "feeutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1190,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -39820,7 +40039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -39829,7 +40048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -39838,7 +40057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -39847,7 +40066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1189,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -39856,61 +40075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 119,
-      "file_type": "code",
-      "id": "auth_verify_formattime",
-      "label": "formatTime()",
-      "norm_label": "formattime()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L149"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "auth_verify_handlecodechange",
-      "label": "handleCodeChange()",
-      "norm_label": "handlecodechange()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "auth_verify_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "auth_verify_reportauthfailure",
-      "label": "reportAuthFailure()",
-      "norm_label": "reportauthfailure()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "auth_verify_resendverificationcode",
-      "label": "resendVerificationCode()",
-      "norm_label": "resendverificationcode()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L282"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
-      "label": "auth.verify.tsx",
-      "norm_label": "auth.verify.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1190,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -39919,7 +40084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -39928,7 +40093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -39937,7 +40102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -39946,57 +40111,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
       "norm_label": "adminshell.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1195,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
-      "label": "admin-shell-patterns.test.tsx",
-      "norm_label": "admin-shell-patterns.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1196,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
-      "label": "Surfaces.stories.tsx",
-      "norm_label": "surfaces.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1197,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
-      "label": "DashboardWorkspace.stories.tsx",
-      "norm_label": "dashboardworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
-      "label": "DataWorkspace.stories.tsx",
-      "norm_label": "dataworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
-      "label": "SettingsWorkspace.stories.tsx",
-      "norm_label": "settingsworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -40164,59 +40284,104 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "graphify_check_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L72"
+      "id": "auth_verify_formattime",
+      "label": "formatTime()",
+      "norm_label": "formattime()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L149"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "graphify_check_collectstalegraphifyartifacts",
-      "label": "collectStaleGraphifyArtifacts()",
-      "norm_label": "collectstalegraphifyartifacts()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L124"
+      "id": "auth_verify_handlecodechange",
+      "label": "handleCodeChange()",
+      "norm_label": "handlecodechange()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L156"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "graphify_check_copygraphifycheckinputs",
-      "label": "copyGraphifyCheckInputs()",
-      "norm_label": "copygraphifycheckinputs()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L106"
+      "id": "auth_verify_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L201"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "graphify_check_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L63"
+      "id": "auth_verify_reportauthfailure",
+      "label": "reportAuthFailure()",
+      "norm_label": "reportauthfailure()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L93"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "graphify_check_rungraphifycheck",
-      "label": "runGraphifyCheck()",
-      "norm_label": "rungraphifycheck()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L151"
+      "id": "auth_verify_resendverificationcode",
+      "label": "resendVerificationCode()",
+      "norm_label": "resendverificationcode()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L282"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "scripts_graphify_check_ts",
-      "label": "graphify-check.ts",
-      "norm_label": "graphify-check.ts",
-      "source_file": "scripts/graphify-check.ts",
+      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
+      "label": "auth.verify.tsx",
+      "norm_label": "auth.verify.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L1"
     },
     {
       "community": 1200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
+      "label": "admin-shell-patterns.test.tsx",
+      "norm_label": "admin-shell-patterns.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
+      "label": "Surfaces.stories.tsx",
+      "norm_label": "surfaces.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1202,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
+      "label": "DashboardWorkspace.stories.tsx",
+      "norm_label": "dashboardworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1203,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
+      "label": "DataWorkspace.stories.tsx",
+      "norm_label": "dataworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1204,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
+      "label": "SettingsWorkspace.stories.tsx",
+      "norm_label": "settingsworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -40225,7 +40390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -40234,7 +40399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -40243,7 +40408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -40252,7 +40417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -40261,7 +40426,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 121,
+      "file_type": "code",
+      "id": "graphify_check_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "graphify_check_collectstalegraphifyartifacts",
+      "label": "collectStaleGraphifyArtifacts()",
+      "norm_label": "collectstalegraphifyartifacts()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "graphify_check_copygraphifycheckinputs",
+      "label": "copyGraphifyCheckInputs()",
+      "norm_label": "copygraphifycheckinputs()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "graphify_check_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "graphify_check_rungraphifycheck",
+      "label": "runGraphifyCheck()",
+      "norm_label": "rungraphifycheck()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "scripts_graphify_check_ts",
+      "label": "graphify-check.ts",
+      "norm_label": "graphify-check.ts",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1210,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -40270,7 +40489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1211,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -40279,7 +40498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -40288,7 +40507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -40297,7 +40516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1209,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -40306,61 +40525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 121,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
-      "label": "buildAthenaRuntimeUrl()",
-      "norm_label": "buildathenaruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
-      "label": "buildValkeyRuntimeUrl()",
-      "norm_label": "buildvalkeyruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
-      "label": "createAthenaRuntimeProcess()",
-      "norm_label": "createathenaruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
-      "label": "createStorefrontRuntimeProcesses()",
-      "norm_label": "createstorefrontruntimeprocesses()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
-      "label": "createValkeyRuntimeProcess()",
-      "norm_label": "createvalkeyruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_scenarios_ts",
-      "label": "harness-behavior-scenarios.ts",
-      "norm_label": "harness-behavior-scenarios.ts",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1210,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -40369,7 +40534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -40378,7 +40543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -40387,7 +40552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -40396,7 +40561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -40405,7 +40570,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 122,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
+      "label": "buildAthenaRuntimeUrl()",
+      "norm_label": "buildathenaruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
+      "label": "buildValkeyRuntimeUrl()",
+      "norm_label": "buildvalkeyruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
+      "label": "createAthenaRuntimeProcess()",
+      "norm_label": "createathenaruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
+      "label": "createStorefrontRuntimeProcesses()",
+      "norm_label": "createstorefrontruntimeprocesses()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
+      "label": "createValkeyRuntimeProcess()",
+      "norm_label": "createvalkeyruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_scenarios_ts",
+      "label": "harness-behavior-scenarios.ts",
+      "norm_label": "harness-behavior-scenarios.ts",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1220,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -40414,7 +40633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1221,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -40423,7 +40642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -40432,7 +40651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -40441,7 +40660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1219,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -40450,52 +40669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 122,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "label": "r2.ts",
-      "norm_label": "r2.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "r2_deletedirectoryinr2",
-      "label": "deleteDirectoryInR2()",
-      "norm_label": "deletedirectoryinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "r2_deletefileinr2",
-      "label": "deleteFileInR2()",
-      "norm_label": "deletefileinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "r2_listitemsinr2directory",
-      "label": "listItemsInR2Directory()",
-      "norm_label": "listitemsinr2directory()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "r2_uploadfiletor2",
-      "label": "uploadFileToR2()",
-      "norm_label": "uploadfiletor2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 1220,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -40504,7 +40678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -40513,7 +40687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -40522,7 +40696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -40531,7 +40705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -40540,7 +40714,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 123,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
+      "label": "r2.ts",
+      "norm_label": "r2.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "r2_deletedirectoryinr2",
+      "label": "deleteDirectoryInR2()",
+      "norm_label": "deletedirectoryinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "r2_deletefileinr2",
+      "label": "deleteFileInR2()",
+      "norm_label": "deletefileinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "r2_listitemsinr2directory",
+      "label": "listItemsInR2Directory()",
+      "norm_label": "listitemsinr2directory()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "r2_uploadfiletor2",
+      "label": "uploadFileToR2()",
+      "norm_label": "uploadfiletor2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 1230,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -40549,7 +40768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1231,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -40558,7 +40777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1232,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -40567,7 +40786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1228,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -40576,7 +40795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1229,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -40585,52 +40804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 123,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
-      "label": "validateExpenseItemBelongsToSession()",
-      "norm_label": "validateexpenseitembelongstosession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionactive",
-      "label": "validateExpenseSessionActive()",
-      "norm_label": "validateexpensesessionactive()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionexists",
-      "label": "validateExpenseSessionExists()",
-      "norm_label": "validateexpensesessionexists()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
-      "label": "validateExpenseSessionModifiable()",
-      "norm_label": "validateexpensesessionmodifiable()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
-      "label": "expenseSessionValidation.ts",
-      "norm_label": "expensesessionvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1230,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -40639,7 +40813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -40648,7 +40822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -40657,7 +40831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -40666,7 +40840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -40675,7 +40849,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 124,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
+      "label": "validateExpenseItemBelongsToSession()",
+      "norm_label": "validateexpenseitembelongstosession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionactive",
+      "label": "validateExpenseSessionActive()",
+      "norm_label": "validateexpensesessionactive()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionexists",
+      "label": "validateExpenseSessionExists()",
+      "norm_label": "validateexpensesessionexists()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
+      "label": "validateExpenseSessionModifiable()",
+      "norm_label": "validateexpensesessionmodifiable()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
+      "label": "expenseSessionValidation.ts",
+      "norm_label": "expensesessionvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1240,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -40684,7 +40903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1241,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -40693,7 +40912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -40702,7 +40921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -40711,7 +40930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1239,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -40720,52 +40939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 124,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_products_ts",
-      "label": "products.ts",
-      "norm_label": "products.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "products_calculatetotalavailablecount",
-      "label": "calculateTotalAvailableCount()",
-      "norm_label": "calculatetotalavailablecount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "products_calculatetotalinventorycount",
-      "label": "calculateTotalInventoryCount()",
-      "norm_label": "calculatetotalinventorycount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "products_generatebarcode",
-      "label": "generateBarcode()",
-      "norm_label": "generatebarcode()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "products_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 1240,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -40774,7 +40948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -40783,7 +40957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -40792,7 +40966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -40801,7 +40975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -40810,7 +40984,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 125,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_products_ts",
+      "label": "products.ts",
+      "norm_label": "products.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "products_calculatetotalavailablecount",
+      "label": "calculateTotalAvailableCount()",
+      "norm_label": "calculatetotalavailablecount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "products_calculatetotalinventorycount",
+      "label": "calculateTotalInventoryCount()",
+      "norm_label": "calculatetotalinventorycount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "products_generatebarcode",
+      "label": "generateBarcode()",
+      "norm_label": "generatebarcode()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "products_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 1250,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -40819,7 +41038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1251,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -40828,7 +41047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -40837,7 +41056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -40846,7 +41065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1249,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -40855,52 +41074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 125,
-      "file_type": "code",
-      "id": "customerprofiles_compactrecord",
-      "label": "compactRecord()",
-      "norm_label": "compactrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
-      "label": "ensureCustomerProfileFromSourcesWithCtx()",
-      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "customerprofiles_findexistingprofile",
-      "label": "findExistingProfile()",
-      "norm_label": "findexistingprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "customerprofiles_loadcustomersources",
-      "label": "loadCustomerSources()",
-      "norm_label": "loadcustomersources()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
-      "label": "customerProfiles.ts",
-      "norm_label": "customerprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1250,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -40909,7 +41083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -40918,7 +41092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -40927,7 +41101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -40936,7 +41110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -40945,7 +41119,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 126,
+      "file_type": "code",
+      "id": "customerprofiles_compactrecord",
+      "label": "compactRecord()",
+      "norm_label": "compactrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
+      "label": "ensureCustomerProfileFromSourcesWithCtx()",
+      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "customerprofiles_findexistingprofile",
+      "label": "findExistingProfile()",
+      "norm_label": "findexistingprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "customerprofiles_loadcustomersources",
+      "label": "loadCustomerSources()",
+      "norm_label": "loadcustomersources()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
+      "label": "customerProfiles.ts",
+      "norm_label": "customerprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1260,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -40954,7 +41173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1261,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -40963,7 +41182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1262,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -40972,7 +41191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -40981,7 +41200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1259,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -40990,52 +41209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 126,
-      "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1260,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -41044,7 +41218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -41053,7 +41227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -41062,7 +41236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -41071,7 +41245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -41080,7 +41254,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 127,
+      "file_type": "code",
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1270,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -41089,7 +41308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1271,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -41098,7 +41317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1272,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -41107,7 +41326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -41116,7 +41335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1269,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -41125,52 +41344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 1270,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -41179,7 +41353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -41188,7 +41362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -41197,7 +41371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -41206,7 +41380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -41215,7 +41389,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 128,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 1280,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -41224,7 +41443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1281,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -41233,7 +41452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1282,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -41242,7 +41461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -41251,7 +41470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1279,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -41260,52 +41479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_paystackservice_ts",
-      "label": "paystackService.ts",
-      "norm_label": "paystackservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "paystackservice_getpaystackheaders",
-      "label": "getPaystackHeaders()",
-      "norm_label": "getpaystackheaders()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "paystackservice_initializetransaction",
-      "label": "initializeTransaction()",
-      "norm_label": "initializetransaction()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "paystackservice_initiaterefund",
-      "label": "initiateRefund()",
-      "norm_label": "initiaterefund()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "paystackservice_verifytransaction",
-      "label": "verifyTransaction()",
-      "norm_label": "verifytransaction()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 1280,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -41314,7 +41488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -41323,7 +41497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -41332,7 +41506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -41341,7 +41515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -41350,7 +41524,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 129,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_paystackservice_ts",
+      "label": "paystackService.ts",
+      "norm_label": "paystackservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "paystackservice_getpaystackheaders",
+      "label": "getPaystackHeaders()",
+      "norm_label": "getpaystackheaders()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "paystackservice_initializetransaction",
+      "label": "initializeTransaction()",
+      "norm_label": "initializetransaction()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "paystackservice_initiaterefund",
+      "label": "initiateRefund()",
+      "norm_label": "initiaterefund()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "paystackservice_verifytransaction",
+      "label": "verifyTransaction()",
+      "norm_label": "verifytransaction()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 1290,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -41359,7 +41578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1291,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -41368,7 +41587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -41377,7 +41596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -41386,7 +41605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1289,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -41395,52 +41614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
-      "label": "returnExchangeOperations.ts",
-      "norm_label": "returnexchangeoperations.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
-      "label": "buildOnlineOrderReturnExchangePlan()",
-      "norm_label": "buildonlineorderreturnexchangeplan()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "returnexchangeoperations_getapprovalreason",
-      "label": "getApprovalReason()",
-      "norm_label": "getapprovalreason()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "returnexchangeoperations_getkind",
-      "label": "getKind()",
-      "norm_label": "getkind()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "returnexchangeoperations_getlinerefundamount",
-      "label": "getLineRefundAmount()",
-      "norm_label": "getlinerefundamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 1290,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -41449,7 +41623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -41458,7 +41632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -41467,7 +41641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -41476,57 +41650,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
       "norm_label": "config.ts",
       "source_file": "packages/storefront-webapp/src/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1295,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1296,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1297,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
-      "label": "useStorefrontObservability.ts",
-      "norm_label": "usestorefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1298,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/storefront-webapp/src/lib/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/storefront-webapp/src/lib/countries.ts",
       "source_location": "L1"
     },
     {
@@ -41694,50 +41823,95 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "offers_createoffer",
-      "label": "createOffer()",
-      "norm_label": "createoffer()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "offers_getupsellproducts",
-      "label": "getUpsellProducts()",
-      "norm_label": "getupsellproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L765"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "offers_isduplicate",
-      "label": "isDuplicate()",
-      "norm_label": "isduplicate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "offers_updatestorefrontactoremail",
-      "label": "updateStoreFrontActorEmail()",
-      "norm_label": "updatestorefrontactoremail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
+      "label": "returnExchangeOperations.ts",
+      "norm_label": "returnexchangeoperations.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
       "source_location": "L1"
     },
     {
+      "community": 130,
+      "file_type": "code",
+      "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
+      "label": "buildOnlineOrderReturnExchangePlan()",
+      "norm_label": "buildonlineorderreturnexchangeplan()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getapprovalreason",
+      "label": "getApprovalReason()",
+      "norm_label": "getapprovalreason()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getkind",
+      "label": "getKind()",
+      "norm_label": "getkind()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getlinerefundamount",
+      "label": "getLineRefundAmount()",
+      "norm_label": "getlinerefundamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L70"
+    },
+    {
       "community": 1300,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1302,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
+      "label": "useStorefrontObservability.ts",
+      "norm_label": "usestorefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1303,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/storefront-webapp/src/lib/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1304,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/storefront-webapp/src/lib/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -41746,7 +41920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -41755,7 +41929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -41764,7 +41938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -41773,7 +41947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -41782,7 +41956,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 131,
+      "file_type": "code",
+      "id": "offers_createoffer",
+      "label": "createOffer()",
+      "norm_label": "createoffer()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L89"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "offers_getupsellproducts",
+      "label": "getUpsellProducts()",
+      "norm_label": "getupsellproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L765"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "offers_isduplicate",
+      "label": "isDuplicate()",
+      "norm_label": "isduplicate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "offers_updatestorefrontactoremail",
+      "label": "updateStoreFrontActorEmail()",
+      "norm_label": "updatestorefrontactoremail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1310,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -41791,7 +42010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1311,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -41800,7 +42019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1312,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -41809,7 +42028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1308,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -41818,7 +42037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1309,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -41827,52 +42046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 131,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
-      "label": "storefrontObservabilityReport.ts",
-      "norm_label": "storefrontobservabilityreport.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
-      "label": "buildStorefrontObservabilityReport()",
-      "norm_label": "buildstorefrontobservabilityreport()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_getnonemptystring",
-      "label": "getNonEmptyString()",
-      "norm_label": "getnonemptystring()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_gettrafficsource",
-      "label": "getTrafficSource()",
-      "norm_label": "gettrafficsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
-      "label": "normalizeStorefrontObservabilityEvent()",
-      "norm_label": "normalizestorefrontobservabilityevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 1310,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -41881,7 +42055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -41890,7 +42064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -41899,7 +42073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -41908,7 +42082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -41917,7 +42091,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 132,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
+      "label": "storefrontObservabilityReport.ts",
+      "norm_label": "storefrontobservabilityreport.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
+      "label": "buildStorefrontObservabilityReport()",
+      "norm_label": "buildstorefrontobservabilityreport()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_getnonemptystring",
+      "label": "getNonEmptyString()",
+      "norm_label": "getnonemptystring()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_gettrafficsource",
+      "label": "getTrafficSource()",
+      "norm_label": "gettrafficsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
+      "label": "normalizeStorefrontObservabilityEvent()",
+      "norm_label": "normalizestorefrontobservabilityevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 1320,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -41926,7 +42145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -41935,7 +42154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -41944,7 +42163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1318,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -41953,7 +42172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1319,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -41962,52 +42181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 132,
-      "file_type": "code",
-      "id": "navbar_appheader",
-      "label": "AppHeader()",
-      "norm_label": "appheader()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "navbar_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "navbar_navbar",
-      "label": "Navbar()",
-      "norm_label": "navbar()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "navbar_settingsheader",
-      "label": "SettingsHeader()",
-      "norm_label": "settingsheader()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_navbar_tsx",
-      "label": "Navbar.tsx",
-      "norm_label": "navbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1320,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -42016,7 +42190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -42025,7 +42199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -42034,7 +42208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -42043,7 +42217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -42052,7 +42226,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 133,
+      "file_type": "code",
+      "id": "navbar_appheader",
+      "label": "AppHeader()",
+      "norm_label": "appheader()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "navbar_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "navbar_navbar",
+      "label": "Navbar()",
+      "norm_label": "navbar()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "navbar_settingsheader",
+      "label": "SettingsHeader()",
+      "norm_label": "settingsheader()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_navbar_tsx",
+      "label": "Navbar.tsx",
+      "norm_label": "navbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1330,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -42061,7 +42280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1331,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -42070,7 +42289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1332,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -42079,7 +42298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -42088,7 +42307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1329,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -42097,52 +42316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 133,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
-      "label": "ProductCategorization.tsx",
-      "norm_label": "productcategorization.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "productcategorization_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L286"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "productcategorization_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L203"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "productcategorization_handleproductvisibility",
-      "label": "handleProductVisibility()",
-      "norm_label": "handleproductvisibility()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L243"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "productcategorization_setinitialselectedoption",
-      "label": "setInitialSelectedOption()",
-      "norm_label": "setinitialselectedoption()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L230"
-    },
-    {
-      "community": 1330,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -42151,7 +42325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -42160,7 +42334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -42169,7 +42343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -42178,7 +42352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -42187,7 +42361,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 134,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
+      "label": "ProductCategorization.tsx",
+      "norm_label": "productcategorization.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "productcategorization_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L286"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "productcategorization_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L203"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "productcategorization_handleproductvisibility",
+      "label": "handleProductVisibility()",
+      "norm_label": "handleproductvisibility()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L243"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "productcategorization_setinitialselectedoption",
+      "label": "setInitialSelectedOption()",
+      "norm_label": "setinitialselectedoption()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L230"
+    },
+    {
+      "community": 1340,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -42196,7 +42415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1341,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -42205,7 +42424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1342,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -42214,7 +42433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1338,
+      "community": 1343,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -42223,57 +42442,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1339,
+      "community": 1344,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
       "norm_label": "harness-repo-validation.test.ts",
       "source_file": "scripts/harness-repo-validation.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1"
     },
     {
@@ -42711,6 +42885,51 @@
     {
       "community": 141,
       "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
       "label": "PaymentView.tsx",
       "norm_label": "paymentview.tsx",
@@ -42718,7 +42937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "paymentview_handleaddpayment",
       "label": "handleAddPayment()",
@@ -42727,7 +42946,7 @@
       "source_location": "L189"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "paymentview_handleamountblur",
       "label": "handleAmountBlur()",
@@ -42736,7 +42955,7 @@
       "source_location": "L252"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "paymentview_handleamountchange",
       "label": "handleAmountChange()",
@@ -42745,7 +42964,7 @@
       "source_location": "L234"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "paymentview_handleclearall",
       "label": "handleClearAll()",
@@ -42754,7 +42973,7 @@
       "source_location": "L227"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
       "label": "PaymentsAddedList.tsx",
@@ -42763,7 +42982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "paymentsaddedlist_getpaymentmethodlabel",
       "label": "getPaymentMethodLabel()",
@@ -42772,7 +42991,7 @@
       "source_location": "L27"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "paymentsaddedlist_handlecanceledit",
       "label": "handleCancelEdit()",
@@ -42781,7 +43000,7 @@
       "source_location": "L104"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "paymentsaddedlist_handlesaveedit",
       "label": "handleSaveEdit()",
@@ -42790,7 +43009,7 @@
       "source_location": "L72"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "paymentsaddedlist_handlestartedit",
       "label": "handleStartEdit()",
@@ -42799,7 +43018,7 @@
       "source_location": "L67"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
       "label": "ReceivingView.tsx",
@@ -42808,7 +43027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "receivingview_builddefaultreceivedquantities",
       "label": "buildDefaultReceivedQuantities()",
@@ -42817,7 +43036,7 @@
       "source_location": "L35"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "receivingview_buildreceivedquantitiesaftersubmission",
       "label": "buildReceivedQuantitiesAfterSubmission()",
@@ -42826,7 +43045,7 @@
       "source_location": "L44"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "receivingview_buildsubmissionkey",
       "label": "buildSubmissionKey()",
@@ -42835,7 +43054,7 @@
       "source_location": "L31"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "receivingview_receivingview",
       "label": "ReceivingView()",
@@ -42844,7 +43063,7 @@
       "source_location": "L70"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -42853,7 +43072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -42862,7 +43081,7 @@
       "source_location": "L146"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -42871,7 +43090,7 @@
       "source_location": "L213"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -42880,7 +43099,7 @@
       "source_location": "L299"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -42889,7 +43108,7 @@
       "source_location": "L351"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -42898,7 +43117,7 @@
       "source_location": "L7"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -42907,7 +43126,7 @@
       "source_location": "L69"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -42916,7 +43135,7 @@
       "source_location": "L44"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -42925,7 +43144,7 @@
       "source_location": "L103"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -42934,7 +43153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
@@ -42943,7 +43162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -42952,7 +43171,7 @@
       "source_location": "L16"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -42961,7 +43180,7 @@
       "source_location": "L23"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -42970,7 +43189,7 @@
       "source_location": "L9"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -42979,7 +43198,7 @@
       "source_location": "L30"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -42988,7 +43207,7 @@
       "source_location": "L18"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -42997,7 +43216,7 @@
       "source_location": "L23"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -43006,7 +43225,7 @@
       "source_location": "L65"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -43015,7 +43234,7 @@
       "source_location": "L45"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -43024,7 +43243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -43033,7 +43252,7 @@
       "source_location": "L78"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -43042,7 +43261,7 @@
       "source_location": "L74"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -43051,7 +43270,7 @@
       "source_location": "L103"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -43060,57 +43279,12 @@
       "source_location": "L109"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
       "norm_label": "imageutils.test.ts",
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "imageutils_convertimagestojpg",
-      "label": "convertImagesToJpg()",
-      "norm_label": "convertimagestojpg()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "imageutils_convertimagestowebp",
-      "label": "convertImagesToWebp()",
-      "norm_label": "convertimagestowebp()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "imageutils_converttojpg",
-      "label": "convertToJpg()",
-      "norm_label": "converttojpg()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "imageutils_getuploadimagesdata",
-      "label": "getUploadImagesData()",
-      "norm_label": "getuploadimagesdata()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_imageutils_ts",
-      "label": "imageUtils.ts",
-      "norm_label": "imageutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L1"
     },
     {
@@ -43269,6 +43443,51 @@
     {
       "community": 150,
       "file_type": "code",
+      "id": "imageutils_convertimagestojpg",
+      "label": "convertImagesToJpg()",
+      "norm_label": "convertimagestojpg()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "imageutils_convertimagestowebp",
+      "label": "convertImagesToWebp()",
+      "norm_label": "convertimagestowebp()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "imageutils_converttojpg",
+      "label": "convertToJpg()",
+      "norm_label": "converttojpg()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "imageutils_getuploadimagesdata",
+      "label": "getUploadImagesData()",
+      "norm_label": "getuploadimagesdata()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_imageutils_ts",
+      "label": "imageUtils.ts",
+      "norm_label": "imageutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
       "norm_label": "results.ts",
@@ -43276,7 +43495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -43285,7 +43504,7 @@
       "source_location": "L86"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -43294,7 +43513,7 @@
       "source_location": "L59"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -43303,7 +43522,7 @@
       "source_location": "L42"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -43312,7 +43531,7 @@
       "source_location": "L76"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "cart_calculateposcarttotals",
       "label": "calculatePosCartTotals()",
@@ -43321,7 +43540,7 @@
       "source_location": "L3"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "cart_calculatepositemtotal",
       "label": "calculatePosItemTotal()",
@@ -43330,7 +43549,7 @@
       "source_location": "L29"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "cart_getposeffectiveprice",
       "label": "getPosEffectivePrice()",
@@ -43339,7 +43558,7 @@
       "source_location": "L33"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "cart_roundposamount",
       "label": "roundPosAmount()",
@@ -43348,7 +43567,7 @@
       "source_location": "L40"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
       "label": "cart.ts",
@@ -43357,7 +43576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "cataloggateway_mapproductbyidresult",
       "label": "mapProductByIdResult()",
@@ -43366,7 +43585,7 @@
       "source_location": "L38"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "cataloggateway_useconvexbarcodelookup",
       "label": "useConvexBarcodeLookup()",
@@ -43375,7 +43594,7 @@
       "source_location": "L85"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "cataloggateway_useconvexproductidlookup",
       "label": "useConvexProductIdLookup()",
@@ -43384,7 +43603,7 @@
       "source_location": "L96"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "cataloggateway_useconvexproductsearch",
       "label": "useConvexProductSearch()",
@@ -43393,7 +43612,7 @@
       "source_location": "L67"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
       "label": "catalogGateway.ts",
@@ -43402,7 +43621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -43411,7 +43630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -43420,7 +43639,7 @@
       "source_location": "L12"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -43429,7 +43648,7 @@
       "source_location": "L24"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -43438,7 +43657,7 @@
       "source_location": "L30"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -43447,7 +43666,7 @@
       "source_location": "L52"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "label": "useRegisterViewModel.ts",
@@ -43456,7 +43675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "useregisterviewmodel_createpaymentid",
       "label": "createPaymentId()",
@@ -43465,7 +43684,7 @@
       "source_location": "L84"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "useregisterviewmodel_hascustomerdetails",
       "label": "hasCustomerDetails()",
@@ -43474,7 +43693,7 @@
       "source_location": "L58"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "useregisterviewmodel_mapsessioncustomer",
       "label": "mapSessionCustomer()",
@@ -43483,7 +43702,7 @@
       "source_location": "L71"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "useregisterviewmodel_useregisterviewmodel",
       "label": "useRegisterViewModel()",
@@ -43492,7 +43711,7 @@
       "source_location": "L91"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -43501,7 +43720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -43510,7 +43729,7 @@
       "source_location": "L42"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -43519,7 +43738,7 @@
       "source_location": "L29"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -43528,7 +43747,7 @@
       "source_location": "L49"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -43537,7 +43756,7 @@
       "source_location": "L14"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -43546,7 +43765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -43555,7 +43774,7 @@
       "source_location": "L184"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -43564,7 +43783,7 @@
       "source_location": "L200"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -43573,7 +43792,7 @@
       "source_location": "L244"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -43582,7 +43801,7 @@
       "source_location": "L206"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -43591,7 +43810,7 @@
       "source_location": "L93"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -43600,7 +43819,7 @@
       "source_location": "L75"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -43609,7 +43828,7 @@
       "source_location": "L4"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -43618,7 +43837,7 @@
       "source_location": "L47"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -43627,7 +43846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -43636,7 +43855,7 @@
       "source_location": "L11"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -43645,7 +43864,7 @@
       "source_location": "L25"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -43654,7 +43873,7 @@
       "source_location": "L9"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -43663,57 +43882,12 @@
       "source_location": "L39"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "onlineorder_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "onlineorder_getorder",
-      "label": "getOrder()",
-      "norm_label": "getorder()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "onlineorder_getorders",
-      "label": "getOrders()",
-      "norm_label": "getorders()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "onlineorder_updateordersowner",
-      "label": "updateOrdersOwner()",
-      "norm_label": "updateordersowner()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -43872,6 +44046,51 @@
     {
       "community": 160,
       "file_type": "code",
+      "id": "onlineorder_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "onlineorder_getorder",
+      "label": "getOrder()",
+      "norm_label": "getorder()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "onlineorder_getorders",
+      "label": "getOrders()",
+      "norm_label": "getorders()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "onlineorder_updateordersowner",
+      "label": "updateOrdersOwner()",
+      "norm_label": "updateordersowner()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
       "norm_label": "storefrontuser.ts",
@@ -43879,7 +44098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -43888,7 +44107,7 @@
       "source_location": "L28"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -43897,7 +44116,7 @@
       "source_location": "L5"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -43906,7 +44125,7 @@
       "source_location": "L7"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -43915,7 +44134,7 @@
       "source_location": "L46"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -43924,7 +44143,7 @@
       "source_location": "L147"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -43933,7 +44152,7 @@
       "source_location": "L185"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -43942,7 +44161,7 @@
       "source_location": "L115"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -43951,7 +44170,7 @@
       "source_location": "L31"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -43960,7 +44179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -43969,7 +44188,7 @@
       "source_location": "L14"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -43978,7 +44197,7 @@
       "source_location": "L22"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -43987,7 +44206,7 @@
       "source_location": "L30"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -43996,7 +44215,7 @@
       "source_location": "L3"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -44005,7 +44224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -44014,7 +44233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -44023,7 +44242,7 @@
       "source_location": "L136"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -44032,7 +44251,7 @@
       "source_location": "L154"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -44041,7 +44260,7 @@
       "source_location": "L25"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -44050,7 +44269,7 @@
       "source_location": "L47"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -44059,7 +44278,7 @@
       "source_location": "L44"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -44068,7 +44287,7 @@
       "source_location": "L36"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -44077,7 +44296,7 @@
       "source_location": "L26"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -44086,7 +44305,7 @@
       "source_location": "L30"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
@@ -44095,7 +44314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -44104,7 +44323,7 @@
       "source_location": "L109"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -44113,7 +44332,7 @@
       "source_location": "L84"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -44122,7 +44341,7 @@
       "source_location": "L95"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
       "label": "checkout.ts",
@@ -44131,7 +44350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "expensesessions_buildnextexpensesessionnumber",
       "label": "buildNextExpenseSessionNumber()",
@@ -44140,7 +44359,7 @@
       "source_location": "L33"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "expensesessions_listexpensesessionsbystatusbefore",
       "label": "listExpenseSessionsByStatusBefore()",
@@ -44149,7 +44368,7 @@
       "source_location": "L66"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "expensesessions_loadexpensesessionitems",
       "label": "loadExpenseSessionItems()",
@@ -44158,7 +44377,7 @@
       "source_location": "L41"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
       "label": "expenseSessions.ts",
@@ -44167,7 +44386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -44176,7 +44395,7 @@
       "source_location": "L21"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -44185,7 +44404,7 @@
       "source_location": "L35"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -44194,7 +44413,7 @@
       "source_location": "L45"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -44203,7 +44422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -44212,7 +44431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -44221,7 +44440,7 @@
       "source_location": "L21"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -44230,49 +44449,13 @@
       "source_location": "L35"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
       "norm_label": "getsessionexpirydurationminutes()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L45"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "label": "posSessions.ts",
-      "norm_label": "possessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "possessions_listpossessionsbystatusbefore",
-      "label": "listPosSessionsByStatusBefore()",
-      "norm_label": "listpossessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "possessions_listpossessionsforstorestatus",
-      "label": "listPosSessionsForStoreStatus()",
-      "norm_label": "listpossessionsforstorestatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "possessions_loadpossessionitems",
-      "label": "loadPosSessionItems()",
-      "norm_label": "loadpossessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L35"
     },
     {
       "community": 17,
@@ -44430,6 +44613,42 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "label": "posSessions.ts",
+      "norm_label": "possessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "possessions_listpossessionsbystatusbefore",
+      "label": "listPosSessionsByStatusBefore()",
+      "norm_label": "listpossessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "possessions_listpossessionsforstorestatus",
+      "label": "listPosSessionsForStoreStatus()",
+      "norm_label": "listpossessionsforstorestatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "possessions_loadpossessionitems",
+      "label": "loadPosSessionItems()",
+      "norm_label": "loadpossessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
       "norm_label": "todisplayamount()",
@@ -44437,7 +44656,7 @@
       "source_location": "L5"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -44446,7 +44665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -44455,7 +44674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
@@ -44464,7 +44683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
@@ -44473,7 +44692,7 @@
       "source_location": "L26"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -44482,7 +44701,7 @@
       "source_location": "L79"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -44491,7 +44710,7 @@
       "source_location": "L33"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -44500,7 +44719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -44509,7 +44728,7 @@
       "source_location": "L10"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -44518,7 +44737,7 @@
       "source_location": "L18"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -44527,7 +44746,7 @@
       "source_location": "L52"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -44536,7 +44755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -44545,7 +44764,7 @@
       "source_location": "L28"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -44554,7 +44773,7 @@
       "source_location": "L42"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -44563,7 +44782,7 @@
       "source_location": "L73"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -44572,7 +44791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -44581,7 +44800,7 @@
       "source_location": "L8"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -44590,7 +44809,7 @@
       "source_location": "L32"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -44599,7 +44818,7 @@
       "source_location": "L64"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -44608,7 +44827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -44617,7 +44836,7 @@
       "source_location": "L18"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -44626,7 +44845,7 @@
       "source_location": "L25"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -44635,7 +44854,7 @@
       "source_location": "L11"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -44644,7 +44863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -44653,7 +44872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -44662,7 +44881,7 @@
       "source_location": "L36"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -44671,7 +44890,7 @@
       "source_location": "L23"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -44680,7 +44899,7 @@
       "source_location": "L18"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
       "label": "terminals.ts",
@@ -44689,7 +44908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "terminals_deleteterminal",
       "label": "deleteTerminal()",
@@ -44698,7 +44917,7 @@
       "source_location": "L89"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "terminals_registerterminal",
       "label": "registerTerminal()",
@@ -44707,7 +44926,7 @@
       "source_location": "L13"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "terminals_updateterminal",
       "label": "updateTerminal()",
@@ -44716,7 +44935,7 @@
       "source_location": "L54"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -44725,7 +44944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -44734,7 +44953,7 @@
       "source_location": "L122"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -44743,49 +44962,13 @@
       "source_location": "L34"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
       "norm_label": "searchproducts()",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
       "source_location": "L72"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
-      "label": "sessionCommandRepository.ts",
-      "norm_label": "sessioncommandrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sessioncommandrepository_collectsessionitemsfrompages",
-      "label": "collectSessionItemsFromPages()",
-      "norm_label": "collectsessionitemsfrompages()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sessioncommandrepository_createsessioncommandrepository",
-      "label": "createSessionCommandRepository()",
-      "norm_label": "createsessioncommandrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sessioncommandrepository_findsessionitembyskuinpages",
-      "label": "findSessionItemBySkuInPages()",
-      "norm_label": "findsessionitembyskuinpages()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L158"
     },
     {
       "community": 18,
@@ -44943,6 +45126,42 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
+      "label": "sessionCommandRepository.ts",
+      "norm_label": "sessioncommandrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "sessioncommandrepository_collectsessionitemsfrompages",
+      "label": "collectSessionItemsFromPages()",
+      "norm_label": "collectsessionitemsfrompages()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "sessioncommandrepository_createsessioncommandrepository",
+      "label": "createSessionCommandRepository()",
+      "norm_label": "createsessioncommandrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "sessioncommandrepository_findsessionitembyskuinpages",
+      "label": "findSessionItemBySkuInPages()",
+      "norm_label": "findsessionitembyskuinpages()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
       "norm_label": "createapprovaldecisionmutationctx()",
@@ -44950,7 +45169,7 @@
       "source_location": "L30"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -44959,7 +45178,7 @@
       "source_location": "L175"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -44968,7 +45187,7 @@
       "source_location": "L26"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -44977,7 +45196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -44986,7 +45205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -44995,7 +45214,7 @@
       "source_location": "L23"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -45004,7 +45223,7 @@
       "source_location": "L9"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -45013,7 +45232,7 @@
       "source_location": "L13"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -45022,7 +45241,7 @@
       "source_location": "L19"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -45031,7 +45250,7 @@
       "source_location": "L26"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -45040,7 +45259,7 @@
       "source_location": "L12"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -45049,7 +45268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -45058,7 +45277,7 @@
       "source_location": "L21"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -45067,7 +45286,7 @@
       "source_location": "L63"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -45076,7 +45295,7 @@
       "source_location": "L71"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -45085,7 +45304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -45094,7 +45313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -45103,7 +45322,7 @@
       "source_location": "L13"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -45112,7 +45331,7 @@
       "source_location": "L31"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -45121,7 +45340,7 @@
       "source_location": "L9"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -45130,7 +45349,7 @@
       "source_location": "L228"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -45139,7 +45358,7 @@
       "source_location": "L45"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -45148,7 +45367,7 @@
       "source_location": "L26"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -45157,7 +45376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -45166,7 +45385,7 @@
       "source_location": "L55"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -45175,7 +45394,7 @@
       "source_location": "L32"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -45184,7 +45403,7 @@
       "source_location": "L210"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -45193,7 +45412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -45202,7 +45421,7 @@
       "source_location": "L51"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -45211,7 +45430,7 @@
       "source_location": "L26"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -45220,7 +45439,7 @@
       "source_location": "L290"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -45229,7 +45448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -45238,7 +45457,7 @@
       "source_location": "L48"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -45247,7 +45466,7 @@
       "source_location": "L88"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -45256,49 +45475,13 @@
       "source_location": "L14"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
       "norm_label": "analyticsview.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
-      "label": "StorefrontObservabilityPanel.tsx",
-      "norm_label": "storefrontobservabilitypanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_formatlabel",
-      "label": "formatLabel()",
-      "norm_label": "formatlabel()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
-      "label": "getTrafficSourceBadge()",
-      "norm_label": "gettrafficsourcebadge()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_summarycard",
-      "label": "SummaryCard()",
-      "norm_label": "summarycard()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L19"
     },
     {
       "community": 19,
@@ -45447,6 +45630,42 @@
     {
       "community": 190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
+      "label": "StorefrontObservabilityPanel.tsx",
+      "norm_label": "storefrontobservabilitypanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_formatlabel",
+      "label": "formatLabel()",
+      "norm_label": "formatlabel()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
+      "label": "getTrafficSourceBadge()",
+      "norm_label": "gettrafficsourcebadge()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_summarycard",
+      "label": "SummaryCard()",
+      "norm_label": "summarycard()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
       "norm_label": "utils.ts",
@@ -45454,7 +45673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -45463,7 +45682,7 @@
       "source_location": "L52"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -45472,7 +45691,7 @@
       "source_location": "L3"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -45481,7 +45700,7 @@
       "source_location": "L90"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -45490,7 +45709,7 @@
       "source_location": "L86"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -45499,7 +45718,7 @@
       "source_location": "L76"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -45508,7 +45727,7 @@
       "source_location": "L52"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -45517,7 +45736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -45526,7 +45745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -45535,7 +45754,7 @@
       "source_location": "L67"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -45544,7 +45763,7 @@
       "source_location": "L90"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -45553,7 +45772,7 @@
       "source_location": "L73"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -45562,7 +45781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -45571,7 +45790,7 @@
       "source_location": "L103"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -45580,7 +45799,7 @@
       "source_location": "L95"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -45589,7 +45808,7 @@
       "source_location": "L81"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -45598,7 +45817,7 @@
       "source_location": "L91"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -45607,7 +45826,7 @@
       "source_location": "L68"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -45616,7 +45835,7 @@
       "source_location": "L22"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -45625,7 +45844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "ordersummary_handlecompletetransaction",
       "label": "handleCompleteTransaction()",
@@ -45634,7 +45853,7 @@
       "source_location": "L131"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "ordersummary_handleprintreceipt",
       "label": "handlePrintReceipt()",
@@ -45643,7 +45862,7 @@
       "source_location": "L154"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "ordersummary_handlestartnewtransaction",
       "label": "handleStartNewTransaction()",
@@ -45652,7 +45871,7 @@
       "source_location": "L148"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -45661,7 +45880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -45670,7 +45889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -45679,7 +45898,7 @@
       "source_location": "L247"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -45688,7 +45907,7 @@
       "source_location": "L284"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -45697,7 +45916,7 @@
       "source_location": "L166"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -45706,7 +45925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -45715,7 +45934,7 @@
       "source_location": "L79"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -45724,7 +45943,7 @@
       "source_location": "L119"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -45733,7 +45952,7 @@
       "source_location": "L90"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -45742,7 +45961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -45751,7 +45970,7 @@
       "source_location": "L63"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -45760,49 +45979,13 @@
       "source_location": "L54"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
       "norm_label": "productstockstatus()",
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "complimentaryproductsview_body",
-      "label": "Body()",
-      "norm_label": "body()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "complimentaryproductsview_complimentaryproductsview",
-      "label": "ComplimentaryProductsView()",
-      "norm_label": "complimentaryproductsview()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "complimentaryproductsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
-      "label": "ComplimentaryProductsView.tsx",
-      "norm_label": "complimentaryproductsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 2,
@@ -46248,6 +46431,42 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "complimentaryproductsview_body",
+      "label": "Body()",
+      "norm_label": "body()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "complimentaryproductsview_complimentaryproductsview",
+      "label": "ComplimentaryProductsView()",
+      "norm_label": "complimentaryproductsview()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "complimentaryproductsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
+      "label": "ComplimentaryProductsView.tsx",
+      "norm_label": "complimentaryproductsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "label": "ServiceAppointmentsView.tsx",
       "norm_label": "serviceappointmentsview.tsx",
@@ -46255,7 +46474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "serviceappointmentsview_handlesubmit",
       "label": "handleSubmit()",
@@ -46264,7 +46483,7 @@
       "source_location": "L115"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "serviceappointmentsview_parsedatetimelocal",
       "label": "parseDateTimeLocal()",
@@ -46273,7 +46492,7 @@
       "source_location": "L77"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "serviceappointmentsview_withsavestate",
       "label": "withSaveState()",
@@ -46282,7 +46501,7 @@
       "source_location": "L441"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -46291,7 +46510,7 @@
       "source_location": "L75"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -46300,7 +46519,7 @@
       "source_location": "L82"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -46309,7 +46528,7 @@
       "source_location": "L93"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -46318,7 +46537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -46327,7 +46546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -46336,7 +46555,7 @@
       "source_location": "L15"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -46345,7 +46564,7 @@
       "source_location": "L28"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -46354,7 +46573,7 @@
       "source_location": "L54"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -46363,7 +46582,7 @@
       "source_location": "L66"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -46372,7 +46591,7 @@
       "source_location": "L121"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -46381,7 +46600,7 @@
       "source_location": "L74"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -46390,7 +46609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -46399,7 +46618,7 @@
       "source_location": "L51"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -46408,7 +46627,7 @@
       "source_location": "L92"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -46417,7 +46636,7 @@
       "source_location": "L16"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -46426,7 +46645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -46435,7 +46654,7 @@
       "source_location": "L16"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -46444,7 +46663,7 @@
       "source_location": "L6"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -46453,7 +46672,7 @@
       "source_location": "L46"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -46462,7 +46681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -46471,7 +46690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -46480,7 +46699,7 @@
       "source_location": "L24"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -46489,7 +46708,7 @@
       "source_location": "L43"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -46498,7 +46717,7 @@
       "source_location": "L63"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -46507,7 +46726,7 @@
       "source_location": "L4"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -46516,7 +46735,7 @@
       "source_location": "L20"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -46525,7 +46744,7 @@
       "source_location": "L42"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -46534,7 +46753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -46543,7 +46762,7 @@
       "source_location": "L83"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -46552,7 +46771,7 @@
       "source_location": "L59"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -46561,48 +46780,12 @@
       "source_location": "L41"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
       "norm_label": "_layout.tsx",
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "offers_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "offers_getuserredeemedoffers",
-      "label": "getUserRedeemedOffers()",
-      "norm_label": "getuserredeemedoffers()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "offers_submitoffer",
-      "label": "submitOffer()",
-      "norm_label": "submitoffer()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1"
     },
     {
@@ -46743,6 +46926,42 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "offers_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "offers_getuserredeemedoffers",
+      "label": "getUserRedeemedOffers()",
+      "norm_label": "getuserredeemedoffers()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "offers_submitoffer",
+      "label": "submitOffer()",
+      "norm_label": "submitoffer()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
       "norm_label": "stores.ts",
@@ -46750,7 +46969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -46759,7 +46978,7 @@
       "source_location": "L8"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -46768,7 +46987,7 @@
       "source_location": "L5"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -46777,7 +46996,7 @@
       "source_location": "L20"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -46786,7 +47005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -46795,7 +47014,7 @@
       "source_location": "L11"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -46804,7 +47023,7 @@
       "source_location": "L9"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -46813,7 +47032,7 @@
       "source_location": "L25"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -46822,7 +47041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -46831,7 +47050,7 @@
       "source_location": "L50"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -46840,7 +47059,7 @@
       "source_location": "L92"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -46849,7 +47068,7 @@
       "source_location": "L74"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -46858,7 +47077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -46867,7 +47086,7 @@
       "source_location": "L62"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -46876,7 +47095,7 @@
       "source_location": "L109"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -46885,7 +47104,7 @@
       "source_location": "L177"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -46894,7 +47113,7 @@
       "source_location": "L18"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -46903,7 +47122,7 @@
       "source_location": "L52"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -46912,7 +47131,7 @@
       "source_location": "L68"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -46921,7 +47140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -46930,7 +47149,7 @@
       "source_location": "L68"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -46939,7 +47158,7 @@
       "source_location": "L26"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -46948,7 +47167,7 @@
       "source_location": "L7"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -46957,7 +47176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -46966,7 +47185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -46975,7 +47194,7 @@
       "source_location": "L43"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -46984,7 +47203,7 @@
       "source_location": "L13"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -46993,7 +47212,7 @@
       "source_location": "L88"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -47002,7 +47221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -47011,7 +47230,7 @@
       "source_location": "L111"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -47020,7 +47239,7 @@
       "source_location": "L66"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -47029,7 +47248,7 @@
       "source_location": "L127"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -47038,7 +47257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -47047,7 +47266,7 @@
       "source_location": "L115"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -47056,49 +47275,13 @@
       "source_location": "L105"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
       "norm_label": "onmobilefilterscloseclick()",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L110"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "index_cancelorder",
-      "label": "cancelOrder()",
-      "norm_label": "cancelorder()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L121"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "index_geterrormessage",
-      "label": "getErrorMessage()",
-      "norm_label": "geterrormessage()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L26"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "index_placeorder",
-      "label": "placeOrder()",
-      "norm_label": "placeorder()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L71"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 22,
@@ -47238,6 +47421,42 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "index_cancelorder",
+      "label": "cancelOrder()",
+      "norm_label": "cancelorder()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L121"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "index_geterrormessage",
+      "label": "getErrorMessage()",
+      "norm_label": "geterrormessage()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "index_placeorder",
+      "label": "placeOrder()",
+      "norm_label": "placeorder()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L71"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
       "norm_label": "bootstrapcheckout()",
@@ -47245,7 +47464,7 @@
       "source_location": "L46"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -47254,7 +47473,7 @@
       "source_location": "L24"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -47263,7 +47482,7 @@
       "source_location": "L20"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -47272,7 +47491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
@@ -47281,7 +47500,7 @@
       "source_location": "L33"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -47290,7 +47509,7 @@
       "source_location": "L6"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -47299,7 +47518,7 @@
       "source_location": "L25"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -47308,7 +47527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -47317,7 +47536,7 @@
       "source_location": "L17"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -47326,7 +47545,7 @@
       "source_location": "L11"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -47335,7 +47554,7 @@
       "source_location": "L24"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -47344,7 +47563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -47353,7 +47572,7 @@
       "source_location": "L20"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -47362,7 +47581,7 @@
       "source_location": "L65"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -47371,7 +47590,7 @@
       "source_location": "L14"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -47380,7 +47599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -47389,7 +47608,7 @@
       "source_location": "L126"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -47398,7 +47617,7 @@
       "source_location": "L130"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -47407,7 +47626,7 @@
       "source_location": "L630"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -47416,7 +47635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -47425,7 +47644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -47434,7 +47653,7 @@
       "source_location": "L8"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -47443,7 +47662,7 @@
       "source_location": "L79"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -47452,7 +47671,7 @@
       "source_location": "L61"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -47461,7 +47680,7 @@
       "source_location": "L49"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -47470,7 +47689,7 @@
       "source_location": "L17"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -47479,7 +47698,7 @@
       "source_location": "L11"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -47488,7 +47707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -47497,7 +47716,7 @@
       "source_location": "L26"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -47506,7 +47725,7 @@
       "source_location": "L72"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -47515,7 +47734,7 @@
       "source_location": "L36"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -47524,7 +47743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -47533,7 +47752,7 @@
       "source_location": "L90"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -47542,7 +47761,7 @@
       "source_location": "L88"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -47551,39 +47770,12 @@
       "source_location": "L89"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
       "norm_label": "pre-push-review.test.ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "discountcode_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "discountcode_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
-      "label": "DiscountCode.tsx",
-      "norm_label": "discountcode.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L1"
     },
     {
@@ -47715,6 +47907,33 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "discountcode_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "discountcode_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
+      "label": "DiscountCode.tsx",
+      "norm_label": "discountcode.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
       "norm_label": "chunkproducts()",
@@ -47722,7 +47941,7 @@
       "source_location": "L85"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -47731,7 +47950,7 @@
       "source_location": "L31"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -47740,7 +47959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -47749,7 +47968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -47758,7 +47977,7 @@
       "source_location": "L5"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -47767,7 +47986,7 @@
       "source_location": "L12"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -47776,7 +47995,7 @@
       "source_location": "L43"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -47785,7 +48004,7 @@
       "source_location": "L11"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -47794,7 +48013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
       "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
@@ -47803,7 +48022,7 @@
       "source_location": "L75"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestwithctx",
       "label": "decideApprovalRequestWithCtx()",
@@ -47812,7 +48031,7 @@
       "source_location": "L25"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "label": "approvalRequests.ts",
@@ -47821,7 +48040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
       "label": "staffProfiles.ts",
@@ -47830,7 +48049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "staffprofiles_buildfullname",
       "label": "buildFullName()",
@@ -47839,7 +48058,7 @@
       "source_location": "L12"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "staffprofiles_buildroleassignmentdrafts",
       "label": "buildRoleAssignmentDrafts()",
@@ -47848,7 +48067,7 @@
       "source_location": "L17"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -47857,7 +48076,7 @@
       "source_location": "L7"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -47866,7 +48085,7 @@
       "source_location": "L109"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -47875,7 +48094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -47884,7 +48103,7 @@
       "source_location": "L16"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -47893,7 +48112,7 @@
       "source_location": "L35"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -47902,7 +48121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -47911,7 +48130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -47920,7 +48139,7 @@
       "source_location": "L18"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -47929,7 +48148,7 @@
       "source_location": "L9"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -47938,7 +48157,7 @@
       "source_location": "L8"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -47947,40 +48166,13 @@
       "source_location": "L9"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
       "norm_label": "errors.ts",
       "source_file": "packages/athena-webapp/convex/pos/domain/errors.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
-      "label": "sessionRules.ts",
-      "norm_label": "sessionrules.ts",
-      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "sessionrules_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "sessionrules_selectresumablesession",
-      "label": "selectResumableSession()",
-      "norm_label": "selectresumablesession()",
-      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
-      "source_location": "L29"
     },
     {
       "community": 24,
@@ -48111,6 +48303,33 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
+      "label": "sessionRules.ts",
+      "norm_label": "sessionrules.ts",
+      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "sessionrules_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "sessionrules_selectresumablesession",
+      "label": "selectResumableSession()",
+      "norm_label": "selectresumablesession()",
+      "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
       "norm_label": "paymentallocationservice.ts",
@@ -48118,7 +48337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -48127,7 +48346,7 @@
       "source_location": "L13"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -48136,7 +48355,7 @@
       "source_location": "L45"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -48145,7 +48364,7 @@
       "source_location": "L16"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -48154,7 +48373,7 @@
       "source_location": "L42"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -48163,7 +48382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -48172,7 +48391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -48181,7 +48400,7 @@
       "source_location": "L23"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -48190,7 +48409,7 @@
       "source_location": "L16"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -48199,7 +48418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -48208,7 +48427,7 @@
       "source_location": "L12"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -48217,7 +48436,7 @@
       "source_location": "L7"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -48226,7 +48445,7 @@
       "source_location": "L7"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -48235,7 +48454,7 @@
       "source_location": "L14"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -48244,7 +48463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -48253,7 +48472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -48262,7 +48481,7 @@
       "source_location": "L35"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -48271,7 +48490,7 @@
       "source_location": "L25"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -48280,7 +48499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -48289,7 +48508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -48298,7 +48517,7 @@
       "source_location": "L4"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -48307,7 +48526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -48316,7 +48535,7 @@
       "source_location": "L18"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -48325,7 +48544,7 @@
       "source_location": "L5"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -48334,7 +48553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -48343,40 +48562,13 @@
       "source_location": "L19"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
       "norm_label": "usesheet()",
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
-      "label": "WigType.tsx",
-      "norm_label": "wigtype.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "wigtype_wigtype",
-      "label": "WigType()",
-      "norm_label": "wigtype()",
-      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "wigtype_wigtypeview",
-      "label": "WigTypeView()",
-      "norm_label": "wigtypeview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
-      "source_location": "L8"
     },
     {
       "community": 25,
@@ -48507,6 +48699,33 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
+      "label": "WigType.tsx",
+      "norm_label": "wigtype.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "wigtype_wigtype",
+      "label": "WigType()",
+      "norm_label": "wigtype()",
+      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "wigtype_wigtypeview",
+      "label": "WigTypeView()",
+      "norm_label": "wigtypeview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
       "norm_label": "copyimagesprovider()",
@@ -48514,7 +48733,7 @@
       "source_location": "L21"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -48523,7 +48742,7 @@
       "source_location": "L13"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -48532,7 +48751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -48541,7 +48760,7 @@
       "source_location": "L100"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -48550,7 +48769,7 @@
       "source_location": "L10"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -48559,7 +48778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -48568,7 +48787,7 @@
       "source_location": "L100"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -48577,7 +48796,7 @@
       "source_location": "L10"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -48586,7 +48805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -48595,7 +48814,7 @@
       "source_location": "L15"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -48604,7 +48823,7 @@
       "source_location": "L39"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -48613,7 +48832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -48622,7 +48841,7 @@
       "source_location": "L43"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -48631,7 +48850,7 @@
       "source_location": "L51"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -48640,7 +48859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -48649,7 +48868,7 @@
       "source_location": "L3"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -48658,7 +48877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -48667,7 +48886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -48676,7 +48895,7 @@
       "source_location": "L53"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -48685,7 +48904,7 @@
       "source_location": "L65"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -48694,7 +48913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -48703,7 +48922,7 @@
       "source_location": "L47"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -48712,7 +48931,7 @@
       "source_location": "L53"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -48721,7 +48940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -48730,7 +48949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -48739,40 +48958,13 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
       "norm_label": "videoplayer()",
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "operationsqueueview_handledecideapprovalrequest",
-      "label": "handleDecideApprovalRequest()",
-      "norm_label": "handledecideapprovalrequest()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L289"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "operationsqueueview_handlesubmitstockbatch",
-      "label": "handleSubmitStockBatch()",
-      "norm_label": "handlesubmitstockbatch()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L279"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
-      "label": "OperationsQueueView.tsx",
-      "norm_label": "operationsqueueview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 26,
@@ -48894,6 +49086,33 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "operationsqueueview_handledecideapprovalrequest",
+      "label": "handleDecideApprovalRequest()",
+      "norm_label": "handledecideapprovalrequest()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L289"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "operationsqueueview_handlesubmitstockbatch",
+      "label": "handleSubmitStockBatch()",
+      "norm_label": "handlesubmitstockbatch()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L279"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
+      "label": "OperationsQueueView.tsx",
+      "norm_label": "operationsqueueview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
       "norm_label": "pickupdetailsview.tsx",
@@ -48901,7 +49120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -48910,7 +49129,7 @@
       "source_location": "L67"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -48919,7 +49138,7 @@
       "source_location": "L9"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
@@ -48928,7 +49147,7 @@
       "source_location": "L100"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -48937,7 +49156,7 @@
       "source_location": "L95"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -48946,7 +49165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -48955,7 +49174,7 @@
       "source_location": "L35"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -48964,7 +49183,7 @@
       "source_location": "L31"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -48973,7 +49192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -48982,7 +49201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -48991,7 +49210,7 @@
       "source_location": "L20"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -49000,7 +49219,7 @@
       "source_location": "L26"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -49009,7 +49228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -49018,7 +49237,7 @@
       "source_location": "L65"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -49027,7 +49246,7 @@
       "source_location": "L20"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -49036,7 +49255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -49045,7 +49264,7 @@
       "source_location": "L16"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -49054,7 +49273,7 @@
       "source_location": "L60"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -49063,7 +49282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -49072,7 +49291,7 @@
       "source_location": "L45"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -49081,7 +49300,7 @@
       "source_location": "L19"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -49090,7 +49309,7 @@
       "source_location": "L128"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -49099,7 +49318,7 @@
       "source_location": "L40"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -49108,7 +49327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -49117,7 +49336,7 @@
       "source_location": "L24"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -49126,39 +49345,12 @@
       "source_location": "L20"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
       "norm_label": "color-picker.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "currency_provider_currencyprovider",
-      "label": "CurrencyProvider()",
-      "norm_label": "currencyprovider()",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "currency_provider_usestorecurrency",
-      "label": "useStoreCurrency()",
-      "norm_label": "usestorecurrency()",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
-      "label": "currency-provider.tsx",
-      "norm_label": "currency-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1"
     },
     {
@@ -49281,6 +49473,33 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "currency_provider_currencyprovider",
+      "label": "CurrencyProvider()",
+      "norm_label": "currencyprovider()",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "currency_provider_usestorecurrency",
+      "label": "useStoreCurrency()",
+      "norm_label": "usestorecurrency()",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
+      "label": "currency-provider.tsx",
+      "norm_label": "currency-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
       "norm_label": "serviceintakeview.tsx",
@@ -49288,7 +49507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "serviceintakeview_handlecreateintake",
       "label": "handleCreateIntake()",
@@ -49297,7 +49516,7 @@
       "source_location": "L238"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -49306,7 +49525,7 @@
       "source_location": "L69"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -49315,7 +49534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -49324,7 +49543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -49333,7 +49552,7 @@
       "source_location": "L3"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -49342,7 +49561,7 @@
       "source_location": "L9"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -49351,7 +49570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -49360,7 +49579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -49369,7 +49588,7 @@
       "source_location": "L3"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -49378,7 +49597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -49387,7 +49606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -49396,7 +49615,7 @@
       "source_location": "L3"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -49405,7 +49624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -49414,7 +49633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -49423,7 +49642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -49432,7 +49651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -49441,7 +49660,7 @@
       "source_location": "L3"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -49450,7 +49669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -49459,7 +49678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -49468,7 +49687,7 @@
       "source_location": "L3"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -49477,7 +49696,7 @@
       "source_location": "L4"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -49486,7 +49705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -49495,7 +49714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -49504,7 +49723,7 @@
       "source_location": "L104"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -49513,39 +49732,12 @@
       "source_location": "L36"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
       "norm_label": "feesview.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "app_context_menu_appcontextmenu",
-      "label": "AppContextMenu()",
-      "norm_label": "appcontextmenu()",
-      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
-      "label": "app-context-menu.tsx",
-      "norm_label": "app-context-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/app-context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
-      "label": "app-context-menu.tsx",
-      "norm_label": "app-context-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1"
     },
     {
@@ -49668,6 +49860,33 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "app_context_menu_appcontextmenu",
+      "label": "AppContextMenu()",
+      "norm_label": "appcontextmenu()",
+      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
+      "label": "app-context-menu.tsx",
+      "norm_label": "app-context-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/app-context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
+      "label": "app-context-menu.tsx",
+      "norm_label": "app-context-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
       "norm_label": "badge()",
@@ -49675,7 +49894,7 @@
       "source_location": "L30"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -49684,7 +49903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -49693,7 +49912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -49702,7 +49921,7 @@
       "source_location": "L9"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -49711,7 +49930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -49720,7 +49939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -49729,7 +49948,7 @@
       "source_location": "L38"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -49738,7 +49957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -49747,7 +49966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -49756,7 +49975,7 @@
       "source_location": "L20"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -49765,7 +49984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -49774,7 +49993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -49783,7 +50002,7 @@
       "source_location": "L12"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -49792,7 +50011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -49801,7 +50020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -49810,7 +50029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -49819,7 +50038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -49828,7 +50047,7 @@
       "source_location": "L3"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -49837,7 +50056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -49846,7 +50065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -49855,7 +50074,7 @@
       "source_location": "L6"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -49864,7 +50083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -49873,7 +50092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -49882,7 +50101,7 @@
       "source_location": "L3"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -49891,7 +50110,7 @@
       "source_location": "L44"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -49900,40 +50119,13 @@
       "source_location": "L19"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
       "norm_label": "activitysummarycards.tsx",
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
-      "label": "TimelineEventCard.tsx",
-      "norm_label": "timelineeventcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "timelineeventcard_formatobservabilitylabel",
-      "label": "formatObservabilityLabel()",
-      "norm_label": "formatobservabilitylabel()",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
-      "source_location": "L159"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "timelineeventcard_loadmore",
-      "label": "loadMore()",
-      "norm_label": "loadmore()",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
-      "source_location": "L195"
     },
     {
       "community": 29,
@@ -50055,6 +50247,33 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
+      "label": "TimelineEventCard.tsx",
+      "norm_label": "timelineeventcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "timelineeventcard_formatobservabilitylabel",
+      "label": "formatObservabilityLabel()",
+      "norm_label": "formatobservabilitylabel()",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
+      "source_location": "L159"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "timelineeventcard_loadmore",
+      "label": "loadMore()",
+      "norm_label": "loadmore()",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
+      "source_location": "L195"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
       "norm_label": "useractivity.tsx",
@@ -50062,7 +50281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -50071,7 +50290,7 @@
       "source_location": "L22"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -50080,7 +50299,7 @@
       "source_location": "L45"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -50089,7 +50308,7 @@
       "source_location": "L24"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -50098,7 +50317,7 @@
       "source_location": "L38"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -50107,7 +50326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -50116,7 +50335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -50125,7 +50344,7 @@
       "source_location": "L23"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -50134,7 +50353,7 @@
       "source_location": "L51"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -50143,7 +50362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -50152,7 +50371,7 @@
       "source_location": "L54"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -50161,7 +50380,7 @@
       "source_location": "L282"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -50170,7 +50389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -50179,7 +50398,7 @@
       "source_location": "L12"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -50188,7 +50407,7 @@
       "source_location": "L37"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -50197,7 +50416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -50206,7 +50425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -50215,7 +50434,7 @@
       "source_location": "L4"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -50224,7 +50443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -50233,7 +50452,7 @@
       "source_location": "L9"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -50242,7 +50461,7 @@
       "source_location": "L50"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -50251,7 +50470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -50260,7 +50479,7 @@
       "source_location": "L6"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -50269,7 +50488,7 @@
       "source_location": "L31"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -50278,7 +50497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -50287,40 +50506,13 @@
       "source_location": "L5"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
       "norm_label": "usegetunresolvedproducts()",
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L31"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "maintenanceutils_isinmaintenancemode",
-      "label": "isInMaintenanceMode()",
-      "norm_label": "isinmaintenancemode()",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
-      "label": "maintenanceUtils.ts",
-      "norm_label": "maintenanceutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
-      "label": "maintenanceUtils.ts",
-      "norm_label": "maintenanceutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L1"
     },
     {
       "community": 3,
@@ -50712,6 +50904,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "maintenanceutils_isinmaintenancemode",
+      "label": "isInMaintenanceMode()",
+      "norm_label": "isinmaintenancemode()",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
+      "label": "maintenanceUtils.ts",
+      "norm_label": "maintenanceutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/maintenanceUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
+      "label": "maintenanceUtils.ts",
+      "norm_label": "maintenanceutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
       "norm_label": "formatstoredamount()",
@@ -50719,7 +50938,7 @@
       "source_location": "L3"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -50728,7 +50947,7 @@
       "source_location": "L10"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -50737,7 +50956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -50746,7 +50965,7 @@
       "source_location": "L16"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -50755,7 +50974,7 @@
       "source_location": "L53"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -50764,7 +50983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -50773,7 +50992,7 @@
       "source_location": "L31"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -50782,7 +51001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -50791,7 +51010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -50800,7 +51019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -50809,7 +51028,7 @@
       "source_location": "L28"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -50818,7 +51037,7 @@
       "source_location": "L46"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -50827,7 +51046,7 @@
       "source_location": "L18"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -50836,7 +51055,7 @@
       "source_location": "L38"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -50845,7 +51064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -50854,7 +51073,7 @@
       "source_location": "L127"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -50863,7 +51082,7 @@
       "source_location": "L106"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -50872,7 +51091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -50881,7 +51100,7 @@
       "source_location": "L66"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -50890,7 +51109,7 @@
       "source_location": "L20"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -50899,7 +51118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -50908,7 +51127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -50917,7 +51136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -50926,7 +51145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -50935,7 +51154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -50944,40 +51163,13 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
       "norm_label": "createversionchecker()",
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L16"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vite_config_ts",
-      "label": "vite.config.ts",
-      "norm_label": "vite.config.ts",
-      "source_file": "packages/athena-webapp/vite.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vite_config_ts",
-      "label": "vite.config.ts",
-      "norm_label": "vite.config.ts",
-      "source_file": "packages/storefront-webapp/vite.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "vite_config_manualchunks",
-      "label": "manualChunks()",
-      "norm_label": "manualchunks()",
-      "source_file": "packages/storefront-webapp/vite.config.ts",
-      "source_location": "L19"
     },
     {
       "community": 31,
@@ -51081,6 +51273,33 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_athena_webapp_vite_config_ts",
+      "label": "vite.config.ts",
+      "norm_label": "vite.config.ts",
+      "source_file": "packages/athena-webapp/vite.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_vite_config_ts",
+      "label": "vite.config.ts",
+      "norm_label": "vite.config.ts",
+      "source_file": "packages/storefront-webapp/vite.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "vite_config_manualchunks",
+      "label": "manualChunks()",
+      "norm_label": "manualchunks()",
+      "source_file": "packages/storefront-webapp/vite.config.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
       "norm_label": "logout()",
@@ -51088,7 +51307,7 @@
       "source_location": "L32"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -51097,7 +51316,7 @@
       "source_location": "L3"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -51106,7 +51325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -51115,7 +51334,7 @@
       "source_location": "L7"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -51124,7 +51343,7 @@
       "source_location": "L5"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -51133,7 +51352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -51142,7 +51361,7 @@
       "source_location": "L6"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -51151,7 +51370,7 @@
       "source_location": "L18"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -51160,7 +51379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -51169,7 +51388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -51178,7 +51397,7 @@
       "source_location": "L3"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -51187,7 +51406,7 @@
       "source_location": "L5"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -51196,7 +51415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -51205,7 +51424,7 @@
       "source_location": "L18"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -51214,7 +51433,7 @@
       "source_location": "L23"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -51223,7 +51442,7 @@
       "source_location": "L22"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -51232,7 +51451,7 @@
       "source_location": "L55"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -51241,7 +51460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -51250,7 +51469,7 @@
       "source_location": "L77"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -51259,7 +51478,7 @@
       "source_location": "L11"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -51268,7 +51487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -51277,7 +51496,7 @@
       "source_location": "L11"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -51286,7 +51505,7 @@
       "source_location": "L22"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -51295,7 +51514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -51304,7 +51523,7 @@
       "source_location": "L110"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -51313,39 +51532,12 @@
       "source_location": "L89"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
       "norm_label": "mobilebagsummary.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "checkoutstorage_loadcheckoutstate",
-      "label": "loadCheckoutState()",
-      "norm_label": "loadcheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "checkoutstorage_savecheckoutstate",
-      "label": "saveCheckoutState()",
-      "norm_label": "savecheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
-      "label": "checkoutStorage.ts",
-      "norm_label": "checkoutstorage.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L1"
     },
     {
@@ -51450,6 +51642,33 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "checkoutstorage_loadcheckoutstate",
+      "label": "loadCheckoutState()",
+      "norm_label": "loadcheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "checkoutstorage_savecheckoutstate",
+      "label": "saveCheckoutState()",
+      "norm_label": "savecheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
+      "label": "checkoutStorage.ts",
+      "norm_label": "checkoutstorage.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
       "norm_label": "enablecategories()",
@@ -51457,7 +51676,7 @@
       "source_location": "L131"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -51466,7 +51685,7 @@
       "source_location": "L12"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -51475,7 +51694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -51484,7 +51703,7 @@
       "source_location": "L20"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -51493,7 +51712,7 @@
       "source_location": "L46"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -51502,7 +51721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -51511,7 +51730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -51520,7 +51739,7 @@
       "source_location": "L20"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -51529,7 +51748,7 @@
       "source_location": "L59"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -51538,7 +51757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -51547,7 +51766,7 @@
       "source_location": "L25"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -51556,7 +51775,7 @@
       "source_location": "L20"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -51565,7 +51784,7 @@
       "source_location": "L30"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -51574,7 +51793,7 @@
       "source_location": "L95"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -51583,7 +51802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -51592,7 +51811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -51601,7 +51820,7 @@
       "source_location": "L61"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -51610,7 +51829,7 @@
       "source_location": "L65"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -51619,7 +51838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -51628,7 +51847,7 @@
       "source_location": "L150"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -51637,7 +51856,7 @@
       "source_location": "L157"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -51646,7 +51865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -51655,7 +51874,7 @@
       "source_location": "L63"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -51664,7 +51883,7 @@
       "source_location": "L48"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -51673,7 +51892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -51682,40 +51901,13 @@
       "source_location": "L63"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
       "norm_label": "handlesuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L76"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
-      "label": "WelcomeBackModalForm.tsx",
-      "norm_label": "welcomebackmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "welcomebackmodalform_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L51"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "welcomebackmodalform_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
-      "source_location": "L36"
     },
     {
       "community": 33,
@@ -51819,6 +52011,33 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
+      "label": "WelcomeBackModalForm.tsx",
+      "norm_label": "welcomebackmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "welcomebackmodalform_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "welcomebackmodalform_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
       "norm_label": "navigationbarprovider()",
@@ -51826,7 +52045,7 @@
       "source_location": "L16"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -51835,7 +52054,7 @@
       "source_location": "L39"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -51844,7 +52063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -51853,7 +52072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -51862,7 +52081,7 @@
       "source_location": "L25"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -51871,7 +52090,7 @@
       "source_location": "L82"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -51880,7 +52099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -51889,7 +52108,7 @@
       "source_location": "L20"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -51898,7 +52117,7 @@
       "source_location": "L55"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -51907,7 +52126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -51916,7 +52135,7 @@
       "source_location": "L107"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -51925,7 +52144,7 @@
       "source_location": "L25"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -51934,7 +52153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -51943,7 +52162,7 @@
       "source_location": "L556"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -51952,7 +52171,7 @@
       "source_location": "L52"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -51961,7 +52180,7 @@
       "source_location": "L429"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -51970,7 +52189,7 @@
       "source_location": "L102"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -51979,7 +52198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -51988,7 +52207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -51997,7 +52216,7 @@
       "source_location": "L250"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -52006,7 +52225,7 @@
       "source_location": "L46"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -52015,7 +52234,7 @@
       "source_location": "L17"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -52024,7 +52243,7 @@
       "source_location": "L63"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -52033,7 +52252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -52042,7 +52261,7 @@
       "source_location": "L47"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -52051,40 +52270,13 @@
       "source_location": "L141"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
       "norm_label": "login.tsx",
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
-      "label": "verify.index.tsx",
-      "norm_label": "verify.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "verify_index_verify",
-      "label": "Verify()",
-      "norm_label": "verify()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "verify_index_verifycheckoutsessionpayment",
-      "label": "VerifyCheckoutSessionPayment()",
-      "norm_label": "verifycheckoutsessionpayment()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L107"
     },
     {
       "community": 34,
@@ -52188,6 +52380,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
+      "label": "verify.index.tsx",
+      "norm_label": "verify.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "verify_index_verify",
+      "label": "Verify()",
+      "norm_label": "verify()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "verify_index_verifycheckoutsessionpayment",
+      "label": "VerifyCheckoutSessionPayment()",
+      "norm_label": "verifycheckoutsessionpayment()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L107"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
       "norm_label": "signup.tsx",
@@ -52195,7 +52414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -52204,7 +52423,7 @@
       "source_location": "L161"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -52213,7 +52432,7 @@
       "source_location": "L66"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -52222,7 +52441,7 @@
       "source_location": "L11"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -52231,7 +52450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -52240,7 +52459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -52249,7 +52468,7 @@
       "source_location": "L16"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -52258,7 +52477,7 @@
       "source_location": "L10"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -52267,7 +52486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -52276,7 +52495,7 @@
       "source_location": "L17"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -52285,7 +52504,7 @@
       "source_location": "L11"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -52294,7 +52513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -52303,7 +52522,7 @@
       "source_location": "L21"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -52312,7 +52531,7 @@
       "source_location": "L15"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -52321,7 +52540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -52330,7 +52549,7 @@
       "source_location": "L48"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -52339,7 +52558,7 @@
       "source_location": "L42"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -52348,7 +52567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -52357,7 +52576,7 @@
       "source_location": "L16"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -52366,7 +52585,7 @@
       "source_location": "L10"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -52375,7 +52594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -52384,7 +52603,7 @@
       "source_location": "L19"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -52393,7 +52612,7 @@
       "source_location": "L13"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -52402,7 +52621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -52411,7 +52630,7 @@
       "source_location": "L16"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -52420,39 +52639,12 @@
       "source_location": "L10"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
       "norm_label": "harness-self-review.test.ts",
       "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "harness_test_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "harness_test_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "scripts_harness_test_test_ts",
-      "label": "harness-test.test.ts",
-      "norm_label": "harness-test.test.ts",
-      "source_file": "scripts/harness-test.test.ts",
       "source_location": "L1"
     },
     {
@@ -52557,6 +52749,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "harness_test_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "harness_test_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "scripts_harness_test_test_ts",
+      "label": "harness-test.test.ts",
+      "norm_label": "harness-test.test.ts",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
       "norm_label": "log()",
@@ -52564,7 +52783,7 @@
       "source_location": "L26"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -52573,7 +52792,7 @@
       "source_location": "L18"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -52582,7 +52801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
@@ -52591,7 +52810,7 @@
       "source_location": "L45"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
       "label": "stageTrackedGraphifyArtifacts()",
@@ -52600,7 +52819,7 @@
       "source_location": "L20"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -52609,7 +52828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -52618,7 +52837,7 @@
       "source_location": "L8"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -52627,7 +52846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -52636,7 +52855,7 @@
       "source_location": "L9"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -52645,7 +52864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -52654,7 +52873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -52663,7 +52882,7 @@
       "source_location": "L12"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -52672,7 +52891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -52681,7 +52900,7 @@
       "source_location": "L8"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -52690,7 +52909,7 @@
       "source_location": "L10"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -52699,7 +52918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -52708,7 +52927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -52717,7 +52936,7 @@
       "source_location": "L18"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -52726,31 +52945,13 @@
       "source_location": "L10"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
       "norm_label": "mtnmomo.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
-      "label": "routerComposition.test.ts",
-      "norm_label": "routercomposition.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "routercomposition_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
-      "source_location": "L6"
     },
     {
       "community": 36,
@@ -52845,6 +53046,24 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
+      "label": "routerComposition.test.ts",
+      "norm_label": "routercomposition.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "routercomposition_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "cashier_authenticatehandler",
       "label": "authenticateHandler()",
       "norm_label": "authenticatehandler()",
@@ -52852,7 +53071,7 @@
       "source_location": "L239"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -52861,7 +53080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -52870,7 +53089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -52879,7 +53098,7 @@
       "source_location": "L8"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -52888,7 +53107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -52897,7 +53116,7 @@
       "source_location": "L6"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -52906,7 +53125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -52915,7 +53134,7 @@
       "source_location": "L27"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -52924,7 +53143,7 @@
       "source_location": "L4"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -52933,7 +53152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -52942,7 +53161,7 @@
       "source_location": "L3"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -52951,7 +53170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -52960,7 +53179,7 @@
       "source_location": "L3"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -52969,7 +53188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -52978,7 +53197,7 @@
       "source_location": "L6"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -52987,7 +53206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -52996,30 +53215,12 @@
       "source_location": "L3"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
       "norm_label": "approvalrequesthelpers.ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "approvalrequests_test_createapprovalrequestmutationctx",
-      "label": "createApprovalRequestMutationCtx()",
-      "norm_label": "createapprovalrequestmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.test.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
-      "label": "approvalRequests.test.ts",
-      "norm_label": "approvalrequests.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.test.ts",
       "source_location": "L1"
     },
     {
@@ -53115,6 +53316,24 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "approvalrequests_test_createapprovalrequestmutationctx",
+      "label": "createApprovalRequestMutationCtx()",
+      "norm_label": "createapprovalrequestmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
+      "label": "approvalRequests.test.ts",
+      "norm_label": "approvalrequests.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
       "norm_label": "buildoperationaleventmessage()",
@@ -53122,7 +53341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -53131,7 +53350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
@@ -53140,7 +53359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -53149,7 +53368,7 @@
       "source_location": "L7"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -53158,7 +53377,7 @@
       "source_location": "L9"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -53167,7 +53386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
@@ -53176,7 +53395,7 @@
       "source_location": "L31"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
@@ -53185,7 +53404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -53194,7 +53413,7 @@
       "source_location": "L6"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -53203,7 +53422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -53212,7 +53431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -53221,7 +53440,7 @@
       "source_location": "L88"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -53230,7 +53449,7 @@
       "source_location": "L8"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -53239,7 +53458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -53248,7 +53467,7 @@
       "source_location": "L4"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -53257,7 +53476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -53266,30 +53485,12 @@
       "source_location": "L6"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
       "norm_label": "access.test.ts",
       "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "access_requirestorefulladminaccess",
-      "label": "requireStoreFullAdminAccess()",
-      "norm_label": "requirestorefulladminaccess()",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_access_ts",
-      "label": "access.ts",
-      "norm_label": "access.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
       "source_location": "L1"
     },
     {
@@ -53385,6 +53586,24 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "access_requirestorefulladminaccess",
+      "label": "requireStoreFullAdminAccess()",
+      "norm_label": "requirestorefulladminaccess()",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_access_ts",
+      "label": "access.ts",
+      "norm_label": "access.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
       "norm_label": "purchaseorders.test.ts",
@@ -53392,7 +53611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -53401,7 +53620,7 @@
       "source_location": "L8"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -53410,7 +53629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -53419,7 +53638,7 @@
       "source_location": "L13"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -53428,7 +53647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -53437,7 +53656,7 @@
       "source_location": "L5"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -53446,7 +53665,7 @@
       "source_location": "L15"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -53455,7 +53674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -53464,7 +53683,7 @@
       "source_location": "L8"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -53473,7 +53692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -53482,7 +53701,7 @@
       "source_location": "L17"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -53491,7 +53710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -53500,7 +53719,7 @@
       "source_location": "L6"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -53509,7 +53728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -53518,7 +53737,7 @@
       "source_location": "L5"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -53527,7 +53746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -53536,31 +53755,13 @@
       "source_location": "L25"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
       "norm_label": "onlineorderitem.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "reviews_getstorefrontactorbyid",
-      "label": "getStoreFrontActorById()",
-      "norm_label": "getstorefrontactorbyid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
-      "source_location": "L17"
     },
     {
       "community": 39,
@@ -53655,6 +53856,24 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "reviews_getstorefrontactorbyid",
+      "label": "getStoreFrontActorById()",
+      "norm_label": "getstorefrontactorbyid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
@@ -53662,7 +53881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -53671,7 +53890,7 @@
       "source_location": "L7"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -53680,7 +53899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -53689,7 +53908,7 @@
       "source_location": "L14"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -53698,7 +53917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -53707,7 +53926,7 @@
       "source_location": "L8"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -53716,7 +53935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -53725,7 +53944,7 @@
       "source_location": "L3"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -53734,7 +53953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -53743,7 +53962,7 @@
       "source_location": "L5"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -53752,7 +53971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -53761,7 +53980,7 @@
       "source_location": "L16"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -53770,7 +53989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -53779,58 +53998,40 @@
       "source_location": "L30"
     },
     {
-      "community": 397,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
-      "label": "schemaIndexes.test.ts",
-      "norm_label": "schemaindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 397,
-      "file_type": "code",
-      "id": "schemaindexes_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
-      "source_location": "L5"
-    },
-    {
       "community": 398,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_serviceintake_ts",
-      "label": "serviceIntake.ts",
-      "norm_label": "serviceintake.ts",
-      "source_file": "packages/athena-webapp/shared/serviceIntake.ts",
+      "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
+      "label": "presentation.ts",
+      "norm_label": "presentation.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
       "source_location": "L1"
     },
     {
       "community": 398,
       "file_type": "code",
-      "id": "serviceintake_validateserviceintakeinput",
-      "label": "validateServiceIntakeInput()",
-      "norm_label": "validateserviceintakeinput()",
-      "source_file": "packages/athena-webapp/shared/serviceIntake.ts",
+      "id": "presentation_buildworkflowtraceviewmodel",
+      "label": "buildWorkflowTraceViewModel()",
+      "norm_label": "buildworkflowtraceviewmodel()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 399,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
+      "label": "queryUsage.test.ts",
+      "norm_label": "queryusage.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
       "source_location": "L1"
     },
     {
       "community": 399,
       "file_type": "code",
-      "id": "organizationview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organizationview_tsx",
-      "label": "OrganizationView.tsx",
-      "norm_label": "organizationview.tsx",
-      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
-      "source_location": "L1"
+      "id": "queryusage_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L4"
     },
     {
       "community": 4,
@@ -54177,6 +54378,60 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
+      "label": "schemaIndexes.test.ts",
+      "norm_label": "schemaindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "schemaindexes_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_serviceintake_ts",
+      "label": "serviceIntake.ts",
+      "norm_label": "serviceintake.ts",
+      "source_file": "packages/athena-webapp/shared/serviceIntake.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "serviceintake_validateserviceintakeinput",
+      "label": "validateServiceIntakeInput()",
+      "norm_label": "validateserviceintakeinput()",
+      "source_file": "packages/athena-webapp/shared/serviceIntake.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "organizationview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organizationview_tsx",
+      "label": "OrganizationView.tsx",
+      "norm_label": "organizationview.tsx",
+      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
@@ -54184,7 +54439,7 @@
       "source_location": "L12"
     },
     {
-      "community": 400,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -54193,7 +54448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -54202,7 +54457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 404,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -54211,7 +54466,7 @@
       "source_location": "L11"
     },
     {
-      "community": 402,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -54220,7 +54475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 405,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -54229,7 +54484,7 @@
       "source_location": "L11"
     },
     {
-      "community": 403,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -54238,7 +54493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 406,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -54247,7 +54502,7 @@
       "source_location": "L3"
     },
     {
-      "community": 404,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -54256,7 +54511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 407,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -54265,7 +54520,7 @@
       "source_location": "L12"
     },
     {
-      "community": 405,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -54274,7 +54529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 408,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -54283,7 +54538,7 @@
       "source_location": "L42"
     },
     {
-      "community": 406,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -54292,67 +54547,13 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 409,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
       "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 407,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
-      "label": "StoresDropdown.tsx",
-      "norm_label": "storesdropdown.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 407,
-      "file_type": "code",
-      "id": "storesdropdown_storesdropdown",
-      "label": "StoresDropdown()",
-      "norm_label": "storesdropdown()",
-      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "barcodeqrviewer_handleprint",
-      "label": "handlePrint()",
-      "norm_label": "handleprint()",
-      "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
-      "label": "BarcodeQRViewer.tsx",
-      "norm_label": "barcodeqrviewer.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
-      "label": "ProcessingFees.tsx",
-      "norm_label": "processingfees.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "processingfees_processingfeesview",
-      "label": "ProcessingFeesView()",
-      "norm_label": "processingfeesview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
-      "source_location": "L10"
     },
     {
       "community": 41,
@@ -54447,6 +54648,60 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
+      "label": "StoresDropdown.tsx",
+      "norm_label": "storesdropdown.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "storesdropdown_storesdropdown",
+      "label": "StoresDropdown()",
+      "norm_label": "storesdropdown()",
+      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "barcodeqrviewer_handleprint",
+      "label": "handlePrint()",
+      "norm_label": "handleprint()",
+      "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
+      "label": "BarcodeQRViewer.tsx",
+      "norm_label": "barcodeqrviewer.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 412,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
+      "label": "ProcessingFees.tsx",
+      "norm_label": "processingfees.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 412,
+      "file_type": "code",
+      "id": "processingfees_processingfeesview",
+      "label": "ProcessingFeesView()",
+      "norm_label": "processingfeesview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 413,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
       "norm_label": "productattributes.tsx",
@@ -54454,7 +54709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 413,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -54463,7 +54718,7 @@
       "source_location": "L14"
     },
     {
-      "community": 411,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -54472,7 +54727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 414,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -54481,7 +54736,7 @@
       "source_location": "L5"
     },
     {
-      "community": 412,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -54490,7 +54745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 415,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -54499,7 +54754,7 @@
       "source_location": "L10"
     },
     {
-      "community": 413,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -54508,7 +54763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 416,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -54517,7 +54772,7 @@
       "source_location": "L15"
     },
     {
-      "community": 414,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -54526,7 +54781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 417,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -54535,7 +54790,7 @@
       "source_location": "L13"
     },
     {
-      "community": 415,
+      "community": 418,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -54544,7 +54799,7 @@
       "source_location": "L116"
     },
     {
-      "community": 415,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -54553,7 +54808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -54562,67 +54817,13 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 419,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
       "norm_label": "setsourcevariant()",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L47"
-    },
-    {
-      "community": 417,
-      "file_type": "code",
-      "id": "activitytimeline_capitalizefirstletter",
-      "label": "capitalizeFirstLetter()",
-      "norm_label": "capitalizefirstletter()",
-      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
-      "source_location": "L151"
-    },
-    {
-      "community": 417,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
-      "label": "ActivityTimeline.tsx",
-      "norm_label": "activitytimeline.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "analyticsitems_analyticsitems",
-      "label": "AnalyticsItems()",
-      "norm_label": "analyticsitems()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
-      "label": "AnalyticsItems.tsx",
-      "norm_label": "analyticsitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "analyticsproducts_analyticsproducts",
-      "label": "AnalyticsProducts()",
-      "norm_label": "analyticsproducts()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
-      "label": "AnalyticsProducts.tsx",
-      "norm_label": "analyticsproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
-      "source_location": "L1"
     },
     {
       "community": 42,
@@ -54717,6 +54918,60 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "activitytimeline_capitalizefirstletter",
+      "label": "capitalizeFirstLetter()",
+      "norm_label": "capitalizefirstletter()",
+      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
+      "source_location": "L151"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
+      "label": "ActivityTimeline.tsx",
+      "norm_label": "activitytimeline.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "analyticsitems_analyticsitems",
+      "label": "AnalyticsItems()",
+      "norm_label": "analyticsitems()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
+      "label": "AnalyticsItems.tsx",
+      "norm_label": "analyticsitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
+      "id": "analyticsproducts_analyticsproducts",
+      "label": "AnalyticsProducts()",
+      "norm_label": "analyticsproducts()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
+      "label": "AnalyticsProducts.tsx",
+      "norm_label": "analyticsproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 423,
+      "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
       "norm_label": "analyticsusers()",
@@ -54724,7 +54979,7 @@
       "source_location": "L7"
     },
     {
-      "community": 420,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -54733,7 +54988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 424,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -54742,7 +54997,7 @@
       "source_location": "L42"
     },
     {
-      "community": 421,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -54751,7 +55006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -54760,7 +55015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 425,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -54769,7 +55024,7 @@
       "source_location": "L66"
     },
     {
-      "community": 423,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -54778,7 +55033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 426,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -54787,7 +55042,7 @@
       "source_location": "L18"
     },
     {
-      "community": 424,
+      "community": 427,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -54796,7 +55051,7 @@
       "source_location": "L6"
     },
     {
-      "community": 424,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -54805,7 +55060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 428,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -54814,7 +55069,7 @@
       "source_location": "L10"
     },
     {
-      "community": 425,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -54823,7 +55078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 429,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -54832,66 +55087,12 @@
       "source_location": "L27"
     },
     {
-      "community": 426,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
       "norm_label": "logsview.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 427,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
-      "label": "useLoadLogItems.ts",
-      "norm_label": "useloadlogitems.ts",
-      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 427,
-      "file_type": "code",
-      "id": "useloadlogitems_useloadlogitems",
-      "label": "useLoadLogItems()",
-      "norm_label": "useloadlogitems()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "auth_auth",
-      "label": "Auth()",
-      "norm_label": "auth()",
-      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_auth_tsx",
-      "label": "Auth.tsx",
-      "norm_label": "auth.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "index_login",
-      "label": "Login()",
-      "norm_label": "login()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
       "source_location": "L1"
     },
     {
@@ -54987,6 +55188,60 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
+      "label": "useLoadLogItems.ts",
+      "norm_label": "useloadlogitems.ts",
+      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "useloadlogitems_useloadlogitems",
+      "label": "useLoadLogItems()",
+      "norm_label": "useloadlogitems()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "auth_auth",
+      "label": "Auth()",
+      "norm_label": "auth()",
+      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_auth_tsx",
+      "label": "Auth.tsx",
+      "norm_label": "auth.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
+      "id": "index_login",
+      "label": "Login()",
+      "norm_label": "login()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 433,
+      "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
       "norm_label": "handleloadproducts()",
@@ -54994,7 +55249,7 @@
       "source_location": "L49"
     },
     {
-      "community": 430,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -55003,7 +55258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 434,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -55012,7 +55267,7 @@
       "source_location": "L23"
     },
     {
-      "community": 431,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -55021,7 +55276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 435,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -55030,7 +55285,7 @@
       "source_location": "L50"
     },
     {
-      "community": 432,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -55039,7 +55294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 436,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -55048,7 +55303,7 @@
       "source_location": "L13"
     },
     {
-      "community": 433,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -55057,7 +55312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 437,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -55066,7 +55321,7 @@
       "source_location": "L11"
     },
     {
-      "community": 434,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -55075,7 +55330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -55084,7 +55339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 438,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -55093,7 +55348,7 @@
       "source_location": "L7"
     },
     {
-      "community": 436,
+      "community": 439,
       "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
@@ -55102,66 +55357,12 @@
       "source_location": "L32"
     },
     {
-      "community": 436,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
       "norm_label": "expensecompletion.tsx",
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "bestsellersdialog_handleaddbestseller",
-      "label": "handleAddBestSeller()",
-      "norm_label": "handleaddbestseller()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
-      "label": "BestSellersDialog.tsx",
-      "norm_label": "bestsellersdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "featuredsectiondialog_handleaddfeatureditem",
-      "label": "handleAddFeaturedItem()",
-      "norm_label": "handleaddfeatureditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
-      "label": "FeaturedSectionDialog.tsx",
-      "norm_label": "featuredsectiondialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "home_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_home_tsx",
-      "label": "Home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
       "source_location": "L1"
     },
     {
@@ -55257,6 +55458,60 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "bestsellersdialog_handleaddbestseller",
+      "label": "handleAddBestSeller()",
+      "norm_label": "handleaddbestseller()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
+      "label": "BestSellersDialog.tsx",
+      "norm_label": "bestsellersdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "featuredsectiondialog_handleaddfeatureditem",
+      "label": "handleAddFeaturedItem()",
+      "norm_label": "handleaddfeatureditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
+      "label": "FeaturedSectionDialog.tsx",
+      "norm_label": "featuredsectiondialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
+      "id": "home_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_home_tsx",
+      "label": "Home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 443,
+      "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
       "norm_label": "handleupdateconfig()",
@@ -55264,7 +55519,7 @@
       "source_location": "L83"
     },
     {
-      "community": 440,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -55273,7 +55528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -55282,7 +55537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 444,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -55291,7 +55546,7 @@
       "source_location": "L35"
     },
     {
-      "community": 442,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -55300,7 +55555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 445,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -55309,7 +55564,7 @@
       "source_location": "L28"
     },
     {
-      "community": 443,
+      "community": 446,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -55318,7 +55573,7 @@
       "source_location": "L11"
     },
     {
-      "community": 443,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -55327,7 +55582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 447,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -55336,7 +55591,7 @@
       "source_location": "L13"
     },
     {
-      "community": 444,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -55345,7 +55600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 448,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -55354,7 +55609,7 @@
       "source_location": "L41"
     },
     {
-      "community": 445,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -55363,7 +55618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 449,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -55372,67 +55627,13 @@
       "source_location": "L33"
     },
     {
-      "community": 446,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
       "norm_label": "ordermetricspanel.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 447,
-      "file_type": "code",
-      "id": "orderview_handlerefundorder",
-      "label": "handleRefundOrder()",
-      "norm_label": "handlerefundorder()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
-      "source_location": "L68"
-    },
-    {
-      "community": 447,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
-      "label": "OrderView.tsx",
-      "norm_label": "orderview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "ordersview_gettimefilter",
-      "label": "getTimeFilter()",
-      "norm_label": "gettimefilter()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
-      "label": "OrdersView.tsx",
-      "norm_label": "ordersview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
-      "label": "RefundsView.tsx",
-      "norm_label": "refundsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "refundsview_handlerefundorder",
-      "label": "handleRefundOrder()",
-      "norm_label": "handlerefundorder()",
-      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
-      "source_location": "L79"
     },
     {
       "community": 45,
@@ -55527,6 +55728,60 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "orderview_handlerefundorder",
+      "label": "handleRefundOrder()",
+      "norm_label": "handlerefundorder()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
+      "source_location": "L68"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
+      "label": "OrderView.tsx",
+      "norm_label": "orderview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "ordersview_gettimefilter",
+      "label": "getTimeFilter()",
+      "norm_label": "gettimefilter()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
+      "label": "OrdersView.tsx",
+      "norm_label": "ordersview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
+      "label": "RefundsView.tsx",
+      "norm_label": "refundsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
+      "id": "refundsview_handlerefundorder",
+      "label": "handleRefundOrder()",
+      "norm_label": "handlerefundorder()",
+      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
+      "source_location": "L79"
+    },
+    {
+      "community": 453,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
       "norm_label": "usegetactiveonlineorder.ts",
@@ -55534,7 +55789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 453,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -55543,7 +55798,7 @@
       "source_location": "L6"
     },
     {
-      "community": 451,
+      "community": 454,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -55552,7 +55807,7 @@
       "source_location": "L34"
     },
     {
-      "community": 451,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -55561,7 +55816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 455,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -55570,7 +55825,7 @@
       "source_location": "L89"
     },
     {
-      "community": 452,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -55579,7 +55834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 456,
       "file_type": "code",
       "id": "cashierview_cashierview",
       "label": "CashierView()",
@@ -55588,7 +55843,7 @@
       "source_location": "L8"
     },
     {
-      "community": 453,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -55597,7 +55852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 457,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -55606,7 +55861,7 @@
       "source_location": "L5"
     },
     {
-      "community": 454,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -55615,7 +55870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 458,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -55624,7 +55879,7 @@
       "source_location": "L7"
     },
     {
-      "community": 455,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -55633,7 +55888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -55642,67 +55897,13 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 459,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
       "norm_label": "pininput()",
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 457,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
-      "label": "PointOfSaleView.tsx",
-      "norm_label": "pointofsaleview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 457,
-      "file_type": "code",
-      "id": "pointofsaleview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
-      "label": "PrintInstructions.tsx",
-      "norm_label": "printinstructions.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "printinstructions_printinstructions",
-      "label": "PrintInstructions()",
-      "norm_label": "printinstructions()",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
-      "label": "ProductCard.tsx",
-      "norm_label": "productcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "productcard_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
-      "source_location": "L14"
     },
     {
       "community": 46,
@@ -55797,6 +55998,60 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
+      "label": "PointOfSaleView.tsx",
+      "norm_label": "pointofsaleview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "pointofsaleview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
+      "label": "PrintInstructions.tsx",
+      "norm_label": "printinstructions.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "printinstructions_printinstructions",
+      "label": "PrintInstructions()",
+      "norm_label": "printinstructions()",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
+      "label": "ProductCard.tsx",
+      "norm_label": "productcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
+      "id": "productcard_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 463,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
       "norm_label": "productentry.tsx",
@@ -55804,7 +56059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 463,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -55813,7 +56068,7 @@
       "source_location": "L86"
     },
     {
-      "community": 461,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -55822,7 +56077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 464,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -55831,7 +56086,7 @@
       "source_location": "L15"
     },
     {
-      "community": 462,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -55840,7 +56095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 465,
       "file_type": "code",
       "id": "totalsdisplay_totalsdisplay",
       "label": "TotalsDisplay()",
@@ -55849,7 +56104,7 @@
       "source_location": "L14"
     },
     {
-      "community": 463,
+      "community": 466,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -55858,7 +56113,7 @@
       "source_location": "L18"
     },
     {
-      "community": 463,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -55867,7 +56122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -55876,7 +56131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 467,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -55885,7 +56140,7 @@
       "source_location": "L8"
     },
     {
-      "community": 465,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -55894,7 +56149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 468,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
@@ -55903,7 +56158,7 @@
       "source_location": "L8"
     },
     {
-      "community": 466,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -55912,67 +56167,13 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 469,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
       "norm_label": "getpaymentmethodicon()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L22"
-    },
-    {
-      "community": 467,
-      "file_type": "code",
-      "id": "barcodeview_barcodeview",
-      "label": "BarcodeView()",
-      "norm_label": "barcodeview()",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 467,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
-      "label": "BarcodeView.tsx",
-      "norm_label": "barcodeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "categorizationview_categorizationview",
-      "label": "CategorizationView()",
-      "norm_label": "categorizationview()",
-      "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
-      "label": "CategorizationView.tsx",
-      "norm_label": "categorizationview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "imagesview_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
-      "label": "ImagesView.tsx",
-      "norm_label": "imagesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 47,
@@ -56067,6 +56268,60 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "barcodeview_barcodeview",
+      "label": "BarcodeView()",
+      "norm_label": "barcodeview()",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
+      "label": "BarcodeView.tsx",
+      "norm_label": "barcodeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "categorizationview_categorizationview",
+      "label": "CategorizationView()",
+      "norm_label": "categorizationview()",
+      "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
+      "label": "CategorizationView.tsx",
+      "norm_label": "categorizationview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
+      "id": "imagesview_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
+      "label": "ImagesView.tsx",
+      "norm_label": "imagesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 473,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
       "norm_label": "skuselector.tsx",
@@ -56074,7 +56329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 473,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -56083,7 +56338,7 @@
       "source_location": "L10"
     },
     {
-      "community": 471,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -56092,7 +56347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 474,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -56101,7 +56356,7 @@
       "source_location": "L6"
     },
     {
-      "community": 472,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -56110,7 +56365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 475,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -56119,7 +56374,7 @@
       "source_location": "L5"
     },
     {
-      "community": 473,
+      "community": 476,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -56128,7 +56383,7 @@
       "source_location": "L17"
     },
     {
-      "community": 473,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -56137,7 +56392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -56146,7 +56401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 477,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -56155,7 +56410,7 @@
       "source_location": "L4"
     },
     {
-      "community": 475,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -56164,7 +56419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 478,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -56173,7 +56428,7 @@
       "source_location": "L84"
     },
     {
-      "community": 476,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -56182,67 +56437,13 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 479,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
       "norm_label": "handledeletepromocode()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
       "source_location": "L22"
-    },
-    {
-      "community": 477,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
-      "label": "PromoCodesView.tsx",
-      "norm_label": "promocodesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 477,
-      "file_type": "code",
-      "id": "promocodesview_promocodesview",
-      "label": "PromoCodesView()",
-      "norm_label": "promocodesview()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
-      "label": "SelectableCategories.tsx",
-      "norm_label": "selectablecategories.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "selectablecategories_toggle",
-      "label": "toggle()",
-      "norm_label": "toggle()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "discounttypetogglegroup_discounttypetogglegroup",
-      "label": "DiscountTypeToggleGroup()",
-      "norm_label": "discounttypetogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
-      "label": "DiscountTypeToggleGroup.tsx",
-      "norm_label": "discounttypetogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
-      "source_location": "L1"
     },
     {
       "community": 48,
@@ -56337,6 +56538,60 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
+      "label": "PromoCodesView.tsx",
+      "norm_label": "promocodesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "promocodesview_promocodesview",
+      "label": "PromoCodesView()",
+      "norm_label": "promocodesview()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
+      "label": "SelectableCategories.tsx",
+      "norm_label": "selectablecategories.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "selectablecategories_toggle",
+      "label": "toggle()",
+      "norm_label": "toggle()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
+      "id": "discounttypetogglegroup_discounttypetogglegroup",
+      "label": "DiscountTypeToggleGroup()",
+      "norm_label": "discounttypetogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
+      "label": "DiscountTypeToggleGroup.tsx",
+      "norm_label": "discounttypetogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 483,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
       "norm_label": "promocodespantogglegroup.tsx",
@@ -56344,7 +56599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 483,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -56353,7 +56608,7 @@
       "source_location": "L4"
     },
     {
-      "community": 481,
+      "community": 484,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -56362,7 +56617,7 @@
       "source_location": "L13"
     },
     {
-      "community": 481,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -56371,7 +56626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -56380,7 +56635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 485,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -56389,7 +56644,7 @@
       "source_location": "L29"
     },
     {
-      "community": 483,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -56398,7 +56653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 486,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -56407,7 +56662,7 @@
       "source_location": "L20"
     },
     {
-      "community": 484,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -56416,7 +56671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 487,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -56425,7 +56680,7 @@
       "source_location": "L171"
     },
     {
-      "community": 485,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -56434,7 +56689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 488,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -56443,7 +56698,7 @@
       "source_location": "L52"
     },
     {
-      "community": 486,
+      "community": 489,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -56452,66 +56707,12 @@
       "source_location": "L29"
     },
     {
-      "community": 486,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
       "norm_label": "empty-state.tsx",
       "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 487,
-      "file_type": "code",
-      "id": "nopermission_nopermission",
-      "label": "NoPermission()",
-      "norm_label": "nopermission()",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 487,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
-      "label": "NoPermission.tsx",
-      "norm_label": "nopermission.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "nopermissionview_nopermissionview",
-      "label": "NoPermissionView()",
-      "norm_label": "nopermissionview()",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
-      "label": "NoPermissionView.tsx",
-      "norm_label": "nopermissionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "notfoundview_notfoundview",
-      "label": "NotFoundView()",
-      "norm_label": "notfoundview()",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
-      "label": "NotFoundView.tsx",
-      "norm_label": "notfoundview.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L1"
     },
     {
@@ -56598,6 +56799,60 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "nopermission_nopermission",
+      "label": "NoPermission()",
+      "norm_label": "nopermission()",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
+      "label": "NoPermission.tsx",
+      "norm_label": "nopermission.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "nopermissionview_nopermissionview",
+      "label": "NoPermissionView()",
+      "norm_label": "nopermissionview()",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
+      "label": "NoPermissionView.tsx",
+      "norm_label": "nopermissionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
+      "id": "notfoundview_notfoundview",
+      "label": "NotFoundView()",
+      "norm_label": "notfoundview()",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
+      "label": "NotFoundView.tsx",
+      "norm_label": "notfoundview.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 493,
+      "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
       "norm_label": "contactview()",
@@ -56605,7 +56860,7 @@
       "source_location": "L9"
     },
     {
-      "community": 490,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -56614,7 +56869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 494,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -56623,7 +56878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -56632,7 +56887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 495,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -56641,7 +56896,7 @@
       "source_location": "L13"
     },
     {
-      "community": 492,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -56650,7 +56905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -56659,7 +56914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 496,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -56668,7 +56923,7 @@
       "source_location": "L25"
     },
     {
-      "community": 494,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -56677,7 +56932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 497,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -56686,7 +56941,7 @@
       "source_location": "L19"
     },
     {
-      "community": 495,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -56695,7 +56950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 498,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -56704,7 +56959,7 @@
       "source_location": "L63"
     },
     {
-      "community": 496,
+      "community": 499,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -56713,66 +56968,12 @@
       "source_location": "L7"
     },
     {
-      "community": 496,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
       "norm_label": "calendar.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 497,
-      "file_type": "code",
-      "id": "chart_usechart",
-      "label": "useChart()",
-      "norm_label": "usechart()",
-      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 497,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_chart_tsx",
-      "label": "chart.tsx",
-      "norm_label": "chart.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "copy_button_handlecopy",
-      "label": "handleCopy()",
-      "norm_label": "handlecopy()",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
-      "label": "copy-button.tsx",
-      "norm_label": "copy-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "copy_wrapper_handlecopy",
-      "label": "handleCopy()",
-      "norm_label": "handlecopy()",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
-      "label": "copy-wrapper.tsx",
-      "norm_label": "copy-wrapper.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L1"
     },
     {
@@ -57111,6 +57312,60 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "chart_usechart",
+      "label": "useChart()",
+      "norm_label": "usechart()",
+      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_chart_tsx",
+      "label": "chart.tsx",
+      "norm_label": "chart.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "copy_button_handlecopy",
+      "label": "handleCopy()",
+      "norm_label": "handlecopy()",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
+      "label": "copy-button.tsx",
+      "norm_label": "copy-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
+      "id": "copy_wrapper_handlecopy",
+      "label": "handleCopy()",
+      "norm_label": "handlecopy()",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
+      "label": "copy-wrapper.tsx",
+      "norm_label": "copy-wrapper.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 503,
+      "file_type": "code",
       "id": "date_time_picker_datetimepicker",
       "label": "DateTimePicker()",
       "norm_label": "datetimepicker()",
@@ -57118,7 +57373,7 @@
       "source_location": "L21"
     },
     {
-      "community": 500,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -57127,7 +57382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 504,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -57136,7 +57391,7 @@
       "source_location": "L6"
     },
     {
-      "community": 501,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -57145,7 +57400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 505,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -57154,7 +57409,7 @@
       "source_location": "L25"
     },
     {
-      "community": 502,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -57163,7 +57418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 506,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -57172,7 +57427,7 @@
       "source_location": "L49"
     },
     {
-      "community": 503,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -57181,7 +57436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -57190,7 +57445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 507,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -57199,7 +57454,7 @@
       "source_location": "L63"
     },
     {
-      "community": 505,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -57208,7 +57463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 508,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -57217,7 +57472,7 @@
       "source_location": "L5"
     },
     {
-      "community": 506,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -57226,67 +57481,13 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 509,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
       "norm_label": "welcomebackmodal()",
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L12"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
-      "label": "select-native.tsx",
-      "norm_label": "select-native.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "select_native_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
-      "label": "timeline-item.tsx",
-      "norm_label": "timeline-item.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "timeline_item_timelineitem",
-      "label": "TimelineItem()",
-      "norm_label": "timelineitem()",
-      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
-      "label": "webp-image.tsx",
-      "norm_label": "webp-image.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "webp_image_webpimage",
-      "label": "WebpImage()",
-      "norm_label": "webpimage()",
-      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
     },
     {
       "community": 51,
@@ -57372,6 +57573,60 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
+      "label": "select-native.tsx",
+      "norm_label": "select-native.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "select_native_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
+      "label": "timeline-item.tsx",
+      "norm_label": "timeline-item.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "timeline_item_timelineitem",
+      "label": "TimelineItem()",
+      "norm_label": "timelineitem()",
+      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
+      "label": "webp-image.tsx",
+      "norm_label": "webp-image.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
+      "id": "webp_image_webpimage",
+      "label": "WebpImage()",
+      "norm_label": "webpimage()",
+      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 513,
+      "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
       "norm_label": "bagitems()",
@@ -57379,7 +57634,7 @@
       "source_location": "L5"
     },
     {
-      "community": 510,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -57388,7 +57643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 514,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -57397,7 +57652,7 @@
       "source_location": "L11"
     },
     {
-      "community": 511,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -57406,7 +57661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 515,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -57415,7 +57670,7 @@
       "source_location": "L4"
     },
     {
-      "community": 512,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -57424,7 +57679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 516,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -57433,7 +57688,7 @@
       "source_location": "L110"
     },
     {
-      "community": 513,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -57442,7 +57697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -57451,7 +57706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 517,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -57460,7 +57715,7 @@
       "source_location": "L13"
     },
     {
-      "community": 515,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -57469,7 +57724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 518,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -57478,7 +57733,7 @@
       "source_location": "L7"
     },
     {
-      "community": 516,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -57487,67 +57742,13 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 519,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
       "norm_label": "useronlineorders()",
       "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
-      "label": "UserStatus.tsx",
-      "norm_label": "userstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "userstatus_userstatus",
-      "label": "UserStatus()",
-      "norm_label": "userstatus()",
-      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userview_tsx",
-      "label": "UserView.tsx",
-      "norm_label": "userview.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "userview_useractions",
-      "label": "UserActions()",
-      "norm_label": "useractions()",
-      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "customerjourneystage_customerjourneystagecard",
-      "label": "CustomerJourneyStageCard()",
-      "norm_label": "customerjourneystagecard()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
-      "label": "CustomerJourneyStage.tsx",
-      "norm_label": "customerjourneystage.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
-      "source_location": "L1"
     },
     {
       "community": 52,
@@ -57633,6 +57834,60 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
+      "label": "UserStatus.tsx",
+      "norm_label": "userstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "userstatus_userstatus",
+      "label": "UserStatus()",
+      "norm_label": "userstatus()",
+      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userview_tsx",
+      "label": "UserView.tsx",
+      "norm_label": "userview.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "userview_useractions",
+      "label": "UserActions()",
+      "norm_label": "useractions()",
+      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
+      "id": "customerjourneystage_customerjourneystagecard",
+      "label": "CustomerJourneyStageCard()",
+      "norm_label": "customerjourneystagecard()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
+      "label": "CustomerJourneyStage.tsx",
+      "norm_label": "customerjourneystage.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 523,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
       "norm_label": "use-image-upload.ts",
@@ -57640,7 +57895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 520,
+      "community": 523,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -57649,7 +57904,7 @@
       "source_location": "L7"
     },
     {
-      "community": 521,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -57658,7 +57913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 524,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -57667,7 +57922,7 @@
       "source_location": "L5"
     },
     {
-      "community": 522,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -57676,7 +57931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 525,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -57685,7 +57940,7 @@
       "source_location": "L5"
     },
     {
-      "community": 523,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -57694,7 +57949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 526,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -57703,7 +57958,7 @@
       "source_location": "L7"
     },
     {
-      "community": 524,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -57712,7 +57967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 527,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -57721,7 +57976,7 @@
       "source_location": "L9"
     },
     {
-      "community": 525,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -57730,7 +57985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 528,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -57739,7 +57994,7 @@
       "source_location": "L6"
     },
     {
-      "community": 526,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -57748,67 +58003,13 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 529,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
       "norm_label": "makesku()",
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L168"
-    },
-    {
-      "community": 527,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
-      "label": "useCopyText.ts",
-      "norm_label": "usecopytext.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 527,
-      "file_type": "code",
-      "id": "usecopytext_usecopytext",
-      "label": "useCopyText()",
-      "norm_label": "usecopytext()",
-      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
-      "label": "useCreateComplimentaryProduct.ts",
-      "norm_label": "usecreatecomplimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
-      "label": "useCreateComplimentaryProduct()",
-      "norm_label": "usecreatecomplimentaryproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
-      "label": "useDebounce.ts",
-      "norm_label": "usedebounce.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "usedebounce_usedebounce",
-      "label": "useDebounce()",
-      "norm_label": "usedebounce()",
-      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
-      "source_location": "L12"
     },
     {
       "community": 53,
@@ -57894,6 +58095,60 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
+      "label": "useCopyText.ts",
+      "norm_label": "usecopytext.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "usecopytext_usecopytext",
+      "label": "useCopyText()",
+      "norm_label": "usecopytext()",
+      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
+      "label": "useCreateComplimentaryProduct.ts",
+      "norm_label": "usecreatecomplimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
+      "label": "useCreateComplimentaryProduct()",
+      "norm_label": "usecreatecomplimentaryproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
+      "label": "useDebounce.ts",
+      "norm_label": "usedebounce.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
+      "id": "usedebounce_usedebounce",
+      "label": "useDebounce()",
+      "norm_label": "usedebounce()",
+      "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 533,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
       "norm_label": "useexpenseoperations.ts",
@@ -57901,7 +58156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 533,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
@@ -57910,7 +58165,7 @@
       "source_location": "L23"
     },
     {
-      "community": 531,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -57919,7 +58174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 534,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -57928,7 +58183,7 @@
       "source_location": "L6"
     },
     {
-      "community": 532,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -57937,7 +58192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 535,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -57946,7 +58201,7 @@
       "source_location": "L4"
     },
     {
-      "community": 533,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -57955,7 +58210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 536,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -57964,7 +58219,7 @@
       "source_location": "L5"
     },
     {
-      "community": 534,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -57973,7 +58228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 537,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -57982,7 +58237,7 @@
       "source_location": "L5"
     },
     {
-      "community": 535,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -57991,7 +58246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 538,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -58000,7 +58255,7 @@
       "source_location": "L4"
     },
     {
-      "community": 536,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -58009,67 +58264,13 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 539,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
       "norm_label": "usegetsubcategories()",
       "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
-      "label": "useGetTerminal.ts",
-      "norm_label": "usegetterminal.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "usegetterminal_usegetterminal",
-      "label": "useGetTerminal()",
-      "norm_label": "usegetterminal()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
-      "label": "useNewOrderNotification.ts",
-      "norm_label": "usenewordernotification.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "usenewordernotification_usenewordernotification",
-      "label": "useNewOrderNotification()",
-      "norm_label": "usenewordernotification()",
-      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
-      "label": "usePermissions.ts",
-      "norm_label": "usepermissions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "usepermissions_usepermissions",
-      "label": "usePermissions()",
-      "norm_label": "usepermissions()",
-      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
-      "source_location": "L13"
     },
     {
       "community": 54,
@@ -58155,6 +58356,60 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
+      "label": "useGetTerminal.ts",
+      "norm_label": "usegetterminal.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "usegetterminal_usegetterminal",
+      "label": "useGetTerminal()",
+      "norm_label": "usegetterminal()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
+      "label": "useNewOrderNotification.ts",
+      "norm_label": "usenewordernotification.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "usenewordernotification_usenewordernotification",
+      "label": "useNewOrderNotification()",
+      "norm_label": "usenewordernotification()",
+      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
+      "label": "usePermissions.ts",
+      "norm_label": "usepermissions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
+      "id": "usepermissions_usepermissions",
+      "label": "usePermissions()",
+      "norm_label": "usepermissions()",
+      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 543,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
       "norm_label": "useprint.ts",
@@ -58162,7 +58417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 543,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -58171,7 +58426,7 @@
       "source_location": "L3"
     },
     {
-      "community": 541,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -58180,7 +58435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 544,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -58189,7 +58444,7 @@
       "source_location": "L26"
     },
     {
-      "community": 542,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -58198,7 +58453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 545,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -58207,7 +58462,7 @@
       "source_location": "L7"
     },
     {
-      "community": 543,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -58216,7 +58471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 546,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -58225,7 +58480,7 @@
       "source_location": "L17"
     },
     {
-      "community": 544,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -58234,7 +58489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 547,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -58243,7 +58498,7 @@
       "source_location": "L12"
     },
     {
-      "community": 545,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -58252,7 +58507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 548,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -58261,7 +58516,7 @@
       "source_location": "L12"
     },
     {
-      "community": 546,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -58270,67 +58525,13 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 549,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
       "norm_label": "usetogglecomplimentaryproductactive()",
       "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 547,
-      "file_type": "code",
-      "id": "navigationutils_getorigin",
-      "label": "getOrigin()",
-      "norm_label": "getorigin()",
-      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 547,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_navigationutils_ts",
-      "label": "navigationUtils.ts",
-      "norm_label": "navigationutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "additem_additem",
-      "label": "addItem()",
-      "norm_label": "additem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
-      "label": "addItem.ts",
-      "norm_label": "additem.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "bootstrapregister_bootstrapregister",
-      "label": "bootstrapRegister()",
-      "norm_label": "bootstrapregister()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
-      "label": "bootstrapRegister.ts",
-      "norm_label": "bootstrapregister.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
-      "source_location": "L1"
     },
     {
       "community": 55,
@@ -58416,6 +58617,60 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "navigationutils_getorigin",
+      "label": "getOrigin()",
+      "norm_label": "getorigin()",
+      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_navigationutils_ts",
+      "label": "navigationUtils.ts",
+      "norm_label": "navigationutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "additem_additem",
+      "label": "addItem()",
+      "norm_label": "additem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
+      "label": "addItem.ts",
+      "norm_label": "additem.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
+      "id": "bootstrapregister_bootstrapregister",
+      "label": "bootstrapRegister()",
+      "norm_label": "bootstrapregister()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
+      "label": "bootstrapRegister.ts",
+      "norm_label": "bootstrapregister.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 553,
+      "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
       "norm_label": "holdsession()",
@@ -58423,7 +58678,7 @@
       "source_location": "L5"
     },
     {
-      "community": 550,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -58432,7 +58687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -58441,7 +58696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 554,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -58450,7 +58705,7 @@
       "source_location": "L5"
     },
     {
-      "community": 552,
+      "community": 555,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -58459,7 +58714,7 @@
       "source_location": "L10"
     },
     {
-      "community": 552,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -58468,7 +58723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -58477,7 +58732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 556,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -58486,7 +58741,7 @@
       "source_location": "L12"
     },
     {
-      "community": 554,
+      "community": 557,
       "file_type": "code",
       "id": "closeouts_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -58495,7 +58750,7 @@
       "source_location": "L10"
     },
     {
-      "community": 554,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_closeouts_index_tsx",
       "label": "closeouts.index.tsx",
@@ -58504,7 +58759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 558,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -58513,7 +58768,7 @@
       "source_location": "L6"
     },
     {
-      "community": 555,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
@@ -58522,7 +58777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
@@ -58531,67 +58786,13 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 559,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
       "norm_label": "hasorgnotfoundpayload()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 557,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
-      "label": "registers.index.tsx",
-      "norm_label": "registers.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 557,
-      "file_type": "code",
-      "id": "registers_index_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers.index.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "index_storerootredirect",
-      "label": "StoreRootRedirect()",
-      "norm_label": "storerootredirect()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
-      "label": "published.index.tsx",
-      "norm_label": "published.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "published_index_routecomponent",
-      "label": "RouteComponent()",
-      "norm_label": "routecomponent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
-      "source_location": "L9"
     },
     {
       "community": 56,
@@ -58677,6 +58878,60 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
+      "label": "registers.index.tsx",
+      "norm_label": "registers.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "registers_index_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers.index.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "index_storerootredirect",
+      "label": "StoreRootRedirect()",
+      "norm_label": "storerootredirect()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
+      "label": "published.index.tsx",
+      "norm_label": "published.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
+      "id": "published_index_routecomponent",
+      "label": "RouteComponent()",
+      "norm_label": "routecomponent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 563,
+      "file_type": "code",
       "id": "index_index",
       "label": "Index()",
       "norm_label": "index()",
@@ -58684,7 +58939,7 @@
       "source_location": "L13"
     },
     {
-      "community": 560,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -58693,7 +58948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 564,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -58702,7 +58957,7 @@
       "source_location": "L4"
     },
     {
-      "community": 561,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -58711,7 +58966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 565,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -58720,7 +58975,7 @@
       "source_location": "L13"
     },
     {
-      "community": 562,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -58729,7 +58984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 566,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -58738,7 +58993,7 @@
       "source_location": "L5"
     },
     {
-      "community": 563,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -58747,7 +59002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 567,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -58756,7 +59011,7 @@
       "source_location": "L17"
     },
     {
-      "community": 564,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -58765,7 +59020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 568,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -58774,7 +59029,7 @@
       "source_location": "L15"
     },
     {
-      "community": 565,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -58783,7 +59038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 569,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -58792,67 +59047,13 @@
       "source_location": "L12"
     },
     {
-      "community": 566,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
       "norm_label": "feedback.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "overview_stories_primitivesoverview",
-      "label": "PrimitivesOverview()",
-      "norm_label": "primitivesoverview()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
-      "label": "Popover.stories.tsx",
-      "norm_label": "popover.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "popover_stories_popovershowcase",
-      "label": "PopoverShowcase()",
-      "norm_label": "popovershowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
-      "label": "Sheet.stories.tsx",
-      "norm_label": "sheet.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "sheet_stories_sheetshowcase",
-      "label": "SheetShowcase()",
-      "norm_label": "sheetshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
-      "source_location": "L14"
     },
     {
       "community": 57,
@@ -58938,6 +59139,60 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "overview_stories_primitivesoverview",
+      "label": "PrimitivesOverview()",
+      "norm_label": "primitivesoverview()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
+      "label": "Popover.stories.tsx",
+      "norm_label": "popover.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "popover_stories_popovershowcase",
+      "label": "PopoverShowcase()",
+      "norm_label": "popovershowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
+      "label": "Sheet.stories.tsx",
+      "norm_label": "sheet.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
+      "id": "sheet_stories_sheetshowcase",
+      "label": "SheetShowcase()",
+      "norm_label": "sheetshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 573,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
       "norm_label": "tooltip.stories.tsx",
@@ -58945,7 +59200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 573,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -58954,7 +59209,7 @@
       "source_location": "L13"
     },
     {
-      "community": 571,
+      "community": 574,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -58963,7 +59218,7 @@
       "source_location": "L5"
     },
     {
-      "community": 571,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -58972,7 +59227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -58981,7 +59236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 575,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -58990,7 +59245,7 @@
       "source_location": "L17"
     },
     {
-      "community": 573,
+      "community": 576,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -58999,7 +59254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -59008,7 +59263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 577,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -59017,7 +59272,7 @@
       "source_location": "L4"
     },
     {
-      "community": 574,
+      "community": 577,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -59026,7 +59281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 578,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -59035,7 +59290,7 @@
       "source_location": "L27"
     },
     {
-      "community": 575,
+      "community": 578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -59044,7 +59299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 579,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -59053,67 +59308,13 @@
       "source_location": "L4"
     },
     {
-      "community": 576,
+      "community": 579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
       "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 577,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_storefront_ts",
-      "label": "storefront.ts",
-      "norm_label": "storefront.ts",
-      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 577,
-      "file_type": "code",
-      "id": "storefront_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "entitypage_entitypage",
-      "label": "EntityPage()",
-      "norm_label": "entitypage()",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
-      "label": "EntityPage.tsx",
-      "norm_label": "entitypage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productspage_tsx",
-      "label": "ProductsPage.tsx",
-      "norm_label": "productspage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "productspage_productcardloadingskeleton",
-      "label": "ProductCardLoadingSkeleton()",
-      "norm_label": "productcardloadingskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
-      "source_location": "L10"
     },
     {
       "community": 58,
@@ -59190,6 +59391,60 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_storefront_ts",
+      "label": "storefront.ts",
+      "norm_label": "storefront.ts",
+      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "storefront_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "entitypage_entitypage",
+      "label": "EntityPage()",
+      "norm_label": "entitypage()",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
+      "label": "EntityPage.tsx",
+      "norm_label": "entitypage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productspage_tsx",
+      "label": "ProductsPage.tsx",
+      "norm_label": "productspage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "productspage_productcardloadingskeleton",
+      "label": "ProductCardLoadingSkeleton()",
+      "norm_label": "productcardloadingskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 583,
+      "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
       "norm_label": "authcomponent()",
@@ -59197,7 +59452,7 @@
       "source_location": "L4"
     },
     {
-      "community": 580,
+      "community": 583,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -59206,7 +59461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 584,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -59215,7 +59470,7 @@
       "source_location": "L39"
     },
     {
-      "community": 581,
+      "community": 584,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -59224,7 +59479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 585,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -59233,7 +59488,7 @@
       "source_location": "L18"
     },
     {
-      "community": 582,
+      "community": 585,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -59242,7 +59497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 586,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -59251,7 +59506,7 @@
       "source_location": "L71"
     },
     {
-      "community": 583,
+      "community": 586,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -59260,7 +59515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 587,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -59269,7 +59524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 587,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -59278,7 +59533,7 @@
       "source_location": "L12"
     },
     {
-      "community": 585,
+      "community": 588,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -59287,7 +59542,7 @@
       "source_location": "L6"
     },
     {
-      "community": 585,
+      "community": 588,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -59296,7 +59551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 589,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -59305,67 +59560,13 @@
       "source_location": "L18"
     },
     {
-      "community": 586,
+      "community": 589,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
       "norm_label": "ordersummary.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "index_pickupdetails",
-      "label": "PickupDetails()",
-      "norm_label": "pickupdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
-      "label": "PaymentMethodSection.tsx",
-      "norm_label": "paymentmethodsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "paymentmethodsection_paymentmethodsection",
-      "label": "PaymentMethodSection()",
-      "norm_label": "paymentmethodsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
-      "label": "PaymentSection.tsx",
-      "norm_label": "paymentsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "paymentsection_paymentsection",
-      "label": "PaymentSection()",
-      "norm_label": "paymentsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L27"
     },
     {
       "community": 59,
@@ -59442,6 +59643,60 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "index_pickupdetails",
+      "label": "PickupDetails()",
+      "norm_label": "pickupdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
+      "label": "PaymentMethodSection.tsx",
+      "norm_label": "paymentmethodsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "paymentmethodsection_paymentmethodsection",
+      "label": "PaymentMethodSection()",
+      "norm_label": "paymentmethodsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
+      "label": "PaymentSection.tsx",
+      "norm_label": "paymentsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
+      "id": "paymentsection_paymentsection",
+      "label": "PaymentSection()",
+      "norm_label": "paymentsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 593,
+      "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
       "norm_label": "calculatedeliveryfee()",
@@ -59449,7 +59704,7 @@
       "source_location": "L40"
     },
     {
-      "community": 590,
+      "community": 593,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -59458,7 +59713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 594,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -59467,7 +59722,7 @@
       "source_location": "L3"
     },
     {
-      "community": 591,
+      "community": 594,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -59476,7 +59731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 595,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -59485,7 +59740,7 @@
       "source_location": "L8"
     },
     {
-      "community": 592,
+      "community": 595,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -59494,7 +59749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 596,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -59503,7 +59758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 596,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -59512,7 +59767,7 @@
       "source_location": "L12"
     },
     {
-      "community": 594,
+      "community": 597,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -59521,7 +59776,7 @@
       "source_location": "L77"
     },
     {
-      "community": 594,
+      "community": 597,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -59530,7 +59785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 598,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -59539,7 +59794,7 @@
       "source_location": "L161"
     },
     {
-      "community": 595,
+      "community": 598,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -59548,7 +59803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 599,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -59557,66 +59812,12 @@
       "source_location": "L3"
     },
     {
-      "community": 596,
+      "community": 599,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
       "norm_label": "hooks.ts",
       "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 597,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
-      "label": "TrustSignals.tsx",
-      "norm_label": "trustsignals.tsx",
-      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 597,
-      "file_type": "code",
-      "id": "trustsignals_trustsignals",
-      "label": "TrustSignals()",
-      "norm_label": "trustsignals()",
-      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
-      "label": "ProductFilter.tsx",
-      "norm_label": "productfilter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "productfilter_productfilter",
-      "label": "ProductFilter()",
-      "norm_label": "productfilter()",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "filter_handlecheckboxchange",
-      "label": "handleCheckboxChange()",
-      "norm_label": "handlecheckboxchange()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
-      "label": "Filter.tsx",
-      "norm_label": "filter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L1"
     },
     {
@@ -59928,6 +60129,60 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
+      "label": "TrustSignals.tsx",
+      "norm_label": "trustsignals.tsx",
+      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "trustsignals_trustsignals",
+      "label": "TrustSignals()",
+      "norm_label": "trustsignals()",
+      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
+      "label": "ProductFilter.tsx",
+      "norm_label": "productfilter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "productfilter_productfilter",
+      "label": "ProductFilter()",
+      "norm_label": "productfilter()",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "filter_handlecheckboxchange",
+      "label": "handleCheckboxChange()",
+      "norm_label": "handlecheckboxchange()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
+      "label": "Filter.tsx",
+      "norm_label": "filter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 603,
+      "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
       "norm_label": "bestsellerssection()",
@@ -59935,7 +60190,7 @@
       "source_location": "L17"
     },
     {
-      "community": 600,
+      "community": 603,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -59944,7 +60199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 604,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -59953,7 +60208,7 @@
       "source_location": "L13"
     },
     {
-      "community": 601,
+      "community": 604,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -59962,7 +60217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 605,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -59971,7 +60226,7 @@
       "source_location": "L47"
     },
     {
-      "community": 602,
+      "community": 605,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -59980,7 +60235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 606,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -59989,7 +60244,7 @@
       "source_location": "L7"
     },
     {
-      "community": 603,
+      "community": 606,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -59998,7 +60253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 607,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -60007,7 +60262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 607,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -60016,7 +60271,7 @@
       "source_location": "L17"
     },
     {
-      "community": 605,
+      "community": 608,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -60025,7 +60280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 608,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -60034,7 +60289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 609,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -60043,66 +60298,12 @@
       "source_location": "L12"
     },
     {
-      "community": 606,
+      "community": 609,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
       "norm_label": "dimensionbar.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "discountbadge_discountbadge",
-      "label": "DiscountBadge()",
-      "norm_label": "discountbadge()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
-      "label": "DiscountBadge.tsx",
-      "norm_label": "discountbadge.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "galleryviewer_handleclickonpreview",
-      "label": "handleClickOnPreview()",
-      "norm_label": "handleclickonpreview()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
-      "label": "GalleryViewer.tsx",
-      "norm_label": "galleryviewer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "onsaleproduct_onsaleproduct",
-      "label": "OnsaleProduct()",
-      "norm_label": "onsaleproduct()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
-      "label": "OnSaleProduct.tsx",
-      "norm_label": "onsaleproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L1"
     },
     {
@@ -60180,6 +60381,60 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "discountbadge_discountbadge",
+      "label": "DiscountBadge()",
+      "norm_label": "discountbadge()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
+      "label": "DiscountBadge.tsx",
+      "norm_label": "discountbadge.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "galleryviewer_handleclickonpreview",
+      "label": "handleClickOnPreview()",
+      "norm_label": "handleclickonpreview()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
+      "label": "GalleryViewer.tsx",
+      "norm_label": "galleryviewer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "onsaleproduct_onsaleproduct",
+      "label": "OnsaleProduct()",
+      "norm_label": "onsaleproduct()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
+      "label": "OnSaleProduct.tsx",
+      "norm_label": "onsaleproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 613,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
       "norm_label": "productactions.tsx",
@@ -60187,7 +60442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 613,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -60196,7 +60451,7 @@
       "source_location": "L17"
     },
     {
-      "community": 611,
+      "community": 614,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -60205,7 +60460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 614,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -60214,7 +60469,7 @@
       "source_location": "L3"
     },
     {
-      "community": 612,
+      "community": 615,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -60223,7 +60478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 615,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -60232,7 +60487,7 @@
       "source_location": "L78"
     },
     {
-      "community": 613,
+      "community": 616,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -60241,7 +60496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 616,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -60250,7 +60505,7 @@
       "source_location": "L87"
     },
     {
-      "community": 614,
+      "community": 617,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -60259,7 +60514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 617,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -60268,7 +60523,7 @@
       "source_location": "L8"
     },
     {
-      "community": 615,
+      "community": 618,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -60277,7 +60532,7 @@
       "source_location": "L12"
     },
     {
-      "community": 615,
+      "community": 618,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -60286,7 +60541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 619,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -60295,67 +60550,13 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 619,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
       "norm_label": "ratingselector()",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L18"
-    },
-    {
-      "community": 617,
-      "file_type": "code",
-      "id": "guestrewardsprompt_guestrewardsprompt",
-      "label": "GuestRewardsPrompt()",
-      "norm_label": "guestrewardsprompt()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 617,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
-      "label": "GuestRewardsPrompt.tsx",
-      "norm_label": "guestrewardsprompt.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "orderpointsdisplay_orderpointsdisplay",
-      "label": "OrderPointsDisplay()",
-      "norm_label": "orderpointsdisplay()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
-      "label": "OrderPointsDisplay.tsx",
-      "norm_label": "orderpointsdisplay.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
-      "label": "PastOrdersRewards.tsx",
-      "norm_label": "pastordersrewards.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "pastordersrewards_handleclaimpoints",
-      "label": "handleClaimPoints()",
-      "norm_label": "handleclaimpoints()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
-      "source_location": "L59"
     },
     {
       "community": 62,
@@ -60432,6 +60633,60 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "guestrewardsprompt_guestrewardsprompt",
+      "label": "GuestRewardsPrompt()",
+      "norm_label": "guestrewardsprompt()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
+      "label": "GuestRewardsPrompt.tsx",
+      "norm_label": "guestrewardsprompt.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "orderpointsdisplay_orderpointsdisplay",
+      "label": "OrderPointsDisplay()",
+      "norm_label": "orderpointsdisplay()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
+      "label": "OrderPointsDisplay.tsx",
+      "norm_label": "orderpointsdisplay.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
+      "label": "PastOrdersRewards.tsx",
+      "norm_label": "pastordersrewards.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
+      "id": "pastordersrewards_handleclaimpoints",
+      "label": "handleClaimPoints()",
+      "norm_label": "handleclaimpoints()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 623,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
       "norm_label": "rewardspanel.tsx",
@@ -60439,7 +60694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 623,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -60448,7 +60703,7 @@
       "source_location": "L33"
     },
     {
-      "community": 621,
+      "community": 624,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -60457,7 +60712,7 @@
       "source_location": "L19"
     },
     {
-      "community": 621,
+      "community": 624,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -60466,7 +60721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 625,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -60475,7 +60730,7 @@
       "source_location": "L4"
     },
     {
-      "community": 622,
+      "community": 625,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -60484,7 +60739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 626,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -60493,7 +60748,7 @@
       "source_location": "L22"
     },
     {
-      "community": 623,
+      "community": 626,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -60502,7 +60757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 627,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -60511,7 +60766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 627,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -60520,7 +60775,7 @@
       "source_location": "L11"
     },
     {
-      "community": 625,
+      "community": 628,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -60529,7 +60784,7 @@
       "source_location": "L3"
     },
     {
-      "community": 625,
+      "community": 628,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -60538,7 +60793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 629,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -60547,67 +60802,13 @@
       "source_location": "L3"
     },
     {
-      "community": 626,
+      "community": 629,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
       "norm_label": "ghana-region-select.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 627,
-      "file_type": "code",
-      "id": "ghost_button_ghostbutton",
-      "label": "GhostButton()",
-      "norm_label": "ghostbutton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 627,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
-      "label": "ghost-button.tsx",
-      "norm_label": "ghost-button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "leaveareviewmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
-      "label": "LeaveAReviewModal.tsx",
-      "norm_label": "leaveareviewmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
-      "label": "UpsellModalSuccess.tsx",
-      "norm_label": "upsellmodalsuccess.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "upsellmodalsuccess_upsellmodalsuccess",
-      "label": "UpsellModalSuccess()",
-      "norm_label": "upsellmodalsuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
-      "source_location": "L19"
     },
     {
       "community": 63,
@@ -60684,6 +60885,60 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "ghost_button_ghostbutton",
+      "label": "GhostButton()",
+      "norm_label": "ghostbutton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
+      "label": "ghost-button.tsx",
+      "norm_label": "ghost-button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "leaveareviewmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
+      "label": "LeaveAReviewModal.tsx",
+      "norm_label": "leaveareviewmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
+      "label": "UpsellModalSuccess.tsx",
+      "norm_label": "upsellmodalsuccess.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
+      "id": "upsellmodalsuccess_upsellmodalsuccess",
+      "label": "UpsellModalSuccess()",
+      "norm_label": "upsellmodalsuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 633,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
       "norm_label": "welcomebackmodalsuccess.tsx",
@@ -60691,7 +60946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 630,
+      "community": 633,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -60700,7 +60955,7 @@
       "source_location": "L13"
     },
     {
-      "community": 631,
+      "community": 634,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -60709,7 +60964,7 @@
       "source_location": "L46"
     },
     {
-      "community": 631,
+      "community": 634,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -60718,7 +60973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 635,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -60727,7 +60982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 635,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -60736,7 +60991,7 @@
       "source_location": "L46"
     },
     {
-      "community": 633,
+      "community": 636,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -60745,7 +61000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 636,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -60754,7 +61009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 637,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -60763,7 +61018,7 @@
       "source_location": "L15"
     },
     {
-      "community": 634,
+      "community": 637,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -60772,7 +61027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 638,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -60781,7 +61036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 638,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -60790,7 +61045,7 @@
       "source_location": "L5"
     },
     {
-      "community": 636,
+      "community": 639,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -60799,67 +61054,13 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 639,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
       "norm_label": "usediscountcodealert()",
       "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 637,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
-      "label": "useEnhancedTracking.ts",
-      "norm_label": "useenhancedtracking.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 637,
-      "file_type": "code",
-      "id": "useenhancedtracking_useenhancedtracking",
-      "label": "useEnhancedTracking()",
-      "norm_label": "useenhancedtracking()",
-      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
-      "label": "useGetActiveCheckoutSession.tsx",
-      "norm_label": "usegetactivecheckoutsession.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
-      "label": "useGetActiveCheckoutSession()",
-      "norm_label": "usegetactivecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
-      "label": "useGetProduct.tsx",
-      "norm_label": "usegetproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "usegetproduct_usegetproductquery",
-      "label": "useGetProductQuery()",
-      "norm_label": "usegetproductquery()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
-      "source_location": "L5"
     },
     {
       "community": 64,
@@ -60936,6 +61137,60 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
+      "label": "useEnhancedTracking.ts",
+      "norm_label": "useenhancedtracking.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "useenhancedtracking_useenhancedtracking",
+      "label": "useEnhancedTracking()",
+      "norm_label": "useenhancedtracking()",
+      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
+      "label": "useGetActiveCheckoutSession.tsx",
+      "norm_label": "usegetactivecheckoutsession.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
+      "label": "useGetActiveCheckoutSession()",
+      "norm_label": "usegetactivecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
+      "label": "useGetProduct.tsx",
+      "norm_label": "usegetproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "usegetproduct_usegetproductquery",
+      "label": "useGetProductQuery()",
+      "norm_label": "usegetproductquery()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 643,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
       "norm_label": "usegetproductfilters.ts",
@@ -60943,7 +61198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 643,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -60952,7 +61207,7 @@
       "source_location": "L3"
     },
     {
-      "community": 641,
+      "community": 644,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -60961,7 +61216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 644,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -60970,7 +61225,7 @@
       "source_location": "L4"
     },
     {
-      "community": 642,
+      "community": 645,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -60979,7 +61234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 645,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -60988,7 +61243,7 @@
       "source_location": "L4"
     },
     {
-      "community": 643,
+      "community": 646,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -60997,7 +61252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 646,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -61006,7 +61261,7 @@
       "source_location": "L9"
     },
     {
-      "community": 644,
+      "community": 647,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -61015,7 +61270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 647,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -61024,7 +61279,7 @@
       "source_location": "L17"
     },
     {
-      "community": 645,
+      "community": 648,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -61033,7 +61288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 648,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -61042,7 +61297,7 @@
       "source_location": "L5"
     },
     {
-      "community": 646,
+      "community": 649,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -61051,67 +61306,13 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 649,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
       "norm_label": "usemodalstate()",
       "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
       "source_location": "L15"
-    },
-    {
-      "community": 647,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
-      "label": "useProductPageLogic.ts",
-      "norm_label": "useproductpagelogic.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 647,
-      "file_type": "code",
-      "id": "useproductpagelogic_useproductpagelogic",
-      "label": "useProductPageLogic()",
-      "norm_label": "useproductpagelogic()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
-      "label": "useProductReminder.tsx",
-      "norm_label": "useproductreminder.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "useproductreminder_useproductreminder",
-      "label": "useProductReminder()",
-      "norm_label": "useproductreminder()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
-      "label": "usePromoAlert.tsx",
-      "norm_label": "usepromoalert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "usepromoalert_usepromoalert",
-      "label": "usePromoAlert()",
-      "norm_label": "usepromoalert()",
-      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
-      "source_location": "L16"
     },
     {
       "community": 65,
@@ -61188,6 +61389,60 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
+      "label": "useProductPageLogic.ts",
+      "norm_label": "useproductpagelogic.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "useproductpagelogic_useproductpagelogic",
+      "label": "useProductPageLogic()",
+      "norm_label": "useproductpagelogic()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
+      "label": "useProductReminder.tsx",
+      "norm_label": "useproductreminder.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "useproductreminder_useproductreminder",
+      "label": "useProductReminder()",
+      "norm_label": "useproductreminder()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
+      "label": "usePromoAlert.tsx",
+      "norm_label": "usepromoalert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
+      "id": "usepromoalert_usepromoalert",
+      "label": "usePromoAlert()",
+      "norm_label": "usepromoalert()",
+      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 653,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
       "norm_label": "usequeryenabled.ts",
@@ -61195,7 +61450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 653,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -61204,7 +61459,7 @@
       "source_location": "L4"
     },
     {
-      "community": 651,
+      "community": 654,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -61213,7 +61468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 654,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -61222,7 +61477,7 @@
       "source_location": "L11"
     },
     {
-      "community": 652,
+      "community": 655,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -61231,7 +61486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 655,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -61240,7 +61495,7 @@
       "source_location": "L3"
     },
     {
-      "community": 653,
+      "community": 656,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -61249,7 +61504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 656,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -61258,7 +61513,7 @@
       "source_location": "L7"
     },
     {
-      "community": 654,
+      "community": 657,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -61267,7 +61522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 657,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -61276,7 +61531,7 @@
       "source_location": "L4"
     },
     {
-      "community": 655,
+      "community": 658,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -61285,7 +61540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 658,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -61294,7 +61549,7 @@
       "source_location": "L14"
     },
     {
-      "community": 656,
+      "community": 659,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -61303,66 +61558,12 @@
       "source_location": "L4"
     },
     {
-      "community": 656,
+      "community": 659,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
       "norm_label": "analytics.ts",
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "bag_usebagqueries",
-      "label": "useBagQueries()",
-      "norm_label": "usebagqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "bannermessage_usebannermessagequeries",
-      "label": "useBannerMessageQueries()",
-      "norm_label": "usebannermessagequeries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "checkout_usecheckoutsessionqueries",
-      "label": "useCheckoutSessionQueries()",
-      "norm_label": "usecheckoutsessionqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
-      "label": "checkout.ts",
-      "norm_label": "checkout.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
       "source_location": "L1"
     },
     {
@@ -61440,6 +61641,60 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "bag_usebagqueries",
+      "label": "useBagQueries()",
+      "norm_label": "usebagqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "bannermessage_usebannermessagequeries",
+      "label": "useBannerMessageQueries()",
+      "norm_label": "usebannermessagequeries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
+      "id": "checkout_usecheckoutsessionqueries",
+      "label": "useCheckoutSessionQueries()",
+      "norm_label": "usecheckoutsessionqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
+      "label": "checkout.ts",
+      "norm_label": "checkout.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 663,
+      "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
       "norm_label": "useinventoryqueries()",
@@ -61447,7 +61702,7 @@
       "source_location": "L6"
     },
     {
-      "community": 660,
+      "community": 663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -61456,7 +61711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 664,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -61465,7 +61720,7 @@
       "source_location": "L5"
     },
     {
-      "community": 661,
+      "community": 664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -61474,7 +61729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -61483,7 +61738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 665,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -61492,7 +61747,7 @@
       "source_location": "L14"
     },
     {
-      "community": 663,
+      "community": 666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -61501,7 +61756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 666,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -61510,7 +61765,7 @@
       "source_location": "L9"
     },
     {
-      "community": 664,
+      "community": 667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -61519,7 +61774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 667,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -61528,7 +61783,7 @@
       "source_location": "L10"
     },
     {
-      "community": 665,
+      "community": 668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -61537,7 +61792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 668,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -61546,7 +61801,7 @@
       "source_location": "L11"
     },
     {
-      "community": 666,
+      "community": 669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -61555,67 +61810,13 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 669,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
       "norm_label": "useupsellsqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 667,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 667,
-      "file_type": "code",
-      "id": "user_useuserqueries",
-      "label": "useUserQueries()",
-      "norm_label": "useuserqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "useroffers_useuseroffersqueries",
-      "label": "useUserOffersQueries()",
-      "norm_label": "useuseroffersqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
-      "label": "storeConfig.test.ts",
-      "norm_label": "storeconfig.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "storeconfig_test_buildv2config",
-      "label": "buildV2Config()",
-      "norm_label": "buildv2config()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L10"
     },
     {
       "community": 67,
@@ -61692,6 +61893,60 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "user_useuserqueries",
+      "label": "useUserQueries()",
+      "norm_label": "useuserqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "useroffers_useuseroffersqueries",
+      "label": "useUserOffersQueries()",
+      "norm_label": "useuseroffersqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
+      "label": "storeConfig.test.ts",
+      "norm_label": "storeconfig.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
+      "id": "storeconfig_test_buildv2config",
+      "label": "buildV2Config()",
+      "norm_label": "buildv2config()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 673,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
       "norm_label": "storefrontobservability.test.ts",
@@ -61699,7 +61954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 670,
+      "community": 673,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -61708,7 +61963,7 @@
       "source_location": "L15"
     },
     {
-      "community": 671,
+      "community": 674,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -61717,7 +61972,7 @@
       "source_location": "L14"
     },
     {
-      "community": 671,
+      "community": 674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -61726,7 +61981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -61735,7 +61990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 675,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -61744,7 +61999,7 @@
       "source_location": "L6"
     },
     {
-      "community": 673,
+      "community": 676,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -61753,7 +62008,7 @@
       "source_location": "L13"
     },
     {
-      "community": 673,
+      "community": 676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -61762,7 +62017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 677,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -61771,7 +62026,7 @@
       "source_location": "L8"
     },
     {
-      "community": 674,
+      "community": 677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -61780,7 +62035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 678,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -61789,7 +62044,7 @@
       "source_location": "L14"
     },
     {
-      "community": 675,
+      "community": 678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -61798,7 +62053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 679,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -61807,67 +62062,13 @@
       "source_location": "L13"
     },
     {
-      "community": 676,
+      "community": 679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
       "norm_label": "delivery-returns-exchanges.index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 677,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
-      "label": "privacy.index.tsx",
-      "norm_label": "privacy.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 677,
-      "file_type": "code",
-      "id": "privacy_index_privacypolicy",
-      "label": "PrivacyPolicy()",
-      "norm_label": "privacypolicy()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
-      "label": "tos.index.tsx",
-      "norm_label": "tos.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "tos_index_tossection",
-      "label": "TosSection()",
-      "norm_label": "tossection()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
-      "label": "shop.product.$productSlug.tsx",
-      "norm_label": "shop.product.$productslug.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "shop_product_productslug_component",
-      "label": "Component()",
-      "norm_label": "component()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
-      "source_location": "L16"
     },
     {
       "community": 68,
@@ -61944,6 +62145,60 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
+      "label": "privacy.index.tsx",
+      "norm_label": "privacy.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "privacy_index_privacypolicy",
+      "label": "PrivacyPolicy()",
+      "norm_label": "privacypolicy()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
+      "label": "tos.index.tsx",
+      "norm_label": "tos.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "tos_index_tossection",
+      "label": "TosSection()",
+      "norm_label": "tossection()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
+      "label": "shop.product.$productSlug.tsx",
+      "norm_label": "shop.product.$productslug.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
+      "id": "shop_product_productslug_component",
+      "label": "Component()",
+      "norm_label": "component()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 683,
+      "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
       "norm_label": "layoutcomponent()",
@@ -61951,7 +62206,7 @@
       "source_location": "L6"
     },
     {
-      "community": 680,
+      "community": 683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -61960,7 +62215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 684,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -61969,7 +62224,7 @@
       "source_location": "L10"
     },
     {
-      "community": 681,
+      "community": 684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -61978,7 +62233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 685,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -61987,7 +62242,7 @@
       "source_location": "L21"
     },
     {
-      "community": 682,
+      "community": 685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -61996,7 +62251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 686,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -62005,7 +62260,7 @@
       "source_location": "L33"
     },
     {
-      "community": 683,
+      "community": 686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -62014,7 +62269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -62023,7 +62278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 687,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -62032,7 +62287,7 @@
       "source_location": "L193"
     },
     {
-      "community": 685,
+      "community": 688,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -62041,7 +62296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 688,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -62050,7 +62305,7 @@
       "source_location": "L7"
     },
     {
-      "community": 686,
+      "community": 689,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -62059,66 +62314,12 @@
       "source_location": "L10"
     },
     {
-      "community": 686,
+      "community": 689,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
       "norm_label": "architecture-boundaries.test.ts",
       "source_file": "scripts/architecture-boundaries.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 687,
-      "file_type": "code",
-      "id": "architecture_boundary_check_run",
-      "label": "run()",
-      "norm_label": "run()",
-      "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 687,
-      "file_type": "code",
-      "id": "scripts_architecture_boundary_check_ts",
-      "label": "architecture-boundary-check.ts",
-      "norm_label": "architecture-boundary-check.ts",
-      "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "athena_runtime_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
-      "label": "athena-runtime-app.ts",
-      "norm_label": "athena-runtime-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "sample_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_sample_app_ts",
-      "label": "sample-app.ts",
-      "norm_label": "sample-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
       "source_location": "L1"
     },
     {
@@ -62196,6 +62397,60 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "architecture_boundary_check_run",
+      "label": "run()",
+      "norm_label": "run()",
+      "source_file": "scripts/architecture-boundary-check.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "scripts_architecture_boundary_check_ts",
+      "label": "architecture-boundary-check.ts",
+      "norm_label": "architecture-boundary-check.ts",
+      "source_file": "scripts/architecture-boundary-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "athena_runtime_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
+      "label": "athena-runtime-app.ts",
+      "norm_label": "athena-runtime-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
+      "id": "sample_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_sample_app_ts",
+      "label": "sample-app.ts",
+      "norm_label": "sample-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 693,
+      "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
       "norm_label": "buildreportline()",
@@ -62203,7 +62458,7 @@
       "source_location": "L15"
     },
     {
-      "community": 690,
+      "community": 693,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -62212,7 +62467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 694,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -62221,7 +62476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -62230,7 +62485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -62239,7 +62494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -62248,7 +62503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -62257,39 +62512,12 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
       "norm_label": "app.ts",
       "source_file": "packages/athena-webapp/convex/app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 697,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_auth_config_js",
-      "label": "auth.config.js",
-      "norm_label": "auth.config.js",
-      "source_file": "packages/athena-webapp/convex/auth.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
-      "label": "registerSessions.test.ts",
-      "norm_label": "registersessions.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/registerSessions.test.ts",
       "source_location": "L1"
     },
     {
@@ -62583,6 +62811,33 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_auth_config_js",
+      "label": "auth.config.js",
+      "norm_label": "auth.config.js",
+      "source_file": "packages/athena-webapp/convex/auth.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
+      "label": "registerSessions.test.ts",
+      "norm_label": "registersessions.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/registerSessions.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 703,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
       "norm_label": "countries.ts",
@@ -62590,7 +62845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -62599,7 +62854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -62608,7 +62863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -62617,7 +62872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -62626,7 +62881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -62635,39 +62890,12 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
       "norm_label": "neworderadmin.tsx",
       "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 707,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
-      "label": "OrderEmail.tsx",
-      "norm_label": "orderemail.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
-      "label": "PosReceiptEmail.tsx",
-      "norm_label": "posreceiptemail.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_env_ts",
-      "label": "env.ts",
-      "norm_label": "env.ts",
-      "source_file": "packages/athena-webapp/convex/env.ts",
       "source_location": "L1"
     },
     {
@@ -62736,6 +62964,33 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
+      "label": "OrderEmail.tsx",
+      "norm_label": "orderemail.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
+      "label": "PosReceiptEmail.tsx",
+      "norm_label": "posreceiptemail.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_env_ts",
+      "label": "env.ts",
+      "norm_label": "env.ts",
+      "source_file": "packages/athena-webapp/convex/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 713,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
       "label": "analytics.ts",
       "norm_label": "analytics.ts",
@@ -62743,7 +62998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 714,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
@@ -62752,7 +63007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 715,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -62761,7 +63016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 716,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -62770,7 +63025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 717,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -62779,7 +63034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 718,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -62788,39 +63043,12 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 719,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
       "norm_label": "organizations.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/organizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 717,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
-      "label": "products.ts",
-      "norm_label": "products.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/products.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
-      "label": "subcategories.ts",
-      "norm_label": "subcategories.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
       "source_location": "L1"
     },
     {
@@ -62889,6 +63117,33 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
+      "label": "products.ts",
+      "norm_label": "products.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/products.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
+      "label": "subcategories.ts",
+      "norm_label": "subcategories.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 723,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -62896,7 +63151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 724,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
       "label": "bag.ts",
@@ -62905,7 +63160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 725,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
@@ -62914,7 +63169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
@@ -62923,7 +63178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
@@ -62932,7 +63187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
@@ -62941,39 +63196,12 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 727,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
-      "label": "paystack.ts",
-      "norm_label": "paystack.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
       "source_location": "L1"
     },
     {
@@ -63042,6 +63270,33 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
+      "label": "paystack.ts",
+      "norm_label": "paystack.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 732,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 733,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
       "label": "savedBag.ts",
       "norm_label": "savedbag.ts",
@@ -63049,7 +63304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
       "label": "security.test.ts",
@@ -63058,7 +63313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
@@ -63067,7 +63322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
@@ -63076,7 +63331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -63085,7 +63340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -63094,39 +63349,12 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
       "norm_label": "health.test.ts",
       "source_file": "packages/athena-webapp/convex/http/health.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 737,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_ts",
-      "label": "http.ts",
-      "norm_label": "http.ts",
-      "source_file": "packages/athena-webapp/convex/http.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
-      "label": "athenaUser.ts",
-      "norm_label": "athenauser.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
       "source_location": "L1"
     },
     {
@@ -63195,6 +63423,33 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_ts",
+      "label": "http.ts",
+      "norm_label": "http.ts",
+      "source_file": "packages/athena-webapp/convex/http.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
+      "label": "athenaUser.ts",
+      "norm_label": "athenauser.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 742,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 743,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
@@ -63202,7 +63457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -63211,7 +63466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -63220,7 +63475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -63229,7 +63484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -63238,7 +63493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -63247,39 +63502,12 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
       "norm_label": "expensetransactions.ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 747,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
-      "label": "featuredItem.ts",
-      "norm_label": "featureditem.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 748,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
-      "label": "inviteCode.ts",
-      "norm_label": "invitecode.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
-      "label": "organizationMembers.ts",
-      "norm_label": "organizationmembers.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
       "source_location": "L1"
     },
     {
@@ -63348,6 +63576,33 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
+      "label": "featuredItem.ts",
+      "norm_label": "featureditem.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
+      "label": "inviteCode.ts",
+      "norm_label": "invitecode.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 752,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
+      "label": "organizationMembers.ts",
+      "norm_label": "organizationmembers.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 753,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
       "norm_label": "organizations.ts",
@@ -63355,7 +63610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -63364,7 +63619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -63373,7 +63628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -63382,7 +63637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -63391,7 +63646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -63400,39 +63655,12 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
       "norm_label": "productutil.ts",
       "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 757,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_promocode_ts",
-      "label": "promoCode.ts",
-      "norm_label": "promocode.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 758,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
-      "label": "stockValidation.ts",
-      "norm_label": "stockvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
-      "label": "storeConfigV2.test.ts",
-      "norm_label": "storeconfigv2.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
       "source_location": "L1"
     },
     {
@@ -63501,6 +63729,33 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_promocode_ts",
+      "label": "promoCode.ts",
+      "norm_label": "promocode.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
+      "label": "stockValidation.ts",
+      "norm_label": "stockvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 762,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
+      "label": "storeConfigV2.test.ts",
+      "norm_label": "storeconfigv2.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 763,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
       "norm_label": "subcategories.ts",
@@ -63508,7 +63763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -63517,7 +63772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -63526,7 +63781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -63535,7 +63790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -63544,7 +63799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -63553,39 +63808,12 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
       "norm_label": "config.test.ts",
       "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 767,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
-      "label": "normalize.test.ts",
-      "norm_label": "normalize.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 768,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
-      "label": "customerProfiles.test.ts",
-      "norm_label": "customerprofiles.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.test.ts",
       "source_location": "L1"
     },
     {
@@ -63654,6 +63882,33 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
+      "label": "normalize.test.ts",
+      "norm_label": "normalize.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 772,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
+      "label": "customerProfiles.test.ts",
+      "norm_label": "customerprofiles.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 773,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
       "norm_label": "inventorymovements.test.ts",
@@ -63661,7 +63916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -63670,7 +63925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -63679,7 +63934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -63688,7 +63943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -63697,7 +63952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
@@ -63706,7 +63961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
@@ -63715,7 +63970,70 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 78,
+      "file_type": "code",
+      "id": "core_appendworkflowtraceeventwithctx",
+      "label": "appendWorkflowTraceEventWithCtx()",
+      "norm_label": "appendworkflowtraceeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "core_createworkflowtracewithctx",
+      "label": "createWorkflowTraceWithCtx()",
+      "norm_label": "createworkflowtracewithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "core_getworkflowtracebyidwithctx",
+      "label": "getWorkflowTraceByIdWithCtx()",
+      "norm_label": "getworkflowtracebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "core_getworkflowtracebylookupwithctx",
+      "label": "getWorkflowTraceByLookupWithCtx()",
+      "norm_label": "getworkflowtracebylookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "core_listworkflowtraceeventswithctx",
+      "label": "listWorkflowTraceEventsWithCtx()",
+      "norm_label": "listworkflowtraceeventswithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "core_registerworkflowtracelookupwithctx",
+      "label": "registerWorkflowTraceLookupWithCtx()",
+      "norm_label": "registerworkflowtracelookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "label": "core.ts",
+      "norm_label": "core.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 780,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -63724,7 +64042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 781,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -63733,7 +64051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 779,
+      "community": 782,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
@@ -63742,70 +64060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 78,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L112"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_summarystrip",
-      "label": "SummaryStrip()",
-      "norm_label": "summarystrip()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L125"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
-      "label": "CashControlsDashboard.tsx",
-      "norm_label": "cashcontrolsdashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 780,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -63814,7 +64069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -63823,7 +64078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -63832,7 +64087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -63841,7 +64096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -63850,7 +64105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -63859,7 +64114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -63868,7 +64123,70 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 79,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L93"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L112"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_summarystrip",
+      "label": "SummaryStrip()",
+      "norm_label": "summarystrip()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L125"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
+      "label": "CashControlsDashboard.tsx",
+      "norm_label": "cashcontrolsdashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 790,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -63877,7 +64195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 791,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -63886,7 +64204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 789,
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -63895,70 +64213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 79,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
-      "label": "StockAdjustmentWorkspace.tsx",
-      "norm_label": "stockadjustmentworkspace.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
-      "label": "buildCycleCountDrafts()",
-      "norm_label": "buildcyclecountdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildmanualdrafts",
-      "label": "buildManualDrafts()",
-      "norm_label": "buildmanualdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
-      "label": "buildStockAdjustmentSubmissionKey()",
-      "norm_label": "buildstockadjustmentsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_handlemodechange",
-      "label": "handleModeChange()",
-      "norm_label": "handlemodechange()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L166"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 790,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -63967,7 +64222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -63976,7 +64231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -63985,7 +64240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -63994,7 +64249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -64003,7 +64258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -64012,39 +64267,12 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
       "norm_label": "organization.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/organization.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 797,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
-      "label": "organizationMember.ts",
-      "norm_label": "organizationmember.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/organizationMember.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
-      "label": "promoCode.ts",
-      "norm_label": "promocode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
       "source_location": "L1"
     },
     {
@@ -64248,68 +64476,95 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "customerinfopanel_clearcustomer",
-      "label": "clearCustomer()",
-      "norm_label": "clearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "customerinfopanel_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "customerinfopanel_handlecreatecustomer",
-      "label": "handleCreateCustomer()",
-      "norm_label": "handlecreatecustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L78"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "customerinfopanel_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "customerinfopanel_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L60"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "customerinfopanel_handlestartedit",
-      "label": "handleStartEdit()",
-      "norm_label": "handlestartedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
-      "label": "CustomerInfoPanel.tsx",
-      "norm_label": "customerinfopanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "label": "StockAdjustmentWorkspace.tsx",
+      "norm_label": "stockadjustmentworkspace.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
       "source_location": "L1"
     },
     {
+      "community": 80,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
+      "label": "buildCycleCountDrafts()",
+      "norm_label": "buildcyclecountdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildmanualdrafts",
+      "label": "buildManualDrafts()",
+      "norm_label": "buildmanualdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
+      "label": "buildStockAdjustmentSubmissionKey()",
+      "norm_label": "buildstockadjustmentsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_handlemodechange",
+      "label": "handleModeChange()",
+      "norm_label": "handlemodechange()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L166"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L76"
+    },
+    {
       "community": 800,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
+      "label": "organizationMember.ts",
+      "norm_label": "organizationmember.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/organizationMember.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 802,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
+      "label": "promoCode.ts",
+      "norm_label": "promocode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -64318,7 +64573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -64327,7 +64582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -64336,7 +64591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -64345,7 +64600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -64354,7 +64609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -64363,7 +64618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -64372,7 +64627,70 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 81,
+      "file_type": "code",
+      "id": "customerinfopanel_clearcustomer",
+      "label": "clearCustomer()",
+      "norm_label": "clearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "customerinfopanel_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "customerinfopanel_handlecreatecustomer",
+      "label": "handleCreateCustomer()",
+      "norm_label": "handlecreatecustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L78"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "customerinfopanel_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "customerinfopanel_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L60"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "customerinfopanel_handlestartedit",
+      "label": "handleStartEdit()",
+      "norm_label": "handlestartedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
+      "label": "CustomerInfoPanel.tsx",
+      "norm_label": "customerinfopanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 810,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -64381,7 +64699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 811,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -64390,7 +64708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 809,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -64399,70 +64717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 81,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
-      "label": "session.ts",
-      "norm_label": "session.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "session_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "session_hasactiveregistersession",
-      "label": "hasActiveRegisterSession()",
-      "norm_label": "hasactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "session_hasresumableregistersession",
-      "label": "hasResumableRegisterSession()",
-      "norm_label": "hasresumableregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "session_isregisterreadytostart",
-      "label": "isRegisterReadyToStart()",
-      "norm_label": "isregisterreadytostart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "session_requirescashier",
-      "label": "requiresCashier()",
-      "norm_label": "requirescashier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "session_requiresterminal",
-      "label": "requiresTerminal()",
-      "norm_label": "requiresterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 810,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -64471,7 +64726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -64480,7 +64735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -64489,7 +64744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -64498,7 +64753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -64507,7 +64762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -64516,7 +64771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -64525,7 +64780,70 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 82,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "label": "session.ts",
+      "norm_label": "session.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "session_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "session_hasactiveregistersession",
+      "label": "hasActiveRegisterSession()",
+      "norm_label": "hasactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "session_hasresumableregistersession",
+      "label": "hasResumableRegisterSession()",
+      "norm_label": "hasresumableregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "session_isregisterreadytostart",
+      "label": "isRegisterReadyToStart()",
+      "norm_label": "isregisterreadytostart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "session_requirescashier",
+      "label": "requiresCashier()",
+      "norm_label": "requirescashier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "session_requiresterminal",
+      "label": "requiresTerminal()",
+      "norm_label": "requiresterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 820,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -64534,7 +64852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 821,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -64543,7 +64861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 819,
+      "community": 822,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -64552,70 +64870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 82,
-      "file_type": "code",
-      "id": "calculationservice_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "calculationservice_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "calculationservice_calculateitemtotal",
-      "label": "calculateItemTotal()",
-      "norm_label": "calculateitemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "calculationservice_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "calculationservice_geteffectiveprice",
-      "label": "getEffectivePrice()",
-      "norm_label": "geteffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "calculationservice_ispaymentsufficient",
-      "label": "isPaymentSufficient()",
-      "norm_label": "ispaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "label": "calculationService.ts",
-      "norm_label": "calculationservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 820,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -64624,7 +64879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -64633,7 +64888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -64642,7 +64897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -64651,7 +64906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -64660,7 +64915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -64669,7 +64924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -64678,7 +64933,70 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 83,
+      "file_type": "code",
+      "id": "calculationservice_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "calculationservice_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "calculationservice_calculateitemtotal",
+      "label": "calculateItemTotal()",
+      "norm_label": "calculateitemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "calculationservice_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "calculationservice_geteffectiveprice",
+      "label": "getEffectivePrice()",
+      "norm_label": "geteffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "calculationservice_ispaymentsufficient",
+      "label": "isPaymentSufficient()",
+      "norm_label": "ispaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
+      "label": "calculationService.ts",
+      "norm_label": "calculationservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 830,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -64687,7 +65005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 831,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -64696,7 +65014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 829,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -64705,70 +65023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 83,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 830,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -64777,7 +65032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -64786,7 +65041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -64795,7 +65050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -64804,7 +65059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -64813,7 +65068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -64822,7 +65077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -64831,7 +65086,70 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 84,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 840,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -64840,7 +65158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 841,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -64849,7 +65167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 839,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -64858,70 +65176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 84,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
-    },
-    {
-      "community": 840,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
@@ -64930,7 +65185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -64939,7 +65194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -64948,7 +65203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -64957,7 +65212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -64966,7 +65221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -64975,7 +65230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
       "label": "customer.ts",
@@ -64984,7 +65239,70 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 85,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
+    },
+    {
+      "community": 850,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -64993,7 +65311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 851,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -65002,7 +65320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 849,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -65011,70 +65329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 85,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 850,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -65083,7 +65338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -65092,7 +65347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -65101,7 +65356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -65110,7 +65365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -65119,7 +65374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -65128,7 +65383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -65137,7 +65392,70 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 86,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 860,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -65146,7 +65464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 861,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -65155,7 +65473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 859,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -65164,70 +65482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 86,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "label": "storefront-runtime-api.ts",
-      "norm_label": "storefront-runtime-api.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "storefront_runtime_api_emitsignal",
-      "label": "emitSignal()",
-      "norm_label": "emitsignal()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L195"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "label": "handleCheckoutSessionFetch()",
-      "norm_label": "handlecheckoutsessionfetch()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "label": "handleCheckoutSessionUpdate()",
-      "norm_label": "handlecheckoutsessionupdate()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "storefront_runtime_api_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "storefront_runtime_api_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L394"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "storefront_runtime_api_withcorsheaders",
-      "label": "withCorsHeaders()",
-      "norm_label": "withcorsheaders()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 860,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -65236,7 +65491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -65245,7 +65500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -65254,7 +65509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -65263,7 +65518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -65272,7 +65527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -65281,7 +65536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -65290,7 +65545,70 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 87,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "label": "storefront-runtime-api.ts",
+      "norm_label": "storefront-runtime-api.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "storefront_runtime_api_emitsignal",
+      "label": "emitSignal()",
+      "norm_label": "emitsignal()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L195"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "label": "handleCheckoutSessionFetch()",
+      "norm_label": "handlecheckoutsessionfetch()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L199"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "label": "handleCheckoutSessionUpdate()",
+      "norm_label": "handlecheckoutsessionupdate()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "storefront_runtime_api_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "storefront_runtime_api_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L394"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "storefront_runtime_api_withcorsheaders",
+      "label": "withCorsHeaders()",
+      "norm_label": "withcorsheaders()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 870,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -65299,7 +65617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 871,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -65308,7 +65626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 869,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -65317,70 +65635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 87,
-      "file_type": "code",
-      "id": "harness_janitor_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "label": "overwriteFreshGeneratedDocs()",
-      "norm_label": "overwritefreshgenerateddocs()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "label": "overwriteFreshGraphifyArtifacts()",
-      "norm_label": "overwritefreshgraphifyartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "harness_janitor_test_seedartifacts",
-      "label": "seedArtifacts()",
-      "norm_label": "seedartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "harness_janitor_test_sortpaths",
-      "label": "sortPaths()",
-      "norm_label": "sortpaths()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "harness_janitor_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 87,
-      "file_type": "code",
-      "id": "scripts_harness_janitor_test_ts",
-      "label": "harness-janitor.test.ts",
-      "norm_label": "harness-janitor.test.ts",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 870,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -65389,7 +65644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -65398,7 +65653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -65407,7 +65662,25 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 876,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
+      "label": "presentation.test.ts",
+      "norm_label": "presentation.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 877,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
+      "label": "public.ts",
+      "norm_label": "public.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/public.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -65416,7 +65689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -65425,7 +65698,70 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 88,
+      "file_type": "code",
+      "id": "harness_janitor_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgenerateddocs",
+      "label": "overwriteFreshGeneratedDocs()",
+      "norm_label": "overwritefreshgenerateddocs()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
+      "label": "overwriteFreshGraphifyArtifacts()",
+      "norm_label": "overwritefreshgraphifyartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "harness_janitor_test_seedartifacts",
+      "label": "seedArtifacts()",
+      "norm_label": "seedartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "harness_janitor_test_sortpaths",
+      "label": "sortPaths()",
+      "norm_label": "sortpaths()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "harness_janitor_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 88,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_test_ts",
+      "label": "harness-janitor.test.ts",
+      "norm_label": "harness-janitor.test.ts",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 880,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -65434,7 +65770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 881,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
@@ -65443,7 +65779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -65452,7 +65788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -65461,7 +65797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 879,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -65470,70 +65806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 88,
-      "file_type": "code",
-      "id": "harness_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "harness_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "harness_review_test_initializegithistory",
-      "label": "initializeGitHistory()",
-      "norm_label": "initializegithistory()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L259"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "harness_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "harness_review_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L245"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "harness_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 88,
-      "file_type": "code",
-      "id": "scripts_harness_review_test_ts",
-      "label": "harness-review.test.ts",
-      "norm_label": "harness-review.test.ts",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 880,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -65542,7 +65815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -65551,7 +65824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -65560,7 +65833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -65569,7 +65842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -65578,7 +65851,70 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 89,
+      "file_type": "code",
+      "id": "harness_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "harness_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "harness_review_test_initializegithistory",
+      "label": "initializeGitHistory()",
+      "norm_label": "initializegithistory()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L259"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "harness_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "harness_review_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L245"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "harness_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 89,
+      "file_type": "code",
+      "id": "scripts_harness_review_test_ts",
+      "label": "harness-review.test.ts",
+      "norm_label": "harness-review.test.ts",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 890,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -65587,7 +65923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 891,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -65596,7 +65932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -65605,7 +65941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -65614,7 +65950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 889,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -65623,61 +65959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 89,
-      "file_type": "code",
-      "id": "index_valkeyclient",
-      "label": "ValkeyClient",
-      "norm_label": "valkeyclient",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "index_valkeyclient_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "index_valkeyclient_get",
-      "label": ".get()",
-      "norm_label": ".get()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "index_valkeyclient_invalidate",
-      "label": ".invalidate()",
-      "norm_label": ".invalidate()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "index_valkeyclient_set",
-      "label": ".set()",
-      "norm_label": ".set()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 89,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cache_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 890,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -65686,7 +65968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -65695,7 +65977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -65704,7 +65986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -65713,57 +65995,12 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 895,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 896,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 897,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -65958,59 +66195,104 @@
     {
       "community": 90,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
-      "label": "paymentAllocationAttribution.ts",
-      "norm_label": "paymentallocationattribution.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L1"
+      "id": "index_valkeyclient",
+      "label": "ValkeyClient",
+      "norm_label": "valkeyclient",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L4"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "paymentallocationattribution_buildinstorepaymentallocations",
-      "label": "buildInStorePaymentAllocations()",
-      "norm_label": "buildinstorepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L48"
+      "id": "index_valkeyclient_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L11"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "paymentallocationattribution_isactiveregistersessionstatus",
-      "label": "isActiveRegisterSessionStatus()",
-      "norm_label": "isactiveregistersessionstatus()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "id": "index_valkeyclient_get",
+      "label": ".get()",
+      "norm_label": ".get()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L20"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "paymentallocationattribution_normalizeinstorepayments",
-      "label": "normalizeInStorePayments()",
-      "norm_label": "normalizeinstorepayments()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L24"
+      "id": "index_valkeyclient_invalidate",
+      "label": ".invalidate()",
+      "norm_label": ".invalidate()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L75"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
-      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
-      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L120"
+      "id": "index_valkeyclient_set",
+      "label": ".set()",
+      "norm_label": ".set()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L48"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "paymentallocationattribution_selectregistersessionforattribution",
-      "label": "selectRegisterSessionForAttribution()",
-      "norm_label": "selectregistersessionforattribution()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L83"
+      "id": "packages_athena_webapp_convex_cache_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L1"
     },
     {
       "community": 900,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 902,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 903,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 904,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -66019,7 +66301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -66028,7 +66310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66037,7 +66319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -66046,7 +66328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -66055,7 +66337,61 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 91,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "label": "paymentAllocationAttribution.ts",
+      "norm_label": "paymentallocationattribution.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "paymentallocationattribution_buildinstorepaymentallocations",
+      "label": "buildInStorePaymentAllocations()",
+      "norm_label": "buildinstorepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "paymentallocationattribution_isactiveregistersessionstatus",
+      "label": "isActiveRegisterSessionStatus()",
+      "norm_label": "isactiveregistersessionstatus()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "paymentallocationattribution_normalizeinstorepayments",
+      "label": "normalizeInStorePayments()",
+      "norm_label": "normalizeinstorepayments()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
+      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "paymentallocationattribution_selectregistersessionforattribution",
+      "label": "selectRegisterSessionForAttribution()",
+      "norm_label": "selectregistersessionforattribution()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 910,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -66064,7 +66400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 911,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66073,7 +66409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -66082,7 +66418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -66091,7 +66427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 909,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -66100,61 +66436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 91,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 910,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66163,7 +66445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66172,7 +66454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -66181,7 +66463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -66190,7 +66472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -66199,7 +66481,61 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 92,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 92,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 920,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66208,7 +66544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 921,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -66217,7 +66553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -66226,7 +66562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -66235,7 +66571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 919,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66244,61 +66580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 92,
-      "file_type": "code",
-      "id": "assigncustomer_createcustomer",
-      "label": "createCustomer()",
-      "norm_label": "createcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "assigncustomer_linktoguest",
-      "label": "linkToGuest()",
-      "norm_label": "linktoguest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L150"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "assigncustomer_linktostorefrontuser",
-      "label": "linkToStoreFrontUser()",
-      "norm_label": "linktostorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L111"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "assigncustomer_updatecustomer",
-      "label": "updateCustomer()",
-      "norm_label": "updatecustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "assigncustomer_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 92,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
-      "label": "assignCustomer.ts",
-      "norm_label": "assigncustomer.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 920,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66307,7 +66589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -66316,7 +66598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -66325,7 +66607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -66334,7 +66616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -66343,7 +66625,61 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 93,
+      "file_type": "code",
+      "id": "assigncustomer_createcustomer",
+      "label": "createCustomer()",
+      "norm_label": "createcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "assigncustomer_linktoguest",
+      "label": "linkToGuest()",
+      "norm_label": "linktoguest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "assigncustomer_linktostorefrontuser",
+      "label": "linkToStoreFrontUser()",
+      "norm_label": "linktostorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "assigncustomer_updatecustomer",
+      "label": "updateCustomer()",
+      "norm_label": "updatecustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "assigncustomer_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
+      "label": "assignCustomer.ts",
+      "norm_label": "assigncustomer.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 930,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -66352,7 +66688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 931,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66361,7 +66697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66370,7 +66706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -66379,7 +66715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 929,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -66388,61 +66724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 93,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
-      "label": "searchCustomers.ts",
-      "norm_label": "searchcustomers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "searchcustomers_findbystorefrontuser",
-      "label": "findByStoreFrontUser()",
-      "norm_label": "findbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "searchcustomers_findpotentialmatches",
-      "label": "findPotentialMatches()",
-      "norm_label": "findpotentialmatches()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "searchcustomers_getcustomerbyid",
-      "label": "getCustomerById()",
-      "norm_label": "getcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "searchcustomers_getcustomertransactions",
-      "label": "getCustomerTransactions()",
-      "norm_label": "getcustomertransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "searchcustomers_searchcustomers",
-      "label": "searchCustomers()",
-      "norm_label": "searchcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 930,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -66451,7 +66733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -66460,7 +66742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
@@ -66469,7 +66751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -66478,7 +66760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -66487,7 +66769,61 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 94,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
+      "label": "searchCustomers.ts",
+      "norm_label": "searchcustomers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "searchcustomers_findbystorefrontuser",
+      "label": "findByStoreFrontUser()",
+      "norm_label": "findbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "searchcustomers_findpotentialmatches",
+      "label": "findPotentialMatches()",
+      "norm_label": "findpotentialmatches()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "searchcustomers_getcustomerbyid",
+      "label": "getCustomerById()",
+      "norm_label": "getcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "searchcustomers_getcustomertransactions",
+      "label": "getCustomerTransactions()",
+      "norm_label": "getcustomertransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "searchcustomers_searchcustomers",
+      "label": "searchCustomers()",
+      "norm_label": "searchcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 940,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -66496,7 +66832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 941,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66505,7 +66841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66514,7 +66850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -66523,7 +66859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 939,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -66532,61 +66868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 94,
-      "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 940,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -66595,7 +66877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -66604,7 +66886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66613,7 +66895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66622,7 +66904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -66631,7 +66913,61 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 95,
+      "file_type": "code",
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 950,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -66640,7 +66976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 951,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -66649,7 +66985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
       "label": "RegisterCloseoutView.test.tsx",
@@ -66658,7 +66994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -66667,7 +67003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 949,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
       "label": "index.tsx",
@@ -66676,61 +67012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 95,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
-      "label": "purchaseOrders.ts",
-      "norm_label": "purchaseorders.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
-      "label": "assertValidPurchaseOrderStatusTransition()",
-      "norm_label": "assertvalidpurchaseorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordernumber",
-      "label": "buildPurchaseOrderNumber()",
-      "norm_label": "buildpurchaseordernumber()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "purchaseorders_calculatepurchaseordertotals",
-      "label": "calculatePurchaseOrderTotals()",
-      "norm_label": "calculatepurchaseordertotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "purchaseorders_getoperationalworkitemstatus",
-      "label": "getOperationalWorkItemStatus()",
-      "norm_label": "getoperationalworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "purchaseorders_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 950,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -66739,7 +67021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66748,7 +67030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -66757,7 +67039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -66766,7 +67048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -66775,7 +67057,61 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 96,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
+      "label": "purchaseOrders.ts",
+      "norm_label": "purchaseorders.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
+      "label": "assertValidPurchaseOrderStatusTransition()",
+      "norm_label": "assertvalidpurchaseorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "purchaseorders_buildpurchaseordernumber",
+      "label": "buildPurchaseOrderNumber()",
+      "norm_label": "buildpurchaseordernumber()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "purchaseorders_calculatepurchaseordertotals",
+      "label": "calculatePurchaseOrderTotals()",
+      "norm_label": "calculatepurchaseordertotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "purchaseorders_getoperationalworkitemstatus",
+      "label": "getOperationalWorkItemStatus()",
+      "norm_label": "getoperationalworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "purchaseorders_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 960,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -66784,7 +67120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 961,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -66793,7 +67129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -66802,7 +67138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -66811,7 +67147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 959,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -66820,61 +67156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 96,
-      "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 960,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
@@ -66883,7 +67165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -66892,7 +67174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66901,7 +67183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66910,7 +67192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -66919,7 +67201,61 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 97,
+      "file_type": "code",
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 970,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -66928,7 +67264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 971,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -66937,7 +67273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -66946,7 +67282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66955,7 +67291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 969,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66964,61 +67300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 97,
-      "file_type": "code",
-      "id": "onlineorder_appendtransition",
-      "label": "appendTransition()",
-      "norm_label": "appendtransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "onlineorder_applyonlineorderupdate",
-      "label": "applyOnlineOrderUpdate()",
-      "norm_label": "applyonlineorderupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereplacementsourceid",
-      "label": "buildReturnExchangeReplacementSourceId()",
-      "norm_label": "buildreturnexchangereplacementsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L204"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereturnsourceid",
-      "label": "buildReturnExchangeReturnSourceId()",
-      "norm_label": "buildreturnexchangereturnsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L212"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "onlineorder_listorderitems",
-      "label": "listOrderItems()",
-      "norm_label": "listorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 97,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 970,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -67027,7 +67309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -67036,7 +67318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -67045,7 +67327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -67054,7 +67336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -67063,7 +67345,61 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 98,
+      "file_type": "code",
+      "id": "onlineorder_appendtransition",
+      "label": "appendTransition()",
+      "norm_label": "appendtransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "onlineorder_applyonlineorderupdate",
+      "label": "applyOnlineOrderUpdate()",
+      "norm_label": "applyonlineorderupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereplacementsourceid",
+      "label": "buildReturnExchangeReplacementSourceId()",
+      "norm_label": "buildreturnexchangereplacementsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L204"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereturnsourceid",
+      "label": "buildReturnExchangeReturnSourceId()",
+      "norm_label": "buildreturnexchangereturnsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L212"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "onlineorder_listorderitems",
+      "label": "listOrderItems()",
+      "norm_label": "listorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 980,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -67072,7 +67408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 981,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -67081,7 +67417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -67090,7 +67426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -67099,7 +67435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 979,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -67108,61 +67444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 98,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_stockadjustment_ts",
-      "label": "stockAdjustment.ts",
-      "norm_label": "stockadjustment.ts",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "stockadjustment_assertstockadjustmentreasoncode",
-      "label": "assertStockAdjustmentReasonCode()",
-      "norm_label": "assertstockadjustmentreasoncode()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "stockadjustment_calculatecyclecountquantitydelta",
-      "label": "calculateCycleCountQuantityDelta()",
-      "norm_label": "calculatecyclecountquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "stockadjustment_requiresstockadjustmentapproval",
-      "label": "requiresStockAdjustmentApproval()",
-      "norm_label": "requiresstockadjustmentapproval()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
-      "label": "resolveStockAdjustmentQuantityDelta()",
-      "norm_label": "resolvestockadjustmentquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "stockadjustment_summarizestockadjustmentlineitems",
-      "label": "summarizeStockAdjustmentLineItems()",
-      "norm_label": "summarizestockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 980,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -67171,7 +67453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -67180,7 +67462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -67189,7 +67471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -67198,7 +67480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -67207,7 +67489,61 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 99,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_stockadjustment_ts",
+      "label": "stockAdjustment.ts",
+      "norm_label": "stockadjustment.ts",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "stockadjustment_assertstockadjustmentreasoncode",
+      "label": "assertStockAdjustmentReasonCode()",
+      "norm_label": "assertstockadjustmentreasoncode()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "stockadjustment_calculatecyclecountquantitydelta",
+      "label": "calculateCycleCountQuantityDelta()",
+      "norm_label": "calculatecyclecountquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "stockadjustment_requiresstockadjustmentapproval",
+      "label": "requiresStockAdjustmentApproval()",
+      "norm_label": "requiresstockadjustmentapproval()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
+      "label": "resolveStockAdjustmentQuantityDelta()",
+      "norm_label": "resolvestockadjustmentquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "stockadjustment_summarizestockadjustmentlineitems",
+      "label": "summarizeStockAdjustmentLineItems()",
+      "norm_label": "summarizestockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 990,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -67216,7 +67552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 991,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -67225,7 +67561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -67234,7 +67570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -67243,7 +67579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 989,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -67252,61 +67588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 99,
-      "file_type": "code",
-      "id": "data_table_toolbar_datatabletoolbar",
-      "label": "DataTableToolbar()",
-      "norm_label": "datatabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 990,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -67315,7 +67597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -67324,7 +67606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
@@ -67333,7 +67615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -67342,57 +67624,12 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
       "norm_label": "registeractionbar.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 995,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
-      "label": "RegisterCheckoutPanel.tsx",
-      "norm_label": "registercheckoutpanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 996,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
-      "label": "TransactionView.tsx",
-      "norm_label": "transactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 997,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
-      "label": "ProcurementView.test.tsx",
-      "norm_label": "procurementview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
-      "label": "ReceivingView.test.tsx",
-      "norm_label": "receivingview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.test.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1103,7 +1103,7 @@
       "relation": "calls",
       "source": "core_getworkflowtracebyidwithctx",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L90",
+      "source_location": "L91",
       "target": "core_createworkflowtracewithctx",
       "weight": 1
     },
@@ -12947,7 +12947,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_workflowtraces_core_ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L133",
+      "source_location": "L134",
       "target": "core_appendworkflowtraceeventwithctx",
       "weight": 1
     },
@@ -12959,7 +12959,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_workflowtraces_core_ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L80",
+      "source_location": "L81",
       "target": "core_createworkflowtracewithctx",
       "weight": 1
     },
@@ -13007,7 +13007,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_workflowtraces_core_ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L103",
+      "source_location": "L104",
       "target": "core_registerworkflowtracelookupwithctx",
       "weight": 1
     },
@@ -64051,7 +64051,7 @@
       "label": "appendWorkflowTraceEventWithCtx()",
       "norm_label": "appendworkflowtraceeventwithctx()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L133"
+      "source_location": "L134"
     },
     {
       "community": 78,
@@ -64060,7 +64060,7 @@
       "label": "createWorkflowTraceWithCtx()",
       "norm_label": "createworkflowtracewithctx()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L80"
+      "source_location": "L81"
     },
     {
       "community": 78,
@@ -64096,7 +64096,7 @@
       "label": "registerWorkflowTraceLookupWithCtx()",
       "norm_label": "registerworkflowtracelookupwithctx()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L103"
+      "source_location": "L104"
     },
     {
       "community": 78,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1103,7 +1103,7 @@
       "relation": "calls",
       "source": "core_getworkflowtracebyidwithctx",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L87",
+      "source_location": "L90",
       "target": "core_createworkflowtracewithctx",
       "weight": 1
     },
@@ -12947,7 +12947,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_workflowtraces_core_ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L130",
+      "source_location": "L133",
       "target": "core_appendworkflowtraceeventwithctx",
       "weight": 1
     },
@@ -12959,7 +12959,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_workflowtraces_core_ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L77",
+      "source_location": "L80",
       "target": "core_createworkflowtracewithctx",
       "weight": 1
     },
@@ -13007,7 +13007,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_workflowtraces_core_ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L100",
+      "source_location": "L103",
       "target": "core_registerworkflowtracelookupwithctx",
       "weight": 1
     },
@@ -13024,15 +13024,51 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_convex_workflowtraces_public_ts",
+      "_tgt": "public_getworkflowtraceviewbyidwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_workflowtraces_public_ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/public.ts",
+      "source_location": "L10",
+      "target": "public_getworkflowtraceviewbyidwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_workflowtraces_public_ts",
+      "_tgt": "public_getworkflowtraceviewbylookupwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_workflowtraces_public_ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/public.ts",
+      "source_location": "L44",
+      "target": "public_getworkflowtraceviewbylookupwithctx",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
-      "_tgt": "queryusage_test_getsource",
+      "_tgt": "queryusage_test_comparebyfields",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L4",
-      "target": "queryusage_test_getsource",
+      "source_location": "L84",
+      "target": "queryusage_test_comparebyfields",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
+      "_tgt": "queryusage_test_createtestctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L100",
+      "target": "queryusage_test_createtestctx",
       "weight": 1
     },
     {
@@ -28624,6 +28660,18 @@
       "weight": 1
     },
     {
+      "_src": "public_getworkflowtraceviewbylookupwithctx",
+      "_tgt": "public_getworkflowtraceviewbyidwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "public_getworkflowtraceviewbyidwithctx",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/public.ts",
+      "source_location": "L68",
+      "target": "public_getworkflowtraceviewbylookupwithctx",
+      "weight": 1
+    },
+    {
       "_src": "reeluploader_handlefileselect",
       "_tgt": "reeluploader_validatefile",
       "confidence": "EXTRACTED",
@@ -37782,56 +37830,56 @@
     {
       "community": 105,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1050,
@@ -37926,56 +37974,56 @@
     {
       "community": 106,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
     },
     {
       "community": 1060,
@@ -38070,56 +38118,56 @@
     {
       "community": 107,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L33"
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L23"
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L48"
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L85"
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L7"
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
     },
     {
       "community": 1070,
@@ -38214,56 +38262,56 @@
     {
       "community": 108,
       "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L7"
     },
     {
       "community": 1080,
@@ -38358,56 +38406,56 @@
     {
       "community": 109,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
-      "label": "payments.ts",
-      "norm_label": "payments.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "payments_calculateposchange",
-      "label": "calculatePosChange()",
-      "norm_label": "calculateposchange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "payments_calculateposremainingdue",
-      "label": "calculatePosRemainingDue()",
-      "norm_label": "calculateposremainingdue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "payments_calculatepostotalpaid",
-      "label": "calculatePosTotalPaid()",
-      "norm_label": "calculatepostotalpaid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "payments_ispospaymentsufficient",
-      "label": "isPosPaymentSufficient()",
-      "norm_label": "ispospaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "payments_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L27"
     },
     {
       "community": 1090,
@@ -38682,56 +38730,56 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
-      "label": "selectors.ts",
-      "norm_label": "selectors.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
       "source_location": "L1"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "selectors_buildregisterheaderstate",
-      "label": "buildRegisterHeaderState()",
-      "norm_label": "buildregisterheaderstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
       "source_location": "L27"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "selectors_buildregisterinfostate",
-      "label": "buildRegisterInfoState()",
-      "norm_label": "buildregisterinfostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "selectors_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "selectors_getregistercustomerinfo",
-      "label": "getRegisterCustomerInfo()",
-      "norm_label": "getregistercustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "selectors_isregistersessionactive",
-      "label": "isRegisterSessionActive()",
-      "norm_label": "isregistersessionactive()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L48"
     },
     {
       "community": 1100,
@@ -38826,56 +38874,56 @@
     {
       "community": 111,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
+      "label": "selectors.ts",
+      "norm_label": "selectors.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
       "source_location": "L1"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
+      "id": "selectors_buildregisterheaderstate",
+      "label": "buildRegisterHeaderState()",
+      "norm_label": "buildregisterheaderstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L27"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
+      "id": "selectors_buildregisterinfostate",
+      "label": "buildRegisterInfoState()",
+      "norm_label": "buildregisterinfostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L36"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
+      "id": "selectors_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L11"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
+      "id": "selectors_getregistercustomerinfo",
+      "label": "getRegisterCustomerInfo()",
+      "norm_label": "getregistercustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L5"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
+      "id": "selectors_isregistersessionactive",
+      "label": "isRegisterSessionActive()",
+      "norm_label": "isregistersessionactive()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L48"
     },
     {
       "community": 1110,
@@ -38970,56 +39018,56 @@
     {
       "community": 112,
       "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L198"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L71"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
     },
     {
       "community": 1120,
@@ -39114,56 +39162,56 @@
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L232"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
+      "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
       "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L156"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storesettingsview_onsubmit",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L198"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L105"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
       "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L82"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L71"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L28"
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1130,
@@ -39258,56 +39306,56 @@
     {
       "community": 114,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L83"
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L232"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L82"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L28"
     },
     {
       "community": 1140,
@@ -39402,56 +39450,56 @@
     {
       "community": 115,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
       "source_location": "L1"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L83"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
     },
     {
       "community": 1150,
@@ -39546,56 +39594,56 @@
     {
       "community": 116,
       "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
     },
     {
       "community": 1160,
@@ -39690,55 +39738,55 @@
     {
       "community": 117,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1"
     },
     {
@@ -39834,55 +39882,55 @@
     {
       "community": 118,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1"
     },
     {
@@ -42453,6 +42501,51 @@
     {
       "community": 135,
       "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
       "norm_label": "getperiodrange()",
@@ -42460,7 +42553,7 @@
       "source_location": "L20"
     },
     {
-      "community": 135,
+      "community": 136,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -42469,7 +42562,7 @@
       "source_location": "L50"
     },
     {
-      "community": 135,
+      "community": 136,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -42478,7 +42571,7 @@
       "source_location": "L342"
     },
     {
-      "community": 135,
+      "community": 136,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -42487,7 +42580,7 @@
       "source_location": "L322"
     },
     {
-      "community": 135,
+      "community": 136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -42496,7 +42589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -42505,7 +42598,7 @@
       "source_location": "L61"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -42514,7 +42607,7 @@
       "source_location": "L57"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -42523,7 +42616,7 @@
       "source_location": "L98"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -42532,7 +42625,7 @@
       "source_location": "L134"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -42541,7 +42634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -42550,7 +42643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -42559,7 +42652,7 @@
       "source_location": "L38"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -42568,7 +42661,7 @@
       "source_location": "L64"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -42577,7 +42670,7 @@
       "source_location": "L135"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -42586,7 +42679,7 @@
       "source_location": "L43"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -42595,7 +42688,7 @@
       "source_location": "L58"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -42604,7 +42697,7 @@
       "source_location": "L63"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -42613,7 +42706,7 @@
       "source_location": "L50"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -42622,57 +42715,12 @@
       "source_location": "L53"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
       "norm_label": "activityview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "orderdetailsview_fetchtransactions",
-      "label": "fetchTransactions()",
-      "norm_label": "fetchtransactions()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L138"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkasverified",
-      "label": "handleMarkAsVerified()",
-      "norm_label": "handlemarkasverified()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L175"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkpaymentcollected",
-      "label": "handleMarkPaymentCollected()",
-      "norm_label": "handlemarkpaymentcollected()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L189"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "orderdetailsview_verifiedbadge",
-      "label": "VerifiedBadge()",
-      "norm_label": "verifiedbadge()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "label": "OrderDetailsView.tsx",
-      "norm_label": "orderdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L1"
     },
     {
@@ -42840,6 +42888,51 @@
     {
       "community": 140,
       "file_type": "code",
+      "id": "orderdetailsview_fetchtransactions",
+      "label": "fetchTransactions()",
+      "norm_label": "fetchtransactions()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L138"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkasverified",
+      "label": "handleMarkAsVerified()",
+      "norm_label": "handlemarkasverified()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L175"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkpaymentcollected",
+      "label": "handleMarkPaymentCollected()",
+      "norm_label": "handlemarkpaymentcollected()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L189"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "orderdetailsview_verifiedbadge",
+      "label": "VerifiedBadge()",
+      "norm_label": "verifiedbadge()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
+      "label": "OrderDetailsView.tsx",
+      "norm_label": "orderdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
       "norm_label": "handlerequestfeedback()",
@@ -42847,7 +42940,7 @@
       "source_location": "L77"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -42856,7 +42949,7 @@
       "source_location": "L295"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -42865,7 +42958,7 @@
       "source_location": "L61"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -42874,57 +42967,12 @@
       "source_location": "L47"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
       "norm_label": "orderitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1"
     },
     {
@@ -44649,42 +44697,6 @@
     {
       "community": 171,
       "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
       "norm_label": "getcachedtokenrecord()",
@@ -44692,7 +44704,7 @@
       "source_location": "L26"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -44701,7 +44713,7 @@
       "source_location": "L79"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -44710,7 +44722,7 @@
       "source_location": "L33"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -44719,7 +44731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -44728,7 +44740,7 @@
       "source_location": "L10"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -44737,7 +44749,7 @@
       "source_location": "L18"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -44746,7 +44758,7 @@
       "source_location": "L52"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -44755,7 +44767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -44764,7 +44776,7 @@
       "source_location": "L28"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -44773,7 +44785,7 @@
       "source_location": "L42"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -44782,7 +44794,7 @@
       "source_location": "L73"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -44791,7 +44803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -44800,7 +44812,7 @@
       "source_location": "L8"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -44809,7 +44821,7 @@
       "source_location": "L32"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -44818,7 +44830,7 @@
       "source_location": "L64"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -44827,7 +44839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -44836,7 +44848,7 @@
       "source_location": "L18"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -44845,7 +44857,7 @@
       "source_location": "L25"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -44854,7 +44866,7 @@
       "source_location": "L11"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -44863,7 +44875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -44872,7 +44884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -44881,7 +44893,7 @@
       "source_location": "L36"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -44890,7 +44902,7 @@
       "source_location": "L23"
     },
     {
-      "community": 177,
+      "community": 176,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -44899,7 +44911,7 @@
       "source_location": "L18"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
       "label": "terminals.ts",
@@ -44908,7 +44920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "terminals_deleteterminal",
       "label": "deleteTerminal()",
@@ -44917,7 +44929,7 @@
       "source_location": "L89"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "terminals_registerterminal",
       "label": "registerTerminal()",
@@ -44926,7 +44938,7 @@
       "source_location": "L13"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "terminals_updateterminal",
       "label": "updateTerminal()",
@@ -44935,7 +44947,7 @@
       "source_location": "L54"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -44944,7 +44956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -44953,7 +44965,7 @@
       "source_location": "L122"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -44962,13 +44974,49 @@
       "source_location": "L34"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
       "norm_label": "searchproducts()",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
       "source_location": "L72"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
+      "label": "sessionCommandRepository.ts",
+      "norm_label": "sessioncommandrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "sessioncommandrepository_collectsessionitemsfrompages",
+      "label": "collectSessionItemsFromPages()",
+      "norm_label": "collectsessionitemsfrompages()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "sessioncommandrepository_createsessioncommandrepository",
+      "label": "createSessionCommandRepository()",
+      "norm_label": "createsessioncommandrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "sessioncommandrepository_findsessionitembyskuinpages",
+      "label": "findSessionItemBySkuInPages()",
+      "norm_label": "findsessionitembyskuinpages()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
+      "source_location": "L158"
     },
     {
       "community": 18,
@@ -45126,42 +45174,6 @@
     {
       "community": 180,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
-      "label": "sessionCommandRepository.ts",
-      "norm_label": "sessioncommandrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "sessioncommandrepository_collectsessionitemsfrompages",
-      "label": "collectSessionItemsFromPages()",
-      "norm_label": "collectsessionitemsfrompages()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "sessioncommandrepository_createsessioncommandrepository",
-      "label": "createSessionCommandRepository()",
-      "norm_label": "createsessioncommandrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "sessioncommandrepository_findsessionitembyskuinpages",
-      "label": "findSessionItemBySkuInPages()",
-      "norm_label": "findsessionitembyskuinpages()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
       "norm_label": "createapprovaldecisionmutationctx()",
@@ -45169,7 +45181,7 @@
       "source_location": "L30"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -45178,7 +45190,7 @@
       "source_location": "L175"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -45187,7 +45199,7 @@
       "source_location": "L26"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -45196,7 +45208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -45205,7 +45217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -45214,7 +45226,7 @@
       "source_location": "L23"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -45223,7 +45235,7 @@
       "source_location": "L9"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -45232,7 +45244,7 @@
       "source_location": "L13"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -45241,7 +45253,7 @@
       "source_location": "L19"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -45250,7 +45262,7 @@
       "source_location": "L26"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -45259,7 +45271,7 @@
       "source_location": "L12"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -45268,7 +45280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -45277,7 +45289,7 @@
       "source_location": "L21"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -45286,7 +45298,7 @@
       "source_location": "L63"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -45295,7 +45307,7 @@
       "source_location": "L71"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -45304,7 +45316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -45313,7 +45325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -45322,7 +45334,7 @@
       "source_location": "L13"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -45331,7 +45343,7 @@
       "source_location": "L31"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -45340,7 +45352,7 @@
       "source_location": "L9"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -45349,7 +45361,7 @@
       "source_location": "L228"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -45358,7 +45370,7 @@
       "source_location": "L45"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -45367,7 +45379,7 @@
       "source_location": "L26"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -45376,7 +45388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -45385,7 +45397,7 @@
       "source_location": "L55"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -45394,7 +45406,7 @@
       "source_location": "L32"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -45403,7 +45415,7 @@
       "source_location": "L210"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -45412,7 +45424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -45421,7 +45433,7 @@
       "source_location": "L51"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -45430,7 +45442,7 @@
       "source_location": "L26"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -45439,7 +45451,7 @@
       "source_location": "L290"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -45448,7 +45460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 189,
+      "community": 188,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -45457,7 +45469,7 @@
       "source_location": "L48"
     },
     {
-      "community": 189,
+      "community": 188,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -45466,7 +45478,7 @@
       "source_location": "L88"
     },
     {
-      "community": 189,
+      "community": 188,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -45475,13 +45487,49 @@
       "source_location": "L14"
     },
     {
-      "community": 189,
+      "community": 188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
       "norm_label": "analyticsview.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
+      "label": "StorefrontObservabilityPanel.tsx",
+      "norm_label": "storefrontobservabilitypanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_formatlabel",
+      "label": "formatLabel()",
+      "norm_label": "formatlabel()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
+      "label": "getTrafficSourceBadge()",
+      "norm_label": "gettrafficsourcebadge()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_summarycard",
+      "label": "SummaryCard()",
+      "norm_label": "summarycard()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L19"
     },
     {
       "community": 19,
@@ -45630,42 +45678,6 @@
     {
       "community": 190,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
-      "label": "StorefrontObservabilityPanel.tsx",
-      "norm_label": "storefrontobservabilitypanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_formatlabel",
-      "label": "formatLabel()",
-      "norm_label": "formatlabel()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
-      "label": "getTrafficSourceBadge()",
-      "norm_label": "gettrafficsourcebadge()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_summarycard",
-      "label": "SummaryCard()",
-      "norm_label": "summarycard()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
       "norm_label": "utils.ts",
@@ -45673,7 +45685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -45682,7 +45694,7 @@
       "source_location": "L52"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -45691,7 +45703,7 @@
       "source_location": "L3"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -45700,7 +45712,7 @@
       "source_location": "L90"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -45709,7 +45721,7 @@
       "source_location": "L86"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -45718,7 +45730,7 @@
       "source_location": "L76"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -45727,7 +45739,7 @@
       "source_location": "L52"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -45736,7 +45748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -45745,7 +45757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -45754,7 +45766,7 @@
       "source_location": "L67"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -45763,7 +45775,7 @@
       "source_location": "L90"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -45772,7 +45784,7 @@
       "source_location": "L73"
     },
     {
-      "community": 194,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -45781,7 +45793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 193,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -45790,7 +45802,7 @@
       "source_location": "L103"
     },
     {
-      "community": 194,
+      "community": 193,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -45799,7 +45811,7 @@
       "source_location": "L95"
     },
     {
-      "community": 194,
+      "community": 193,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -45808,7 +45820,7 @@
       "source_location": "L81"
     },
     {
-      "community": 195,
+      "community": 194,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -45817,7 +45829,7 @@
       "source_location": "L91"
     },
     {
-      "community": 195,
+      "community": 194,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -45826,7 +45838,7 @@
       "source_location": "L68"
     },
     {
-      "community": 195,
+      "community": 194,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -45835,7 +45847,7 @@
       "source_location": "L22"
     },
     {
-      "community": 195,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -45844,7 +45856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 195,
       "file_type": "code",
       "id": "ordersummary_handlecompletetransaction",
       "label": "handleCompleteTransaction()",
@@ -45853,7 +45865,7 @@
       "source_location": "L131"
     },
     {
-      "community": 196,
+      "community": 195,
       "file_type": "code",
       "id": "ordersummary_handleprintreceipt",
       "label": "handlePrintReceipt()",
@@ -45862,7 +45874,7 @@
       "source_location": "L154"
     },
     {
-      "community": 196,
+      "community": 195,
       "file_type": "code",
       "id": "ordersummary_handlestartnewtransaction",
       "label": "handleStartNewTransaction()",
@@ -45871,7 +45883,7 @@
       "source_location": "L148"
     },
     {
-      "community": 196,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -45880,7 +45892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -45889,7 +45901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 196,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -45898,7 +45910,7 @@
       "source_location": "L247"
     },
     {
-      "community": 197,
+      "community": 196,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -45907,7 +45919,7 @@
       "source_location": "L284"
     },
     {
-      "community": 197,
+      "community": 196,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -45916,7 +45928,7 @@
       "source_location": "L166"
     },
     {
-      "community": 198,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -45925,7 +45937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 198,
+      "community": 197,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -45934,7 +45946,7 @@
       "source_location": "L79"
     },
     {
-      "community": 198,
+      "community": 197,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -45943,7 +45955,7 @@
       "source_location": "L119"
     },
     {
-      "community": 198,
+      "community": 197,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -45952,7 +45964,7 @@
       "source_location": "L90"
     },
     {
-      "community": 199,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -45961,7 +45973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 199,
+      "community": 198,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -45970,7 +45982,7 @@
       "source_location": "L63"
     },
     {
-      "community": 199,
+      "community": 198,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -45979,13 +45991,49 @@
       "source_location": "L54"
     },
     {
-      "community": 199,
+      "community": 198,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
       "norm_label": "productstockstatus()",
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L11"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "complimentaryproductsview_body",
+      "label": "Body()",
+      "norm_label": "body()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "complimentaryproductsview_complimentaryproductsview",
+      "label": "ComplimentaryProductsView()",
+      "norm_label": "complimentaryproductsview()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "complimentaryproductsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
+      "label": "ComplimentaryProductsView.tsx",
+      "norm_label": "complimentaryproductsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 2,
@@ -46431,42 +46479,6 @@
     {
       "community": 200,
       "file_type": "code",
-      "id": "complimentaryproductsview_body",
-      "label": "Body()",
-      "norm_label": "body()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "complimentaryproductsview_complimentaryproductsview",
-      "label": "ComplimentaryProductsView()",
-      "norm_label": "complimentaryproductsview()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "complimentaryproductsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
-      "label": "ComplimentaryProductsView.tsx",
-      "norm_label": "complimentaryproductsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "label": "ServiceAppointmentsView.tsx",
       "norm_label": "serviceappointmentsview.tsx",
@@ -46474,7 +46486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 200,
       "file_type": "code",
       "id": "serviceappointmentsview_handlesubmit",
       "label": "handleSubmit()",
@@ -46483,7 +46495,7 @@
       "source_location": "L115"
     },
     {
-      "community": 201,
+      "community": 200,
       "file_type": "code",
       "id": "serviceappointmentsview_parsedatetimelocal",
       "label": "parseDateTimeLocal()",
@@ -46492,7 +46504,7 @@
       "source_location": "L77"
     },
     {
-      "community": 201,
+      "community": 200,
       "file_type": "code",
       "id": "serviceappointmentsview_withsavestate",
       "label": "withSaveState()",
@@ -46501,7 +46513,7 @@
       "source_location": "L441"
     },
     {
-      "community": 202,
+      "community": 201,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -46510,7 +46522,7 @@
       "source_location": "L75"
     },
     {
-      "community": 202,
+      "community": 201,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -46519,7 +46531,7 @@
       "source_location": "L82"
     },
     {
-      "community": 202,
+      "community": 201,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -46528,7 +46540,7 @@
       "source_location": "L93"
     },
     {
-      "community": 202,
+      "community": 201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -46537,7 +46549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -46546,7 +46558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -46555,7 +46567,7 @@
       "source_location": "L15"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -46564,7 +46576,7 @@
       "source_location": "L28"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -46573,7 +46585,7 @@
       "source_location": "L54"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -46582,7 +46594,7 @@
       "source_location": "L66"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -46591,7 +46603,7 @@
       "source_location": "L121"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -46600,7 +46612,7 @@
       "source_location": "L74"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -46609,7 +46621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -46618,7 +46630,7 @@
       "source_location": "L51"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -46627,7 +46639,7 @@
       "source_location": "L92"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -46636,7 +46648,7 @@
       "source_location": "L16"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -46645,7 +46657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -46654,7 +46666,7 @@
       "source_location": "L16"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -46663,7 +46675,7 @@
       "source_location": "L6"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -46672,7 +46684,7 @@
       "source_location": "L46"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -46681,7 +46693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -46690,7 +46702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 206,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -46699,7 +46711,7 @@
       "source_location": "L24"
     },
     {
-      "community": 207,
+      "community": 206,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -46708,7 +46720,7 @@
       "source_location": "L43"
     },
     {
-      "community": 207,
+      "community": 206,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -46717,7 +46729,7 @@
       "source_location": "L63"
     },
     {
-      "community": 208,
+      "community": 207,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -46726,7 +46738,7 @@
       "source_location": "L4"
     },
     {
-      "community": 208,
+      "community": 207,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -46735,7 +46747,7 @@
       "source_location": "L20"
     },
     {
-      "community": 208,
+      "community": 207,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -46744,7 +46756,7 @@
       "source_location": "L42"
     },
     {
-      "community": 208,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -46753,7 +46765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 209,
+      "community": 208,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -46762,7 +46774,7 @@
       "source_location": "L83"
     },
     {
-      "community": 209,
+      "community": 208,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -46771,7 +46783,7 @@
       "source_location": "L59"
     },
     {
-      "community": 209,
+      "community": 208,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -46780,12 +46792,48 @@
       "source_location": "L41"
     },
     {
-      "community": 209,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
       "norm_label": "_layout.tsx",
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 209,
+      "file_type": "code",
+      "id": "offers_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 209,
+      "file_type": "code",
+      "id": "offers_getuserredeemedoffers",
+      "label": "getUserRedeemedOffers()",
+      "norm_label": "getuserredeemedoffers()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 209,
+      "file_type": "code",
+      "id": "offers_submitoffer",
+      "label": "submitOffer()",
+      "norm_label": "submitoffer()",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 209,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1"
     },
     {
@@ -46926,42 +46974,6 @@
     {
       "community": 210,
       "file_type": "code",
-      "id": "offers_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "offers_getuserredeemedoffers",
-      "label": "getUserRedeemedOffers()",
-      "norm_label": "getuserredeemedoffers()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "offers_submitoffer",
-      "label": "submitOffer()",
-      "norm_label": "submitoffer()",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/storefront-webapp/src/api/offers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 211,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
       "norm_label": "stores.ts",
@@ -46969,7 +46981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -46978,7 +46990,7 @@
       "source_location": "L8"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -46987,7 +46999,7 @@
       "source_location": "L5"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -46996,7 +47008,7 @@
       "source_location": "L20"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -47005,7 +47017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -47014,7 +47026,7 @@
       "source_location": "L11"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -47023,7 +47035,7 @@
       "source_location": "L9"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -47032,7 +47044,7 @@
       "source_location": "L25"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -47041,7 +47053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -47050,7 +47062,7 @@
       "source_location": "L50"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -47059,7 +47071,7 @@
       "source_location": "L92"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -47068,7 +47080,7 @@
       "source_location": "L74"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -47077,7 +47089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -47086,7 +47098,7 @@
       "source_location": "L62"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -47095,7 +47107,7 @@
       "source_location": "L109"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -47104,7 +47116,7 @@
       "source_location": "L177"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -47113,7 +47125,7 @@
       "source_location": "L18"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -47122,7 +47134,7 @@
       "source_location": "L52"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -47131,7 +47143,7 @@
       "source_location": "L68"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -47140,7 +47152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -47149,7 +47161,7 @@
       "source_location": "L68"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -47158,7 +47170,7 @@
       "source_location": "L26"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -47167,7 +47179,7 @@
       "source_location": "L7"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -47176,7 +47188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -47185,7 +47197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -47194,7 +47206,7 @@
       "source_location": "L43"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -47203,7 +47215,7 @@
       "source_location": "L13"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -47212,7 +47224,7 @@
       "source_location": "L88"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -47221,7 +47233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -47230,7 +47242,7 @@
       "source_location": "L111"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -47239,13 +47251,49 @@
       "source_location": "L66"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
       "norm_label": "handlesuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L127"
+    },
+    {
+      "community": 218,
+      "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 218,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 218,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 218,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
     },
     {
       "community": 219,
@@ -48465,6 +48513,60 @@
     {
       "community": 246,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
+      "label": "public.ts",
+      "norm_label": "public.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/public.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "public_getworkflowtraceviewbyidwithctx",
+      "label": "getWorkflowTraceViewByIdWithCtx()",
+      "norm_label": "getworkflowtraceviewbyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/public.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "public_getworkflowtraceviewbylookupwithctx",
+      "label": "getWorkflowTraceViewByLookupWithCtx()",
+      "norm_label": "getworkflowtraceviewbylookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/public.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
+      "label": "queryUsage.test.ts",
+      "norm_label": "queryusage.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "queryusage_test_comparebyfields",
+      "label": "compareByFields()",
+      "norm_label": "comparebyfields()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "queryusage_test_createtestctx",
+      "label": "createTestCtx()",
+      "norm_label": "createtestctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
       "norm_label": "workflowtrace.ts",
@@ -48472,7 +48574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 248,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -48481,7 +48583,7 @@
       "source_location": "L35"
     },
     {
-      "community": 246,
+      "community": 248,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -48490,7 +48592,7 @@
       "source_location": "L25"
     },
     {
-      "community": 247,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -48499,7 +48601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 249,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -48508,67 +48610,13 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 249,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
       "norm_label": "view()",
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L4"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
-      "label": "ProductAvailability.tsx",
-      "norm_label": "productavailability.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "productavailability_productavailability",
-      "label": "ProductAvailability()",
-      "norm_label": "productavailability()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "productavailability_productavailabilityview",
-      "label": "ProductAvailabilityView()",
-      "norm_label": "productavailabilityview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
-      "label": "SheetProvider.tsx",
-      "norm_label": "sheetprovider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "sheetprovider_sheetprovider",
-      "label": "SheetProvider()",
-      "norm_label": "sheetprovider()",
-      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "sheetprovider_usesheet",
-      "label": "useSheet()",
-      "norm_label": "usesheet()",
-      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
-      "source_location": "L11"
     },
     {
       "community": 25,
@@ -48699,6 +48747,60 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
+      "label": "ProductAvailability.tsx",
+      "norm_label": "productavailability.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "productavailability_productavailability",
+      "label": "ProductAvailability()",
+      "norm_label": "productavailability()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "productavailability_productavailabilityview",
+      "label": "ProductAvailabilityView()",
+      "norm_label": "productavailabilityview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
+      "label": "SheetProvider.tsx",
+      "norm_label": "sheetprovider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "sheetprovider_sheetprovider",
+      "label": "SheetProvider()",
+      "norm_label": "sheetprovider()",
+      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "sheetprovider_usesheet",
+      "label": "useSheet()",
+      "norm_label": "usesheet()",
+      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
       "norm_label": "wigtype.tsx",
@@ -48706,7 +48808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 250,
+      "community": 252,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -48715,7 +48817,7 @@
       "source_location": "L21"
     },
     {
-      "community": 250,
+      "community": 252,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -48724,7 +48826,7 @@
       "source_location": "L8"
     },
     {
-      "community": 251,
+      "community": 253,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -48733,7 +48835,7 @@
       "source_location": "L21"
     },
     {
-      "community": 251,
+      "community": 253,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -48742,7 +48844,7 @@
       "source_location": "L13"
     },
     {
-      "community": 251,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -48751,7 +48853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 254,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -48760,7 +48862,7 @@
       "source_location": "L100"
     },
     {
-      "community": 252,
+      "community": 254,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -48769,7 +48871,7 @@
       "source_location": "L10"
     },
     {
-      "community": 252,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -48778,7 +48880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 255,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -48787,7 +48889,7 @@
       "source_location": "L100"
     },
     {
-      "community": 253,
+      "community": 255,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -48796,7 +48898,7 @@
       "source_location": "L10"
     },
     {
-      "community": 253,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -48805,7 +48907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 256,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -48814,7 +48916,7 @@
       "source_location": "L15"
     },
     {
-      "community": 254,
+      "community": 256,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -48823,7 +48925,7 @@
       "source_location": "L39"
     },
     {
-      "community": 254,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -48832,7 +48934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 257,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -48841,7 +48943,7 @@
       "source_location": "L43"
     },
     {
-      "community": 255,
+      "community": 257,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -48850,7 +48952,7 @@
       "source_location": "L51"
     },
     {
-      "community": 255,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -48859,7 +48961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 258,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -48868,7 +48970,7 @@
       "source_location": "L3"
     },
     {
-      "community": 256,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -48877,7 +48979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 258,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -48886,7 +48988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 259,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -48895,7 +48997,7 @@
       "source_location": "L53"
     },
     {
-      "community": 257,
+      "community": 259,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -48904,67 +49006,13 @@
       "source_location": "L65"
     },
     {
-      "community": 257,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
       "norm_label": "bestsellers.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "featuredsection_handlehighlighteditem",
-      "label": "handleHighlightedItem()",
-      "norm_label": "handlehighlighteditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "featuredsection_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
-      "label": "FeaturedSection.tsx",
-      "norm_label": "featuredsection.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
-      "label": "VideoPlayer.tsx",
-      "norm_label": "videoplayer.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
-      "label": "VideoPlayer.tsx",
-      "norm_label": "videoplayer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "videoplayer_videoplayer",
-      "label": "VideoPlayer()",
-      "norm_label": "videoplayer()",
-      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
-      "source_location": "L9"
     },
     {
       "community": 26,
@@ -49086,6 +49134,60 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "featuredsection_handlehighlighteditem",
+      "label": "handleHighlightedItem()",
+      "norm_label": "handlehighlighteditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "featuredsection_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
+      "label": "FeaturedSection.tsx",
+      "norm_label": "featuredsection.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
+      "label": "VideoPlayer.tsx",
+      "norm_label": "videoplayer.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
+      "label": "VideoPlayer.tsx",
+      "norm_label": "videoplayer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "videoplayer_videoplayer",
+      "label": "VideoPlayer()",
+      "norm_label": "videoplayer()",
+      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
       "id": "operationsqueueview_handledecideapprovalrequest",
       "label": "handleDecideApprovalRequest()",
       "norm_label": "handledecideapprovalrequest()",
@@ -49093,7 +49195,7 @@
       "source_location": "L289"
     },
     {
-      "community": 260,
+      "community": 262,
       "file_type": "code",
       "id": "operationsqueueview_handlesubmitstockbatch",
       "label": "handleSubmitStockBatch()",
@@ -49102,7 +49204,7 @@
       "source_location": "L279"
     },
     {
-      "community": 260,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -49111,7 +49213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -49120,7 +49222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 263,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -49129,7 +49231,7 @@
       "source_location": "L67"
     },
     {
-      "community": 261,
+      "community": 263,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -49138,7 +49240,7 @@
       "source_location": "L9"
     },
     {
-      "community": 262,
+      "community": 264,
       "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
@@ -49147,7 +49249,7 @@
       "source_location": "L100"
     },
     {
-      "community": 262,
+      "community": 264,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -49156,7 +49258,7 @@
       "source_location": "L95"
     },
     {
-      "community": 262,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -49165,7 +49267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 265,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -49174,7 +49276,7 @@
       "source_location": "L35"
     },
     {
-      "community": 263,
+      "community": 265,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -49183,7 +49285,7 @@
       "source_location": "L31"
     },
     {
-      "community": 263,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -49192,7 +49294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -49201,7 +49303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 266,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -49210,7 +49312,7 @@
       "source_location": "L20"
     },
     {
-      "community": 264,
+      "community": 266,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -49219,7 +49321,7 @@
       "source_location": "L26"
     },
     {
-      "community": 265,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -49228,7 +49330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 267,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -49237,7 +49339,7 @@
       "source_location": "L65"
     },
     {
-      "community": 265,
+      "community": 267,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -49246,7 +49348,7 @@
       "source_location": "L20"
     },
     {
-      "community": 266,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -49255,7 +49357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 268,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -49264,7 +49366,7 @@
       "source_location": "L16"
     },
     {
-      "community": 266,
+      "community": 268,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -49273,7 +49375,7 @@
       "source_location": "L60"
     },
     {
-      "community": 267,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -49282,7 +49384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 269,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -49291,67 +49393,13 @@
       "source_location": "L45"
     },
     {
-      "community": 267,
+      "community": 269,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
       "norm_label": "productactionstogglegroup()",
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L19"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "addcomplimentaryproduct_addcomplimentaryproduct",
-      "label": "AddComplimentaryProduct()",
-      "norm_label": "addcomplimentaryproduct()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
-      "source_location": "L128"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
-      "label": "handleAddComplimentaryProducts()",
-      "norm_label": "handleaddcomplimentaryproducts()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
-      "source_location": "L40"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
-      "label": "AddComplimentaryProduct.tsx",
-      "norm_label": "addcomplimentaryproduct.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "color_picker_handleblur",
-      "label": "handleBlur()",
-      "norm_label": "handleblur()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "color_picker_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
-      "label": "color-picker.tsx",
-      "norm_label": "color-picker.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
-      "source_location": "L1"
     },
     {
       "community": 27,
@@ -49473,6 +49521,60 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "addcomplimentaryproduct_addcomplimentaryproduct",
+      "label": "AddComplimentaryProduct()",
+      "norm_label": "addcomplimentaryproduct()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
+      "source_location": "L128"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
+      "label": "handleAddComplimentaryProducts()",
+      "norm_label": "handleaddcomplimentaryproducts()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
+      "label": "AddComplimentaryProduct.tsx",
+      "norm_label": "addcomplimentaryproduct.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
+      "id": "color_picker_handleblur",
+      "label": "handleBlur()",
+      "norm_label": "handleblur()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
+      "id": "color_picker_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
+      "label": "color-picker.tsx",
+      "norm_label": "color-picker.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 272,
+      "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
       "norm_label": "currencyprovider()",
@@ -49480,7 +49582,7 @@
       "source_location": "L25"
     },
     {
-      "community": 270,
+      "community": 272,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -49489,7 +49591,7 @@
       "source_location": "L17"
     },
     {
-      "community": 270,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -49498,7 +49600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -49507,7 +49609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 273,
       "file_type": "code",
       "id": "serviceintakeview_handlecreateintake",
       "label": "handleCreateIntake()",
@@ -49516,7 +49618,7 @@
       "source_location": "L238"
     },
     {
-      "community": 271,
+      "community": 273,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -49525,7 +49627,7 @@
       "source_location": "L69"
     },
     {
-      "community": 272,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -49534,7 +49636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 274,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -49543,7 +49645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 274,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -49552,7 +49654,7 @@
       "source_location": "L3"
     },
     {
-      "community": 273,
+      "community": 275,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -49561,7 +49663,7 @@
       "source_location": "L9"
     },
     {
-      "community": 273,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -49570,7 +49672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 275,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -49579,7 +49681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 276,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -49588,7 +49690,7 @@
       "source_location": "L3"
     },
     {
-      "community": 274,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -49597,7 +49699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 276,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -49606,7 +49708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 277,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -49615,7 +49717,7 @@
       "source_location": "L3"
     },
     {
-      "community": 275,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -49624,7 +49726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 277,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -49633,7 +49735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -49642,7 +49744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 278,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -49651,7 +49753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 278,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -49660,7 +49762,7 @@
       "source_location": "L3"
     },
     {
-      "community": 277,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -49669,7 +49771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 279,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -49678,67 +49780,13 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 279,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
       "norm_label": "transactionsskeleton()",
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "notfound_notfound",
-      "label": "NotFound()",
-      "norm_label": "notfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
-      "label": "NotFound.tsx",
-      "norm_label": "notfound.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFound.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 278,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
-      "label": "NotFound.tsx",
-      "norm_label": "notfound.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "feesview_handletoggleallfees",
-      "label": "handleToggleAllFees()",
-      "norm_label": "handletoggleallfees()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "feesview_handleupdatefees",
-      "label": "handleUpdateFees()",
-      "norm_label": "handleupdatefees()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
-      "source_location": "L36"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
-      "label": "FeesView.tsx",
-      "norm_label": "feesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 28,
@@ -49860,6 +49908,60 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "notfound_notfound",
+      "label": "NotFound()",
+      "norm_label": "notfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
+      "label": "NotFound.tsx",
+      "norm_label": "notfound.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFound.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
+      "label": "NotFound.tsx",
+      "norm_label": "notfound.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "feesview_handletoggleallfees",
+      "label": "handleToggleAllFees()",
+      "norm_label": "handletoggleallfees()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "feesview_handleupdatefees",
+      "label": "handleUpdateFees()",
+      "norm_label": "handleupdatefees()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
+      "label": "FeesView.tsx",
+      "norm_label": "feesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
       "norm_label": "appcontextmenu()",
@@ -49867,7 +49969,7 @@
       "source_location": "L20"
     },
     {
-      "community": 280,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -49876,7 +49978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 282,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -49885,7 +49987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 283,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -49894,7 +49996,7 @@
       "source_location": "L30"
     },
     {
-      "community": 281,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -49903,7 +50005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 283,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -49912,7 +50014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -49921,7 +50023,7 @@
       "source_location": "L9"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -49930,7 +50032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -49939,7 +50041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -49948,7 +50050,7 @@
       "source_location": "L38"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -49957,7 +50059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -49966,7 +50068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -49975,7 +50077,7 @@
       "source_location": "L20"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -49984,7 +50086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -49993,7 +50095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -50002,7 +50104,7 @@
       "source_location": "L12"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -50011,7 +50113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -50020,7 +50122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -50029,7 +50131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -50038,7 +50140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -50047,7 +50149,7 @@
       "source_location": "L3"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -50056,7 +50158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -50065,67 +50167,13 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
       "norm_label": "toaster()",
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
-      "label": "spinner.tsx",
-      "norm_label": "spinner.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/spinner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
-      "label": "spinner.tsx",
-      "norm_label": "spinner.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "spinner_spinner",
-      "label": "Spinner()",
-      "norm_label": "spinner()",
-      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "activitysummarycards_activitysummarycards",
-      "label": "ActivitySummaryCards()",
-      "norm_label": "activitysummarycards()",
-      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "activitysummarycards_summarycard",
-      "label": "SummaryCard()",
-      "norm_label": "summarycard()",
-      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
-      "label": "ActivitySummaryCards.tsx",
-      "norm_label": "activitysummarycards.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
-      "source_location": "L1"
     },
     {
       "community": 29,
@@ -50247,6 +50295,60 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
+      "label": "spinner.tsx",
+      "norm_label": "spinner.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/spinner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
+      "label": "spinner.tsx",
+      "norm_label": "spinner.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "spinner_spinner",
+      "label": "Spinner()",
+      "norm_label": "spinner()",
+      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "activitysummarycards_activitysummarycards",
+      "label": "ActivitySummaryCards()",
+      "norm_label": "activitysummarycards()",
+      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "activitysummarycards_summarycard",
+      "label": "SummaryCard()",
+      "norm_label": "summarycard()",
+      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
+      "label": "ActivitySummaryCards.tsx",
+      "norm_label": "activitysummarycards.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 292,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
       "norm_label": "timelineeventcard.tsx",
@@ -50254,7 +50356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 292,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -50263,7 +50365,7 @@
       "source_location": "L159"
     },
     {
-      "community": 290,
+      "community": 292,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -50272,7 +50374,7 @@
       "source_location": "L195"
     },
     {
-      "community": 291,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -50281,7 +50383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 293,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -50290,7 +50392,7 @@
       "source_location": "L22"
     },
     {
-      "community": 291,
+      "community": 293,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -50299,7 +50401,7 @@
       "source_location": "L45"
     },
     {
-      "community": 292,
+      "community": 294,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -50308,7 +50410,7 @@
       "source_location": "L24"
     },
     {
-      "community": 292,
+      "community": 294,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -50317,7 +50419,7 @@
       "source_location": "L38"
     },
     {
-      "community": 292,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -50326,7 +50428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -50335,7 +50437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -50344,7 +50446,7 @@
       "source_location": "L23"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -50353,7 +50455,7 @@
       "source_location": "L51"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -50362,7 +50464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -50371,7 +50473,7 @@
       "source_location": "L54"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -50380,7 +50482,7 @@
       "source_location": "L282"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -50389,7 +50491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -50398,7 +50500,7 @@
       "source_location": "L12"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -50407,7 +50509,7 @@
       "source_location": "L37"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -50416,7 +50518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -50425,7 +50527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -50434,7 +50536,7 @@
       "source_location": "L4"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -50443,7 +50545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -50452,67 +50554,13 @@
       "source_location": "L9"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
       "norm_label": "usegetstores()",
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L50"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
-      "label": "useGetOrganizations.ts",
-      "norm_label": "usegetorganizations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "usegetorganizations_usegetactiveorganization",
-      "label": "useGetActiveOrganization()",
-      "norm_label": "usegetactiveorganization()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "usegetorganizations_usegetorganizations",
-      "label": "useGetOrganizations()",
-      "norm_label": "usegetorganizations()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
-      "label": "useGetProducts.ts",
-      "norm_label": "usegetproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "usegetproducts_usegetproducts",
-      "label": "useGetProducts()",
-      "norm_label": "usegetproducts()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "usegetproducts_usegetunresolvedproducts",
-      "label": "useGetUnresolvedProducts()",
-      "norm_label": "usegetunresolvedproducts()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
-      "source_location": "L31"
     },
     {
       "community": 3,
@@ -50904,6 +50952,60 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
+      "label": "useGetOrganizations.ts",
+      "norm_label": "usegetorganizations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "usegetorganizations_usegetactiveorganization",
+      "label": "useGetActiveOrganization()",
+      "norm_label": "usegetactiveorganization()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "usegetorganizations_usegetorganizations",
+      "label": "useGetOrganizations()",
+      "norm_label": "usegetorganizations()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
+      "label": "useGetProducts.ts",
+      "norm_label": "usegetproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "usegetproducts_usegetproducts",
+      "label": "useGetProducts()",
+      "norm_label": "usegetproducts()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "usegetproducts_usegetunresolvedproducts",
+      "label": "useGetUnresolvedProducts()",
+      "norm_label": "usegetunresolvedproducts()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
       "norm_label": "isinmaintenancemode()",
@@ -50911,7 +51013,7 @@
       "source_location": "L7"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -50920,7 +51022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -50929,7 +51031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -50938,7 +51040,7 @@
       "source_location": "L3"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -50947,7 +51049,7 @@
       "source_location": "L10"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -50956,7 +51058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -50965,7 +51067,7 @@
       "source_location": "L16"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -50974,7 +51076,7 @@
       "source_location": "L53"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -50983,7 +51085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -50992,7 +51094,7 @@
       "source_location": "L31"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -51001,7 +51103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -51010,7 +51112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -51019,7 +51121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -51028,7 +51130,7 @@
       "source_location": "L28"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -51037,7 +51139,7 @@
       "source_location": "L46"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -51046,7 +51148,7 @@
       "source_location": "L18"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -51055,7 +51157,7 @@
       "source_location": "L38"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -51064,7 +51166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -51073,7 +51175,7 @@
       "source_location": "L127"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -51082,7 +51184,7 @@
       "source_location": "L106"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -51091,7 +51193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -51100,7 +51202,7 @@
       "source_location": "L66"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -51109,67 +51211,13 @@
       "source_location": "L20"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
       "norm_label": "inventoryvalidationlogic.test.ts",
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "index_hashpassword",
-      "label": "hashPassword()",
-      "norm_label": "hashpassword()",
-      "source_file": "packages/storefront-webapp/src/utils/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_utils_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/utils/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_utils_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/storefront-webapp/src/utils/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "versionchecker_createversionchecker",
-      "label": "createVersionChecker()",
-      "norm_label": "createversionchecker()",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L16"
     },
     {
       "community": 31,
@@ -51273,6 +51321,60 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "index_hashpassword",
+      "label": "hashPassword()",
+      "norm_label": "hashpassword()",
+      "source_file": "packages/storefront-webapp/src/utils/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_utils_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/utils/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_utils_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/storefront-webapp/src/utils/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "versionchecker_createversionchecker",
+      "label": "createVersionChecker()",
+      "norm_label": "createversionchecker()",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
       "norm_label": "vite.config.ts",
@@ -51280,7 +51382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -51289,7 +51391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -51298,7 +51400,7 @@
       "source_location": "L19"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -51307,7 +51409,7 @@
       "source_location": "L32"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -51316,7 +51418,7 @@
       "source_location": "L3"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -51325,7 +51427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -51334,7 +51436,7 @@
       "source_location": "L7"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -51343,7 +51445,7 @@
       "source_location": "L5"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -51352,7 +51454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -51361,7 +51463,7 @@
       "source_location": "L6"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -51370,7 +51472,7 @@
       "source_location": "L18"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -51379,7 +51481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -51388,7 +51490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -51397,7 +51499,7 @@
       "source_location": "L3"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -51406,7 +51508,7 @@
       "source_location": "L5"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -51415,7 +51517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -51424,7 +51526,7 @@
       "source_location": "L18"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -51433,7 +51535,7 @@
       "source_location": "L23"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -51442,7 +51544,7 @@
       "source_location": "L22"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -51451,7 +51553,7 @@
       "source_location": "L55"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -51460,7 +51562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -51469,7 +51571,7 @@
       "source_location": "L77"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -51478,66 +51580,12 @@
       "source_location": "L11"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
       "norm_label": "deliveryoptionsselector.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "deliverysection_deliverydetails",
-      "label": "DeliveryDetails()",
-      "norm_label": "deliverydetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "deliverysection_deliveryoptions",
-      "label": "DeliveryOptions()",
-      "norm_label": "deliveryoptions()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
-      "label": "DeliverySection.tsx",
-      "norm_label": "deliverysection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "mobilebagsummary_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "mobilebagsummary_handleredeempromocode",
-      "label": "handleRedeemPromoCode()",
-      "norm_label": "handleredeempromocode()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
-      "label": "MobileBagSummary.tsx",
-      "norm_label": "mobilebagsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L1"
     },
     {
@@ -51642,6 +51690,60 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "deliverysection_deliverydetails",
+      "label": "DeliveryDetails()",
+      "norm_label": "deliverydetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "deliverysection_deliveryoptions",
+      "label": "DeliveryOptions()",
+      "norm_label": "deliveryoptions()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
+      "label": "DeliverySection.tsx",
+      "norm_label": "deliverysection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "mobilebagsummary_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "mobilebagsummary_handleredeempromocode",
+      "label": "handleRedeemPromoCode()",
+      "norm_label": "handleredeempromocode()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
+      "label": "MobileBagSummary.tsx",
+      "norm_label": "mobilebagsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
       "norm_label": "loadcheckoutstate()",
@@ -51649,7 +51751,7 @@
       "source_location": "L4"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -51658,7 +51760,7 @@
       "source_location": "L24"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -51667,7 +51769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -51676,7 +51778,7 @@
       "source_location": "L131"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -51685,7 +51787,7 @@
       "source_location": "L12"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -51694,7 +51796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -51703,7 +51805,7 @@
       "source_location": "L20"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -51712,7 +51814,7 @@
       "source_location": "L46"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -51721,7 +51823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -51730,7 +51832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -51739,7 +51841,7 @@
       "source_location": "L20"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -51748,7 +51850,7 @@
       "source_location": "L59"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -51757,7 +51859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -51766,7 +51868,7 @@
       "source_location": "L25"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -51775,7 +51877,7 @@
       "source_location": "L20"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -51784,7 +51886,7 @@
       "source_location": "L30"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -51793,7 +51895,7 @@
       "source_location": "L95"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -51802,7 +51904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -51811,7 +51913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -51820,7 +51922,7 @@
       "source_location": "L61"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -51829,7 +51931,7 @@
       "source_location": "L65"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -51838,7 +51940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -51847,67 +51949,13 @@
       "source_location": "L150"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
       "norm_label": "handlesubmit()",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L157"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
-      "label": "UpsellModalForm.tsx",
-      "norm_label": "upsellmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "upsellmodalform_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "upsellmodalform_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
-      "label": "WelcomeBackModal.tsx",
-      "norm_label": "welcomebackmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "welcomebackmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "welcomebackmodal_handlesuccess",
-      "label": "handleSuccess()",
-      "norm_label": "handlesuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L76"
     },
     {
       "community": 33,
@@ -52011,6 +52059,60 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
+      "label": "UpsellModalForm.tsx",
+      "norm_label": "upsellmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "upsellmodalform_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "upsellmodalform_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
+      "label": "WelcomeBackModal.tsx",
+      "norm_label": "welcomebackmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "welcomebackmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "welcomebackmodal_handlesuccess",
+      "label": "handleSuccess()",
+      "norm_label": "handlesuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
       "norm_label": "welcomebackmodalform.tsx",
@@ -52018,7 +52120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 332,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -52027,7 +52129,7 @@
       "source_location": "L51"
     },
     {
-      "community": 330,
+      "community": 332,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -52036,7 +52138,7 @@
       "source_location": "L36"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -52045,7 +52147,7 @@
       "source_location": "L16"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -52054,7 +52156,7 @@
       "source_location": "L39"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -52063,7 +52165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -52072,7 +52174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -52081,7 +52183,7 @@
       "source_location": "L25"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -52090,7 +52192,7 @@
       "source_location": "L82"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -52099,7 +52201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -52108,7 +52210,7 @@
       "source_location": "L20"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -52117,7 +52219,7 @@
       "source_location": "L55"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -52126,7 +52228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -52135,7 +52237,7 @@
       "source_location": "L107"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -52144,7 +52246,7 @@
       "source_location": "L25"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -52153,7 +52255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -52162,7 +52264,7 @@
       "source_location": "L556"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -52171,7 +52273,7 @@
       "source_location": "L52"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -52180,7 +52282,7 @@
       "source_location": "L429"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -52189,7 +52291,7 @@
       "source_location": "L102"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -52198,7 +52300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -52207,7 +52309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -52216,67 +52318,13 @@
       "source_location": "L250"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
       "norm_label": "ordernavigation()",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L46"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "account_accountbeforeload",
-      "label": "accountBeforeLoad()",
-      "norm_label": "accountbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "account_handleonsubmitform",
-      "label": "handleOnSubmitForm()",
-      "norm_label": "handleonsubmitform()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
-      "label": "account.tsx",
-      "norm_label": "account.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "login_loginbeforeload",
-      "label": "loginBeforeLoad()",
-      "norm_label": "loginbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "login_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "label": "login.tsx",
-      "norm_label": "login.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L1"
     },
     {
       "community": 34,
@@ -52380,6 +52428,60 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "account_accountbeforeload",
+      "label": "accountBeforeLoad()",
+      "norm_label": "accountbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "account_handleonsubmitform",
+      "label": "handleOnSubmitForm()",
+      "norm_label": "handleonsubmitform()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
+      "label": "account.tsx",
+      "norm_label": "account.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "login_loginbeforeload",
+      "label": "loginBeforeLoad()",
+      "norm_label": "loginbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "login_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_login_tsx",
+      "label": "login.tsx",
+      "norm_label": "login.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
       "norm_label": "verify.index.tsx",
@@ -52387,7 +52489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 340,
+      "community": 342,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -52396,7 +52498,7 @@
       "source_location": "L21"
     },
     {
-      "community": 340,
+      "community": 342,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -52405,7 +52507,7 @@
       "source_location": "L107"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -52414,7 +52516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -52423,7 +52525,7 @@
       "source_location": "L161"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -52432,7 +52534,7 @@
       "source_location": "L66"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -52441,7 +52543,7 @@
       "source_location": "L11"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -52450,7 +52552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -52459,7 +52561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -52468,7 +52570,7 @@
       "source_location": "L16"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -52477,7 +52579,7 @@
       "source_location": "L10"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -52486,7 +52588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -52495,7 +52597,7 @@
       "source_location": "L17"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -52504,7 +52606,7 @@
       "source_location": "L11"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -52513,7 +52615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -52522,7 +52624,7 @@
       "source_location": "L21"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -52531,7 +52633,7 @@
       "source_location": "L15"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -52540,7 +52642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -52549,7 +52651,7 @@
       "source_location": "L48"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -52558,7 +52660,7 @@
       "source_location": "L42"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -52567,7 +52669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -52576,7 +52678,7 @@
       "source_location": "L16"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -52585,66 +52687,12 @@
       "source_location": "L10"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
       "norm_label": "harness-generate.test.ts",
       "source_file": "scripts/harness-generate.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "harness_inferential_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "harness_inferential_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "scripts_harness_inferential_review_test_ts",
-      "label": "harness-inferential-review.test.ts",
-      "norm_label": "harness-inferential-review.test.ts",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "harness_self_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "harness_self_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "scripts_harness_self_review_test_ts",
-      "label": "harness-self-review.test.ts",
-      "norm_label": "harness-self-review.test.ts",
-      "source_file": "scripts/harness-self-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -52749,6 +52797,60 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "harness_inferential_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "harness_inferential_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "scripts_harness_inferential_review_test_ts",
+      "label": "harness-inferential-review.test.ts",
+      "norm_label": "harness-inferential-review.test.ts",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "harness_self_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "harness_self_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "scripts_harness_self_review_test_ts",
+      "label": "harness-self-review.test.ts",
+      "norm_label": "harness-self-review.test.ts",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -52756,7 +52858,7 @@
       "source_location": "L20"
     },
     {
-      "community": 350,
+      "community": 352,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -52765,7 +52867,7 @@
       "source_location": "L14"
     },
     {
-      "community": 350,
+      "community": 352,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
@@ -52774,7 +52876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -52783,7 +52885,7 @@
       "source_location": "L26"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -52792,7 +52894,7 @@
       "source_location": "L18"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -52801,7 +52903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
       "label": "runPreCommitGeneratedArtifacts()",
@@ -52810,7 +52912,7 @@
       "source_location": "L45"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
       "label": "stageTrackedGraphifyArtifacts()",
@@ -52819,7 +52921,7 @@
       "source_location": "L20"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_ts",
       "label": "pre-commit-generated-artifacts.ts",
@@ -52828,7 +52930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -52837,7 +52939,7 @@
       "source_location": "L8"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -52846,7 +52948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -52855,7 +52957,7 @@
       "source_location": "L9"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -52864,7 +52966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -52873,7 +52975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -52882,7 +52984,7 @@
       "source_location": "L12"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -52891,7 +52993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -52900,7 +53002,7 @@
       "source_location": "L8"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -52909,48 +53011,12 @@
       "source_location": "L10"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
       "norm_label": "convexauditscript.test.ts",
       "source_file": "packages/athena-webapp/convex/convexAuditScript.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
-      "label": "VerificationCode.tsx",
-      "norm_label": "verificationcode.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "verificationcode_verificationcode",
-      "label": "VerificationCode()",
-      "norm_label": "verificationcode()",
-      "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "mtnmomo_handlecollectionnotification",
-      "label": "handleCollectionNotification()",
-      "norm_label": "handlecollectionnotification()",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
-      "label": "mtnMomo.ts",
-      "norm_label": "mtnmomo.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
       "source_location": "L1"
     },
     {
@@ -53046,6 +53112,42 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
+      "label": "VerificationCode.tsx",
+      "norm_label": "verificationcode.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "verificationcode_verificationcode",
+      "label": "VerificationCode()",
+      "norm_label": "verificationcode()",
+      "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "mtnmomo_handlecollectionnotification",
+      "label": "handleCollectionNotification()",
+      "norm_label": "handlecollectionnotification()",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
+      "label": "mtnMomo.ts",
+      "norm_label": "mtnmomo.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
       "norm_label": "routercomposition.test.ts",
@@ -53053,7 +53155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 362,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -53062,7 +53164,7 @@
       "source_location": "L6"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "cashier_authenticatehandler",
       "label": "authenticateHandler()",
@@ -53071,7 +53173,7 @@
       "source_location": "L239"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -53080,7 +53182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -53089,7 +53191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -53098,7 +53200,7 @@
       "source_location": "L8"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -53107,7 +53209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -53116,7 +53218,7 @@
       "source_location": "L6"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -53125,7 +53227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -53134,7 +53236,7 @@
       "source_location": "L27"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -53143,7 +53245,7 @@
       "source_location": "L4"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -53152,7 +53254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 368,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -53161,7 +53263,7 @@
       "source_location": "L3"
     },
     {
-      "community": 366,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -53170,7 +53272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 369,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -53179,48 +53281,12 @@
       "source_location": "L3"
     },
     {
-      "community": 367,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
       "norm_label": "openai.ts",
       "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "foundation_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
-      "label": "foundation.test.ts",
-      "norm_label": "foundation.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "approvalrequesthelpers_buildapprovalrequest",
-      "label": "buildApprovalRequest()",
-      "norm_label": "buildapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
-      "label": "approvalRequestHelpers.ts",
-      "norm_label": "approvalrequesthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
       "source_location": "L1"
     },
     {
@@ -53316,6 +53382,42 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "foundation_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
+      "label": "foundation.test.ts",
+      "norm_label": "foundation.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "approvalrequesthelpers_buildapprovalrequest",
+      "label": "buildApprovalRequest()",
+      "norm_label": "buildapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
+      "label": "approvalRequestHelpers.ts",
+      "norm_label": "approvalrequesthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
       "norm_label": "createapprovalrequestmutationctx()",
@@ -53323,7 +53425,7 @@
       "source_location": "L18"
     },
     {
-      "community": 370,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -53332,7 +53434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 373,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -53341,7 +53443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -53350,7 +53452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
@@ -53359,7 +53461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 374,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -53368,7 +53470,7 @@
       "source_location": "L7"
     },
     {
-      "community": 373,
+      "community": 375,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -53377,7 +53479,7 @@
       "source_location": "L9"
     },
     {
-      "community": 373,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -53386,7 +53488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 376,
       "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
@@ -53395,7 +53497,7 @@
       "source_location": "L31"
     },
     {
-      "community": 374,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
@@ -53404,7 +53506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 377,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -53413,7 +53515,7 @@
       "source_location": "L6"
     },
     {
-      "community": 375,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -53422,7 +53524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -53431,7 +53533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 378,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -53440,7 +53542,7 @@
       "source_location": "L88"
     },
     {
-      "community": 377,
+      "community": 379,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -53449,48 +53551,12 @@
       "source_location": "L8"
     },
     {
-      "community": 377,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
       "norm_label": "catalog.ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "modulewiring_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
-      "label": "moduleWiring.test.ts",
-      "norm_label": "modulewiring.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "access_test_createstockopsaccessqueryctx",
-      "label": "createStockOpsAccessQueryCtx()",
-      "norm_label": "createstockopsaccessqueryctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_access_test_ts",
-      "label": "access.test.ts",
-      "norm_label": "access.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
       "source_location": "L1"
     },
     {
@@ -53586,6 +53652,42 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "modulewiring_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
+      "label": "moduleWiring.test.ts",
+      "norm_label": "modulewiring.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "access_test_createstockopsaccessqueryctx",
+      "label": "createStockOpsAccessQueryCtx()",
+      "norm_label": "createstockopsaccessqueryctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_access_test_ts",
+      "label": "access.test.ts",
+      "norm_label": "access.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
       "norm_label": "requirestorefulladminaccess()",
@@ -53593,7 +53695,7 @@
       "source_location": "L6"
     },
     {
-      "community": 380,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -53602,7 +53704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -53611,7 +53713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 383,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -53620,7 +53722,7 @@
       "source_location": "L8"
     },
     {
-      "community": 382,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -53629,7 +53731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 384,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -53638,7 +53740,7 @@
       "source_location": "L13"
     },
     {
-      "community": 383,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -53647,7 +53749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 385,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -53656,7 +53758,7 @@
       "source_location": "L5"
     },
     {
-      "community": 384,
+      "community": 386,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -53665,7 +53767,7 @@
       "source_location": "L15"
     },
     {
-      "community": 384,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -53674,7 +53776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 387,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -53683,7 +53785,7 @@
       "source_location": "L8"
     },
     {
-      "community": 385,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -53692,7 +53794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 388,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -53701,7 +53803,7 @@
       "source_location": "L17"
     },
     {
-      "community": 386,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -53710,7 +53812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 389,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -53719,48 +53821,12 @@
       "source_location": "L6"
     },
     {
-      "community": 387,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
       "norm_label": "helperorchestration.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "customerengagementevents_test_createmutationctx",
-      "label": "createMutationCtx()",
-      "norm_label": "createmutationctx()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
-      "label": "customerEngagementEvents.test.ts",
-      "norm_label": "customerengagementevents.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "onlineorderitem_updateonlineorderitem",
-      "label": "updateOnlineOrderItem()",
-      "norm_label": "updateonlineorderitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
-      "label": "onlineOrderItem.ts",
-      "norm_label": "onlineorderitem.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L1"
     },
     {
@@ -53856,6 +53922,42 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "customerengagementevents_test_createmutationctx",
+      "label": "createMutationCtx()",
+      "norm_label": "createmutationctx()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
+      "label": "customerEngagementEvents.test.ts",
+      "norm_label": "customerengagementevents.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "onlineorderitem_updateonlineorderitem",
+      "label": "updateOnlineOrderItem()",
+      "norm_label": "updateonlineorderitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
+      "label": "onlineOrderItem.ts",
+      "norm_label": "onlineorderitem.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 392,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
       "norm_label": "reviews.ts",
@@ -53863,7 +53965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 392,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -53872,7 +53974,7 @@
       "source_location": "L17"
     },
     {
-      "community": 391,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -53881,7 +53983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 393,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -53890,7 +53992,7 @@
       "source_location": "L7"
     },
     {
-      "community": 392,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -53899,7 +54001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 394,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -53908,7 +54010,7 @@
       "source_location": "L14"
     },
     {
-      "community": 393,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -53917,7 +54019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 395,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -53926,7 +54028,7 @@
       "source_location": "L8"
     },
     {
-      "community": 394,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -53935,7 +54037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 396,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -53944,7 +54046,7 @@
       "source_location": "L3"
     },
     {
-      "community": 395,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -53953,7 +54055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 397,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -53962,7 +54064,7 @@
       "source_location": "L5"
     },
     {
-      "community": 396,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -53971,7 +54073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 398,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -53980,7 +54082,7 @@
       "source_location": "L16"
     },
     {
-      "community": 397,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -53989,49 +54091,13 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 399,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
       "norm_label": "determineoffereligibility()",
       "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
       "source_location": "L30"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
-      "label": "presentation.ts",
-      "norm_label": "presentation.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "presentation_buildworkflowtraceviewmodel",
-      "label": "buildWorkflowTraceViewModel()",
-      "norm_label": "buildworkflowtraceviewmodel()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
-      "label": "queryUsage.test.ts",
-      "norm_label": "queryusage.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "queryusage_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L4"
     },
     {
       "community": 4,
@@ -54378,6 +54444,24 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
+      "label": "presentation.ts",
+      "norm_label": "presentation.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "presentation_buildworkflowtraceviewmodel",
+      "label": "buildWorkflowTraceViewModel()",
+      "norm_label": "buildworkflowtraceviewmodel()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
       "norm_label": "schemaindexes.test.ts",
@@ -54385,7 +54469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -54394,7 +54478,7 @@
       "source_location": "L5"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -54403,7 +54487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -54412,7 +54496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -54421,7 +54505,7 @@
       "source_location": "L7"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -54430,7 +54514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -54439,7 +54523,7 @@
       "source_location": "L12"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -54448,7 +54532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -54457,7 +54541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -54466,7 +54550,7 @@
       "source_location": "L11"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -54475,7 +54559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -54484,7 +54568,7 @@
       "source_location": "L11"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -54493,7 +54577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -54502,7 +54586,7 @@
       "source_location": "L3"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -54511,7 +54595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -54520,7 +54604,7 @@
       "source_location": "L12"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -54529,31 +54613,13 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
       "norm_label": "storedropdown()",
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L42"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeview_tsx",
-      "label": "StoreView.tsx",
-      "norm_label": "storeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "storeview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L13"
     },
     {
       "community": 41,
@@ -54648,6 +54714,24 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeview_tsx",
+      "label": "StoreView.tsx",
+      "norm_label": "storeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "storeview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
       "norm_label": "storesdropdown.tsx",
@@ -54655,7 +54739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -54664,7 +54748,7 @@
       "source_location": "L42"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -54673,7 +54757,7 @@
       "source_location": "L31"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -54682,7 +54766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -54691,7 +54775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -54700,7 +54784,7 @@
       "source_location": "L10"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -54709,7 +54793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -54718,7 +54802,7 @@
       "source_location": "L14"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -54727,7 +54811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -54736,7 +54820,7 @@
       "source_location": "L5"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -54745,7 +54829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -54754,7 +54838,7 @@
       "source_location": "L10"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -54763,7 +54847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -54772,7 +54856,7 @@
       "source_location": "L15"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -54781,7 +54865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -54790,7 +54874,7 @@
       "source_location": "L13"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -54799,31 +54883,13 @@
       "source_location": "L116"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
       "norm_label": "copyimagesview.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
-      "label": "product-variant-columns.tsx",
-      "norm_label": "product-variant-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "product_variant_columns_setsourcevariant",
-      "label": "setSourceVariant()",
-      "norm_label": "setsourcevariant()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L47"
     },
     {
       "community": 42,
@@ -54918,6 +54984,24 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
+      "label": "product-variant-columns.tsx",
+      "norm_label": "product-variant-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "product_variant_columns_setsourcevariant",
+      "label": "setSourceVariant()",
+      "norm_label": "setsourcevariant()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
       "norm_label": "capitalizefirstletter()",
@@ -54925,7 +55009,7 @@
       "source_location": "L151"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -54934,7 +55018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -54943,7 +55027,7 @@
       "source_location": "L6"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -54952,7 +55036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -54961,7 +55045,7 @@
       "source_location": "L19"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -54970,7 +55054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -54979,7 +55063,7 @@
       "source_location": "L7"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -54988,7 +55072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -54997,7 +55081,7 @@
       "source_location": "L42"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -55006,7 +55090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -55015,7 +55099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -55024,7 +55108,7 @@
       "source_location": "L66"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -55033,7 +55117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -55042,7 +55126,7 @@
       "source_location": "L18"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -55051,7 +55135,7 @@
       "source_location": "L6"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -55060,7 +55144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -55069,30 +55153,12 @@
       "source_location": "L10"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
       "norm_label": "logview.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "logsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
-      "label": "LogsView.tsx",
-      "norm_label": "logsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L1"
     },
     {
@@ -55188,6 +55254,24 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "logsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
+      "label": "LogsView.tsx",
+      "norm_label": "logsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
       "norm_label": "useloadlogitems.ts",
@@ -55195,7 +55279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -55204,7 +55288,7 @@
       "source_location": "L12"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -55213,7 +55297,7 @@
       "source_location": "L3"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -55222,7 +55306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -55231,7 +55315,7 @@
       "source_location": "L5"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -55240,7 +55324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -55249,7 +55333,7 @@
       "source_location": "L49"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -55258,7 +55342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -55267,7 +55351,7 @@
       "source_location": "L23"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -55276,7 +55360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -55285,7 +55369,7 @@
       "source_location": "L50"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -55294,7 +55378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -55303,7 +55387,7 @@
       "source_location": "L13"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -55312,7 +55396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -55321,7 +55405,7 @@
       "source_location": "L11"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -55330,7 +55414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -55339,31 +55423,13 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
       "norm_label": "pageheader()",
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
       "source_location": "L7"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "expensecompletion_expensecompletion",
-      "label": "ExpenseCompletion()",
-      "norm_label": "expensecompletion()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L32"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
-      "label": "ExpenseCompletion.tsx",
-      "norm_label": "expensecompletion.tsx",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L1"
     },
     {
       "community": 44,
@@ -55458,6 +55524,24 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "expensecompletion_expensecompletion",
+      "label": "ExpenseCompletion()",
+      "norm_label": "expensecompletion()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
+      "source_location": "L32"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
+      "label": "ExpenseCompletion.tsx",
+      "norm_label": "expensecompletion.tsx",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
       "norm_label": "handleaddbestseller()",
@@ -55465,7 +55549,7 @@
       "source_location": "L29"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -55474,7 +55558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -55483,7 +55567,7 @@
       "source_location": "L37"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -55492,7 +55576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -55501,7 +55585,7 @@
       "source_location": "L25"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -55510,7 +55594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -55519,7 +55603,7 @@
       "source_location": "L83"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -55528,7 +55612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -55537,7 +55621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -55546,7 +55630,7 @@
       "source_location": "L35"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -55555,7 +55639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -55564,7 +55648,7 @@
       "source_location": "L28"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -55573,7 +55657,7 @@
       "source_location": "L11"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -55582,7 +55666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -55591,7 +55675,7 @@
       "source_location": "L13"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -55600,7 +55684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -55609,30 +55693,12 @@
       "source_location": "L41"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
       "norm_label": "emailstatusview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "ordermetricspanel_handletimerangechange",
-      "label": "handleTimeRangeChange()",
-      "norm_label": "handletimerangechange()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
-      "label": "OrderMetricsPanel.tsx",
-      "norm_label": "ordermetricspanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L1"
     },
     {
@@ -55728,6 +55794,24 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "ordermetricspanel_handletimerangechange",
+      "label": "handleTimeRangeChange()",
+      "norm_label": "handletimerangechange()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
+      "label": "OrderMetricsPanel.tsx",
+      "norm_label": "ordermetricspanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
       "norm_label": "handlerefundorder()",
@@ -55735,7 +55819,7 @@
       "source_location": "L68"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -55744,7 +55828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -55753,7 +55837,7 @@
       "source_location": "L35"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -55762,7 +55846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -55771,7 +55855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -55780,7 +55864,7 @@
       "source_location": "L79"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -55789,7 +55873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -55798,7 +55882,7 @@
       "source_location": "L6"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -55807,7 +55891,7 @@
       "source_location": "L34"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -55816,7 +55900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -55825,7 +55909,7 @@
       "source_location": "L89"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -55834,7 +55918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "cashierview_cashierview",
       "label": "CashierView()",
@@ -55843,7 +55927,7 @@
       "source_location": "L8"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -55852,7 +55936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -55861,7 +55945,7 @@
       "source_location": "L5"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -55870,7 +55954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -55879,31 +55963,13 @@
       "source_location": "L7"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
       "norm_label": "noresultsmessage.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
-      "label": "PinInput.tsx",
-      "norm_label": "pininput.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "pininput_pininput",
-      "label": "PinInput()",
-      "norm_label": "pininput()",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L13"
     },
     {
       "community": 46,
@@ -55998,6 +56064,24 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
+      "label": "PinInput.tsx",
+      "norm_label": "pininput.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "pininput_pininput",
+      "label": "PinInput()",
+      "norm_label": "pininput()",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
       "norm_label": "pointofsaleview.tsx",
@@ -56005,7 +56089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
@@ -56014,7 +56098,7 @@
       "source_location": "L35"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -56023,7 +56107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -56032,7 +56116,7 @@
       "source_location": "L3"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -56041,7 +56125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -56050,7 +56134,7 @@
       "source_location": "L14"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -56059,7 +56143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -56068,7 +56152,7 @@
       "source_location": "L86"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -56077,7 +56161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -56086,7 +56170,7 @@
       "source_location": "L15"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -56095,7 +56179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "totalsdisplay_totalsdisplay",
       "label": "TotalsDisplay()",
@@ -56104,7 +56188,7 @@
       "source_location": "L14"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -56113,7 +56197,7 @@
       "source_location": "L18"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -56122,7 +56206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -56131,7 +56215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -56140,7 +56224,7 @@
       "source_location": "L8"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -56149,31 +56233,13 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
       "norm_label": "registersessionpanel()",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
       "source_location": "L8"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
-      "label": "transactionColumns.tsx",
-      "norm_label": "transactioncolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "transactioncolumns_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L22"
     },
     {
       "community": 47,
@@ -56268,6 +56334,24 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
+      "label": "transactionColumns.tsx",
+      "norm_label": "transactioncolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "transactioncolumns_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
       "norm_label": "barcodeview()",
@@ -56275,7 +56359,7 @@
       "source_location": "L14"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -56284,7 +56368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -56293,7 +56377,7 @@
       "source_location": "L6"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -56302,7 +56386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -56311,7 +56395,7 @@
       "source_location": "L38"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -56320,7 +56404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -56329,7 +56413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -56338,7 +56422,7 @@
       "source_location": "L10"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -56347,7 +56431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -56356,7 +56440,7 @@
       "source_location": "L6"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -56365,7 +56449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -56374,7 +56458,7 @@
       "source_location": "L5"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -56383,7 +56467,7 @@
       "source_location": "L17"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -56392,7 +56476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -56401,7 +56485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -56410,7 +56494,7 @@
       "source_location": "L4"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -56419,31 +56503,13 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
       "norm_label": "togglediscounttype()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L84"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
-      "label": "PromoCodeHeader.tsx",
-      "norm_label": "promocodeheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "promocodeheader_handledeletepromocode",
-      "label": "handleDeletePromoCode()",
-      "norm_label": "handledeletepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L22"
     },
     {
       "community": 48,
@@ -56538,6 +56604,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
+      "label": "PromoCodeHeader.tsx",
+      "norm_label": "promocodeheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "promocodeheader_handledeletepromocode",
+      "label": "handleDeletePromoCode()",
+      "norm_label": "handledeletepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
       "norm_label": "promocodesview.tsx",
@@ -56545,7 +56629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -56554,7 +56638,7 @@
       "source_location": "L9"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -56563,7 +56647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -56572,7 +56656,7 @@
       "source_location": "L23"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -56581,7 +56665,7 @@
       "source_location": "L5"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -56590,7 +56674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -56599,7 +56683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -56608,7 +56692,7 @@
       "source_location": "L4"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -56617,7 +56701,7 @@
       "source_location": "L13"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -56626,7 +56710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -56635,7 +56719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -56644,7 +56728,7 @@
       "source_location": "L29"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -56653,7 +56737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -56662,7 +56746,7 @@
       "source_location": "L20"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -56671,7 +56755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -56680,7 +56764,7 @@
       "source_location": "L171"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -56689,31 +56773,13 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
       "norm_label": "serviceintakeform()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx",
       "source_location": "L52"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "empty_state_onclick",
-      "label": "onClick()",
-      "norm_label": "onclick()",
-      "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
-      "label": "empty-state.tsx",
-      "norm_label": "empty-state.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
-      "source_location": "L1"
     },
     {
       "community": 49,
@@ -56799,6 +56865,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "empty_state_onclick",
+      "label": "onClick()",
+      "norm_label": "onclick()",
+      "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
+      "label": "empty-state.tsx",
+      "norm_label": "empty-state.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
       "norm_label": "nopermission()",
@@ -56806,7 +56890,7 @@
       "source_location": "L3"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -56815,7 +56899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -56824,7 +56908,7 @@
       "source_location": "L4"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -56833,7 +56917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -56842,7 +56926,7 @@
       "source_location": "L4"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -56851,7 +56935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -56860,7 +56944,7 @@
       "source_location": "L9"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -56869,7 +56953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -56878,7 +56962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -56887,7 +56971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -56896,7 +56980,7 @@
       "source_location": "L13"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -56905,7 +56989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -56914,7 +56998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -56923,7 +57007,7 @@
       "source_location": "L25"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -56932,7 +57016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -56941,7 +57025,7 @@
       "source_location": "L19"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -56950,31 +57034,13 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
       "norm_label": "onstoreselect()",
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L63"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "calendar_calendar",
-      "label": "Calendar()",
-      "norm_label": "calendar()",
-      "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
-      "label": "calendar.tsx",
-      "norm_label": "calendar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
-      "source_location": "L1"
     },
     {
       "community": 5,
@@ -57312,6 +57378,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "calendar_calendar",
+      "label": "Calendar()",
+      "norm_label": "calendar()",
+      "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
+      "label": "calendar.tsx",
+      "norm_label": "calendar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
       "norm_label": "usechart()",
@@ -57319,7 +57403,7 @@
       "source_location": "L25"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -57328,7 +57412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -57337,7 +57421,7 @@
       "source_location": "L15"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -57346,7 +57430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -57355,7 +57439,7 @@
       "source_location": "L21"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -57364,7 +57448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "date_time_picker_datetimepicker",
       "label": "DateTimePicker()",
@@ -57373,7 +57457,7 @@
       "source_location": "L21"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -57382,7 +57466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -57391,7 +57475,7 @@
       "source_location": "L6"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -57400,7 +57484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -57409,7 +57493,7 @@
       "source_location": "L25"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -57418,7 +57502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -57427,7 +57511,7 @@
       "source_location": "L49"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -57436,7 +57520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -57445,7 +57529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -57454,7 +57538,7 @@
       "source_location": "L63"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -57463,31 +57547,13 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
       "norm_label": "welcomebackmodalexample()",
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
-      "label": "welcome-back-modal.tsx",
-      "norm_label": "welcome-back-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "welcome_back_modal_welcomebackmodal",
-      "label": "WelcomeBackModal()",
-      "norm_label": "welcomebackmodal()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
-      "source_location": "L12"
     },
     {
       "community": 51,
@@ -57573,6 +57639,24 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
+      "label": "welcome-back-modal.tsx",
+      "norm_label": "welcome-back-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "welcome_back_modal_welcomebackmodal",
+      "label": "WelcomeBackModal()",
+      "norm_label": "welcomebackmodal()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
       "norm_label": "select-native.tsx",
@@ -57580,7 +57664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -57589,7 +57673,7 @@
       "source_location": "L15"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -57598,7 +57682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -57607,7 +57691,7 @@
       "source_location": "L3"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -57616,7 +57700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -57625,7 +57709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -57634,7 +57718,7 @@
       "source_location": "L5"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -57643,7 +57727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -57652,7 +57736,7 @@
       "source_location": "L11"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -57661,7 +57745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -57670,7 +57754,7 @@
       "source_location": "L4"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -57679,7 +57763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -57688,7 +57772,7 @@
       "source_location": "L110"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -57697,7 +57781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -57706,7 +57790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -57715,7 +57799,7 @@
       "source_location": "L13"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -57724,31 +57808,13 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
       "norm_label": "userbag()",
       "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
       "source_location": "L7"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
-      "label": "UserOnlineOrders.tsx",
-      "norm_label": "useronlineorders.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "useronlineorders_useronlineorders",
-      "label": "UserOnlineOrders()",
-      "norm_label": "useronlineorders()",
-      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
-      "source_location": "L11"
     },
     {
       "community": 52,
@@ -57834,6 +57900,24 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
+      "label": "UserOnlineOrders.tsx",
+      "norm_label": "useronlineorders.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "useronlineorders_useronlineorders",
+      "label": "UserOnlineOrders()",
+      "norm_label": "useronlineorders()",
+      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
       "norm_label": "userstatus.tsx",
@@ -57841,7 +57925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -57850,7 +57934,7 @@
       "source_location": "L7"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -57859,7 +57943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -57868,7 +57952,7 @@
       "source_location": "L45"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -57877,7 +57961,7 @@
       "source_location": "L13"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -57886,7 +57970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -57895,7 +57979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -57904,7 +57988,7 @@
       "source_location": "L7"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -57913,7 +57997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -57922,7 +58006,7 @@
       "source_location": "L5"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -57931,7 +58015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -57940,7 +58024,7 @@
       "source_location": "L5"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -57949,7 +58033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -57958,7 +58042,7 @@
       "source_location": "L7"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -57967,7 +58051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -57976,7 +58060,7 @@
       "source_location": "L9"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -57985,31 +58069,13 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
       "norm_label": "usetablekeyboardpagination()",
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
-      "label": "useBulkOperations.test.ts",
-      "norm_label": "usebulkoperations.test.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "usebulkoperations_test_makesku",
-      "label": "makeSku()",
-      "norm_label": "makesku()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
-      "source_location": "L168"
     },
     {
       "community": 53,
@@ -58095,6 +58161,24 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
+      "label": "useBulkOperations.test.ts",
+      "norm_label": "usebulkoperations.test.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "usebulkoperations_test_makesku",
+      "label": "makeSku()",
+      "norm_label": "makesku()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
       "norm_label": "usecopytext.ts",
@@ -58102,7 +58186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -58111,7 +58195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -58120,7 +58204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -58129,7 +58213,7 @@
       "source_location": "L6"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -58138,7 +58222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -58147,7 +58231,7 @@
       "source_location": "L12"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -58156,7 +58240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
@@ -58165,7 +58249,7 @@
       "source_location": "L23"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -58174,7 +58258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -58183,7 +58267,7 @@
       "source_location": "L6"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -58192,7 +58276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -58201,7 +58285,7 @@
       "source_location": "L4"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -58210,7 +58294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -58219,7 +58303,7 @@
       "source_location": "L5"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -58228,7 +58312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -58237,7 +58321,7 @@
       "source_location": "L5"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -58246,31 +58330,13 @@
       "source_location": "L1"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
       "norm_label": "usegetcurrencyformatter()",
       "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
       "source_location": "L4"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
-      "label": "useGetSubcategories.ts",
-      "norm_label": "usegetsubcategories.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "usegetsubcategories_usegetsubcategories",
-      "label": "useGetSubcategories()",
-      "norm_label": "usegetsubcategories()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
-      "source_location": "L5"
     },
     {
       "community": 54,
@@ -58356,6 +58422,24 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
+      "label": "useGetSubcategories.ts",
+      "norm_label": "usegetsubcategories.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "usegetsubcategories_usegetsubcategories",
+      "label": "useGetSubcategories()",
+      "norm_label": "usegetsubcategories()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
       "norm_label": "usegetterminal.ts",
@@ -58363,7 +58447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -58372,7 +58456,7 @@
       "source_location": "L5"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -58381,7 +58465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -58390,7 +58474,7 @@
       "source_location": "L8"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -58399,7 +58483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -58408,7 +58492,7 @@
       "source_location": "L13"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -58417,7 +58501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -58426,7 +58510,7 @@
       "source_location": "L3"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -58435,7 +58519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -58444,7 +58528,7 @@
       "source_location": "L26"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -58453,7 +58537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -58462,7 +58546,7 @@
       "source_location": "L7"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -58471,7 +58555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -58480,7 +58564,7 @@
       "source_location": "L17"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -58489,7 +58573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -58498,7 +58582,7 @@
       "source_location": "L12"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -58507,31 +58591,13 @@
       "source_location": "L1"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
       "norm_label": "useskusreservedinpossession()",
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
-      "label": "useToggleComplimentaryProductActive.ts",
-      "norm_label": "usetogglecomplimentaryproductactive.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
-      "label": "useToggleComplimentaryProductActive()",
-      "norm_label": "usetogglecomplimentaryproductactive()",
-      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
-      "source_location": "L5"
     },
     {
       "community": 55,
@@ -58617,6 +58683,24 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
+      "label": "useToggleComplimentaryProductActive.ts",
+      "norm_label": "usetogglecomplimentaryproductactive.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
+      "label": "useToggleComplimentaryProductActive()",
+      "norm_label": "usetogglecomplimentaryproductactive()",
+      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
       "norm_label": "getorigin()",
@@ -58624,7 +58708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -58633,7 +58717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -58642,7 +58726,7 @@
       "source_location": "L5"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
@@ -58651,7 +58735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
@@ -58660,7 +58744,7 @@
       "source_location": "L6"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
@@ -58669,7 +58753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
@@ -58678,7 +58762,7 @@
       "source_location": "L5"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -58687,7 +58771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -58696,7 +58780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -58705,7 +58789,7 @@
       "source_location": "L5"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -58714,7 +58798,7 @@
       "source_location": "L10"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -58723,7 +58807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -58732,7 +58816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -58741,7 +58825,7 @@
       "source_location": "L12"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "closeouts_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -58750,7 +58834,7 @@
       "source_location": "L10"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_closeouts_index_tsx",
       "label": "closeouts.index.tsx",
@@ -58759,7 +58843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -58768,31 +58852,13 @@
       "source_location": "L6"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
-      "label": "$sessionId.tsx",
-      "norm_label": "$sessionid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "sessionid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
-      "source_location": "L6"
     },
     {
       "community": 56,
@@ -58878,6 +58944,24 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
+      "label": "$sessionId.tsx",
+      "norm_label": "$sessionid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "sessionid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
       "norm_label": "registers.index.tsx",
@@ -58885,7 +58969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -58894,7 +58978,7 @@
       "source_location": "L6"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -58903,7 +58987,7 @@
       "source_location": "L13"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -58912,7 +58996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -58921,7 +59005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -58930,7 +59014,7 @@
       "source_location": "L9"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -58939,7 +59023,7 @@
       "source_location": "L13"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -58948,7 +59032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -58957,7 +59041,7 @@
       "source_location": "L4"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -58966,7 +59050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -58975,7 +59059,7 @@
       "source_location": "L13"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -58984,7 +59068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -58993,7 +59077,7 @@
       "source_location": "L5"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -59002,7 +59086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -59011,7 +59095,7 @@
       "source_location": "L17"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -59020,7 +59104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -59029,30 +59113,12 @@
       "source_location": "L15"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
       "norm_label": "dialog.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "feedback_stories_feedbackshowcase",
-      "label": "FeedbackShowcase()",
-      "norm_label": "feedbackshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
-      "label": "Feedback.stories.tsx",
-      "norm_label": "feedback.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -59139,6 +59205,24 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "feedback_stories_feedbackshowcase",
+      "label": "FeedbackShowcase()",
+      "norm_label": "feedbackshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
+      "label": "Feedback.stories.tsx",
+      "norm_label": "feedback.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
       "norm_label": "primitivesoverview()",
@@ -59146,7 +59230,7 @@
       "source_location": "L5"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -59155,7 +59239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -59164,7 +59248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -59173,7 +59257,7 @@
       "source_location": "L13"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -59182,7 +59266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -59191,7 +59275,7 @@
       "source_location": "L14"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -59200,7 +59284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -59209,7 +59293,7 @@
       "source_location": "L13"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -59218,7 +59302,7 @@
       "source_location": "L5"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -59227,7 +59311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -59236,7 +59320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -59245,7 +59329,7 @@
       "source_location": "L17"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -59254,7 +59338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -59263,7 +59347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -59272,7 +59356,7 @@
       "source_location": "L4"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -59281,7 +59365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -59290,30 +59374,12 @@
       "source_location": "L27"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
       "norm_label": "checkoutsession.test.ts",
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "guest_updateguest",
-      "label": "updateGuest()",
-      "norm_label": "updateguest()",
-      "source_file": "packages/storefront-webapp/src/api/guest.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L1"
     },
     {
@@ -59391,6 +59457,24 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "guest_updateguest",
+      "label": "updateGuest()",
+      "norm_label": "updateguest()",
+      "source_file": "packages/storefront-webapp/src/api/guest.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/storefront-webapp/src/api/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
       "norm_label": "storefront.ts",
@@ -59398,7 +59482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -59407,7 +59491,7 @@
       "source_location": "L5"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -59416,7 +59500,7 @@
       "source_location": "L10"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -59425,7 +59509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -59434,7 +59518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -59443,7 +59527,7 @@
       "source_location": "L10"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -59452,7 +59536,7 @@
       "source_location": "L4"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -59461,7 +59545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -59470,7 +59554,7 @@
       "source_location": "L39"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -59479,7 +59563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -59488,7 +59572,7 @@
       "source_location": "L18"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -59497,7 +59581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -59506,7 +59590,7 @@
       "source_location": "L71"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -59515,7 +59599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -59524,7 +59608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -59533,7 +59617,7 @@
       "source_location": "L12"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -59542,30 +59626,12 @@
       "source_location": "L6"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
       "norm_label": "enteredbillingaddressdetails.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "ordersummary_ordersummary",
-      "label": "OrderSummary()",
-      "norm_label": "ordersummary()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L1"
     },
     {
@@ -59643,6 +59709,24 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "ordersummary_ordersummary",
+      "label": "OrderSummary()",
+      "norm_label": "ordersummary()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
       "norm_label": "pickupdetails()",
@@ -59650,7 +59734,7 @@
       "source_location": "L10"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -59659,7 +59743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -59668,7 +59752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -59677,7 +59761,7 @@
       "source_location": "L8"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -59686,7 +59770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -59695,7 +59779,7 @@
       "source_location": "L27"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -59704,7 +59788,7 @@
       "source_location": "L40"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -59713,7 +59797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -59722,7 +59806,7 @@
       "source_location": "L3"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -59731,7 +59815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -59740,7 +59824,7 @@
       "source_location": "L8"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -59749,7 +59833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -59758,7 +59842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -59767,7 +59851,7 @@
       "source_location": "L12"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -59776,7 +59860,7 @@
       "source_location": "L77"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -59785,7 +59869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -59794,30 +59878,12 @@
       "source_location": "L161"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
       "norm_label": "deliverydetailsform.tsx",
       "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "hooks_usecountdown",
-      "label": "useCountdown()",
-      "norm_label": "usecountdown()",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
       "source_location": "L1"
     },
     {
@@ -60129,6 +60195,24 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "hooks_usecountdown",
+      "label": "useCountdown()",
+      "norm_label": "usecountdown()",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
       "norm_label": "trustsignals.tsx",
@@ -60136,7 +60220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -60145,7 +60229,7 @@
       "source_location": "L4"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -60154,7 +60238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -60163,7 +60247,7 @@
       "source_location": "L14"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -60172,7 +60256,7 @@
       "source_location": "L27"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -60181,7 +60265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -60190,7 +60274,7 @@
       "source_location": "L17"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -60199,7 +60283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -60208,7 +60292,7 @@
       "source_location": "L13"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -60217,7 +60301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -60226,7 +60310,7 @@
       "source_location": "L47"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -60235,7 +60319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -60244,7 +60328,7 @@
       "source_location": "L7"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -60253,7 +60337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -60262,7 +60346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -60271,7 +60355,7 @@
       "source_location": "L17"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -60280,30 +60364,12 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
       "norm_label": "notificationpill.tsx",
       "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "dimensionbar_mapvaluetolabelindex",
-      "label": "mapValueToLabelIndex()",
-      "norm_label": "mapvaluetolabelindex()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
-      "label": "DimensionBar.tsx",
-      "norm_label": "dimensionbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L1"
     },
     {
@@ -60381,6 +60447,24 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "dimensionbar_mapvaluetolabelindex",
+      "label": "mapValueToLabelIndex()",
+      "norm_label": "mapvaluetolabelindex()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
+      "label": "DimensionBar.tsx",
+      "norm_label": "dimensionbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
       "norm_label": "discountbadge()",
@@ -60388,7 +60472,7 @@
       "source_location": "L7"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -60397,7 +60481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -60406,7 +60490,7 @@
       "source_location": "L45"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -60415,7 +60499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -60424,7 +60508,7 @@
       "source_location": "L5"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -60433,7 +60517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -60442,7 +60526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -60451,7 +60535,7 @@
       "source_location": "L17"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -60460,7 +60544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -60469,7 +60553,7 @@
       "source_location": "L3"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -60478,7 +60562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -60487,7 +60571,7 @@
       "source_location": "L78"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -60496,7 +60580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -60505,7 +60589,7 @@
       "source_location": "L87"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -60514,7 +60598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -60523,7 +60607,7 @@
       "source_location": "L8"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -60532,31 +60616,13 @@
       "source_location": "L12"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
       "norm_label": "orderitem.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
-      "label": "RatingSelector.tsx",
-      "norm_label": "ratingselector.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "ratingselector_ratingselector",
-      "label": "RatingSelector()",
-      "norm_label": "ratingselector()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
-      "source_location": "L18"
     },
     {
       "community": 62,
@@ -60633,6 +60699,24 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
+      "label": "RatingSelector.tsx",
+      "norm_label": "ratingselector.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "ratingselector_ratingselector",
+      "label": "RatingSelector()",
+      "norm_label": "ratingselector()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
       "norm_label": "guestrewardsprompt()",
@@ -60640,7 +60724,7 @@
       "source_location": "L10"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -60649,7 +60733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -60658,7 +60742,7 @@
       "source_location": "L11"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -60667,7 +60751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -60676,7 +60760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -60685,7 +60769,7 @@
       "source_location": "L59"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -60694,7 +60778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -60703,7 +60787,7 @@
       "source_location": "L33"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -60712,7 +60796,7 @@
       "source_location": "L19"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -60721,7 +60805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -60730,7 +60814,7 @@
       "source_location": "L4"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -60739,7 +60823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -60748,7 +60832,7 @@
       "source_location": "L22"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -60757,7 +60841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -60766,7 +60850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -60775,7 +60859,7 @@
       "source_location": "L11"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -60784,30 +60868,12 @@
       "source_location": "L3"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
       "norm_label": "country-select.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "ghana_region_select_ghanaregionselect",
-      "label": "GhanaRegionSelect()",
-      "norm_label": "ghanaregionselect()",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
-      "label": "ghana-region-select.tsx",
-      "norm_label": "ghana-region-select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
       "source_location": "L1"
     },
     {
@@ -60885,6 +60951,24 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "ghana_region_select_ghanaregionselect",
+      "label": "GhanaRegionSelect()",
+      "norm_label": "ghanaregionselect()",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
+      "label": "ghana-region-select.tsx",
+      "norm_label": "ghana-region-select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
       "norm_label": "ghostbutton()",
@@ -60892,7 +60976,7 @@
       "source_location": "L9"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -60901,7 +60985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -60910,7 +60994,7 @@
       "source_location": "L66"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -60919,7 +61003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -60928,7 +61012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -60937,7 +61021,7 @@
       "source_location": "L19"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -60946,7 +61030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -60955,7 +61039,7 @@
       "source_location": "L13"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -60964,7 +61048,7 @@
       "source_location": "L46"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -60973,7 +61057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -60982,7 +61066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -60991,7 +61075,7 @@
       "source_location": "L46"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -61000,7 +61084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -61009,7 +61093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -61018,7 +61102,7 @@
       "source_location": "L15"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -61027,7 +61111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -61036,31 +61120,13 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
       "norm_label": "usecheckout()",
       "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
-      "label": "useDiscountCodeAlert.tsx",
-      "norm_label": "usediscountcodealert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "usediscountcodealert_usediscountcodealert",
-      "label": "useDiscountCodeAlert()",
-      "norm_label": "usediscountcodealert()",
-      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
-      "source_location": "L14"
     },
     {
       "community": 64,
@@ -61137,6 +61203,24 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
+      "label": "useDiscountCodeAlert.tsx",
+      "norm_label": "usediscountcodealert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "usediscountcodealert_usediscountcodealert",
+      "label": "useDiscountCodeAlert()",
+      "norm_label": "usediscountcodealert()",
+      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
       "norm_label": "useenhancedtracking.ts",
@@ -61144,7 +61228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -61153,7 +61237,7 @@
       "source_location": "L29"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -61162,7 +61246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -61171,7 +61255,7 @@
       "source_location": "L5"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -61180,7 +61264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -61189,7 +61273,7 @@
       "source_location": "L5"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -61198,7 +61282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -61207,7 +61291,7 @@
       "source_location": "L3"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -61216,7 +61300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -61225,7 +61309,7 @@
       "source_location": "L4"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -61234,7 +61318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -61243,7 +61327,7 @@
       "source_location": "L4"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -61252,7 +61336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -61261,7 +61345,7 @@
       "source_location": "L9"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -61270,7 +61354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -61279,7 +61363,7 @@
       "source_location": "L17"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -61288,31 +61372,13 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
       "norm_label": "uselogout()",
       "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
-      "label": "useModalState.tsx",
-      "norm_label": "usemodalstate.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "usemodalstate_usemodalstate",
-      "label": "useModalState()",
-      "norm_label": "usemodalstate()",
-      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
-      "source_location": "L15"
     },
     {
       "community": 65,
@@ -61389,6 +61455,24 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
+      "label": "useModalState.tsx",
+      "norm_label": "usemodalstate.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "usemodalstate_usemodalstate",
+      "label": "useModalState()",
+      "norm_label": "usemodalstate()",
+      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
       "norm_label": "useproductpagelogic.ts",
@@ -61396,7 +61480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -61405,7 +61489,7 @@
       "source_location": "L18"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -61414,7 +61498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -61423,7 +61507,7 @@
       "source_location": "L9"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -61432,7 +61516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -61441,7 +61525,7 @@
       "source_location": "L16"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -61450,7 +61534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -61459,7 +61543,7 @@
       "source_location": "L4"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -61468,7 +61552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -61477,7 +61561,7 @@
       "source_location": "L11"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -61486,7 +61570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -61495,7 +61579,7 @@
       "source_location": "L3"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -61504,7 +61588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -61513,7 +61597,7 @@
       "source_location": "L7"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -61522,7 +61606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -61531,7 +61615,7 @@
       "source_location": "L4"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -61540,31 +61624,13 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
       "norm_label": "useupsellmodal()",
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "analytics_usepostanalytics",
-      "label": "usePostAnalytics()",
-      "norm_label": "usepostanalytics()",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
-      "source_location": "L1"
     },
     {
       "community": 66,
@@ -61641,6 +61707,24 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "analytics_usepostanalytics",
+      "label": "usePostAnalytics()",
+      "norm_label": "usepostanalytics()",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
       "norm_label": "usebagqueries()",
@@ -61648,7 +61732,7 @@
       "source_location": "L7"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -61657,7 +61741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -61666,7 +61750,7 @@
       "source_location": "L6"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -61675,7 +61759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -61684,7 +61768,7 @@
       "source_location": "L10"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -61693,7 +61777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -61702,7 +61786,7 @@
       "source_location": "L6"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -61711,7 +61795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -61720,7 +61804,7 @@
       "source_location": "L5"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -61729,7 +61813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -61738,7 +61822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -61747,7 +61831,7 @@
       "source_location": "L14"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -61756,7 +61840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -61765,7 +61849,7 @@
       "source_location": "L9"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -61774,7 +61858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -61783,7 +61867,7 @@
       "source_location": "L10"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -61792,31 +61876,13 @@
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
       "norm_label": "userewardsqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L11"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "upsells_useupsellsqueries",
-      "label": "useUpsellsQueries()",
-      "norm_label": "useupsellsqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
-      "source_location": "L6"
     },
     {
       "community": 67,
@@ -61893,6 +61959,24 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "upsells_useupsellsqueries",
+      "label": "useUpsellsQueries()",
+      "norm_label": "useupsellsqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
@@ -61900,7 +61984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -61909,7 +61993,7 @@
       "source_location": "L5"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -61918,7 +62002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -61927,7 +62011,7 @@
       "source_location": "L6"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -61936,7 +62020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -61945,7 +62029,7 @@
       "source_location": "L10"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -61954,7 +62038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -61963,7 +62047,7 @@
       "source_location": "L15"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -61972,7 +62056,7 @@
       "source_location": "L14"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -61981,7 +62065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -61990,7 +62074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -61999,7 +62083,7 @@
       "source_location": "L6"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -62008,7 +62092,7 @@
       "source_location": "L13"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -62017,7 +62101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -62026,7 +62110,7 @@
       "source_location": "L8"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -62035,7 +62119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -62044,30 +62128,12 @@
       "source_location": "L14"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
       "norm_label": "contact-us.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "delivery_returns_exchanges_index_onlineorderpolicy",
-      "label": "OnlineOrderPolicy()",
-      "norm_label": "onlineorderpolicy()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
-      "label": "delivery-returns-exchanges.index.tsx",
-      "norm_label": "delivery-returns-exchanges.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1"
     },
     {
@@ -62145,6 +62211,24 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "delivery_returns_exchanges_index_onlineorderpolicy",
+      "label": "OnlineOrderPolicy()",
+      "norm_label": "onlineorderpolicy()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
+      "label": "delivery-returns-exchanges.index.tsx",
+      "norm_label": "delivery-returns-exchanges.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
       "norm_label": "privacy.index.tsx",
@@ -62152,7 +62236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -62161,7 +62245,7 @@
       "source_location": "L9"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -62170,7 +62254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -62179,7 +62263,7 @@
       "source_location": "L15"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -62188,7 +62272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -62197,7 +62281,7 @@
       "source_location": "L16"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -62206,7 +62290,7 @@
       "source_location": "L6"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -62215,7 +62299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -62224,7 +62308,7 @@
       "source_location": "L10"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -62233,7 +62317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -62242,7 +62326,7 @@
       "source_location": "L21"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -62251,7 +62335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -62260,7 +62344,7 @@
       "source_location": "L33"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -62269,7 +62353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -62278,7 +62362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -62287,7 +62371,7 @@
       "source_location": "L193"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -62296,31 +62380,13 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
       "norm_label": "main()",
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L7"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "architecture_boundaries_test_createsnippetlinter",
-      "label": "createSnippetLinter()",
-      "norm_label": "createsnippetlinter()",
-      "source_file": "scripts/architecture-boundaries.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "scripts_architecture_boundaries_test_ts",
-      "label": "architecture-boundaries.test.ts",
-      "norm_label": "architecture-boundaries.test.ts",
-      "source_file": "scripts/architecture-boundaries.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 69,
@@ -62397,6 +62463,24 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "architecture_boundaries_test_createsnippetlinter",
+      "label": "createSnippetLinter()",
+      "norm_label": "createsnippetlinter()",
+      "source_file": "scripts/architecture-boundaries.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "scripts_architecture_boundaries_test_ts",
+      "label": "architecture-boundaries.test.ts",
+      "norm_label": "architecture-boundaries.test.ts",
+      "source_file": "scripts/architecture-boundaries.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
       "norm_label": "run()",
@@ -62404,7 +62488,7 @@
       "source_location": "L32"
     },
     {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -62413,7 +62497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -62422,7 +62506,7 @@
       "source_location": "L211"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -62431,7 +62515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -62440,7 +62524,7 @@
       "source_location": "L85"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -62449,7 +62533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -62458,7 +62542,7 @@
       "source_location": "L15"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -62467,7 +62551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -62476,7 +62560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -62485,7 +62569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -62494,7 +62578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -62503,21 +62587,12 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
       "norm_label": "server.js",
       "source_file": "packages/athena-webapp/convex/_generated/server.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_app_ts",
-      "label": "app.ts",
-      "norm_label": "app.ts",
-      "source_file": "packages/athena-webapp/convex/app.ts",
       "source_location": "L1"
     },
     {
@@ -62811,6 +62886,15 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_app_ts",
+      "label": "app.ts",
+      "norm_label": "app.ts",
+      "source_file": "packages/athena-webapp/convex/app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
       "norm_label": "auth.config.js",
@@ -62818,7 +62902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -62827,7 +62911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
@@ -62836,7 +62920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -62845,7 +62929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -62854,7 +62938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -62863,7 +62947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -62872,7 +62956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -62881,21 +62965,12 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
       "norm_label": "feedbackrequest.tsx",
       "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
-      "label": "NewOrderAdmin.tsx",
-      "norm_label": "neworderadmin.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
       "source_location": "L1"
     },
     {
@@ -62964,6 +63039,15 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
+      "label": "NewOrderAdmin.tsx",
+      "norm_label": "neworderadmin.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
       "norm_label": "orderemail.tsx",
@@ -62971,7 +63055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -62980,7 +63064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -62989,7 +63073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
       "label": "analytics.ts",
@@ -62998,7 +63082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
@@ -63007,7 +63091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -63016,7 +63100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -63025,7 +63109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -63034,21 +63118,12 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
-      "label": "organizations.ts",
-      "norm_label": "organizations.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/organizations.ts",
       "source_location": "L1"
     },
     {
@@ -63117,6 +63192,15 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
+      "label": "organizations.ts",
+      "norm_label": "organizations.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/organizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
       "norm_label": "products.ts",
@@ -63124,7 +63208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
       "label": "stores.ts",
@@ -63133,7 +63217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
       "label": "subcategories.ts",
@@ -63142,7 +63226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
@@ -63151,7 +63235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
       "label": "bag.ts",
@@ -63160,7 +63244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
@@ -63169,7 +63253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
@@ -63178,7 +63262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
@@ -63187,21 +63271,12 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
       "norm_label": "offers.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/offers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -63270,6 +63345,15 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
       "norm_label": "paystack.ts",
@@ -63277,7 +63361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
       "label": "reviews.ts",
@@ -63286,7 +63370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
@@ -63295,7 +63379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -63304,7 +63388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
       "label": "security.test.ts",
@@ -63313,7 +63397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
@@ -63322,7 +63406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
@@ -63331,7 +63415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -63340,21 +63424,12 @@
       "source_location": "L1"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
       "norm_label": "useroffers.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_health_test_ts",
-      "label": "health.test.ts",
-      "norm_label": "health.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/health.test.ts",
       "source_location": "L1"
     },
     {
@@ -63423,6 +63498,15 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_health_test_ts",
+      "label": "health.test.ts",
+      "norm_label": "health.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/health.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
       "norm_label": "http.ts",
@@ -63430,7 +63514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -63439,7 +63523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -63448,7 +63532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -63457,7 +63541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -63466,7 +63550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -63475,7 +63559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -63484,7 +63568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -63493,21 +63577,12 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
       "norm_label": "expensesessionitems.ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
-      "label": "expenseTransactions.ts",
-      "norm_label": "expensetransactions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
       "source_location": "L1"
     },
     {
@@ -63576,6 +63651,15 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
+      "label": "expenseTransactions.ts",
+      "norm_label": "expensetransactions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
       "norm_label": "featureditem.ts",
@@ -63583,7 +63667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -63592,7 +63676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -63601,7 +63685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -63610,7 +63694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -63619,7 +63703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -63628,7 +63712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -63637,7 +63721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -63646,21 +63730,12 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
       "norm_label": "productsku.ts",
       "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_productutil_ts",
-      "label": "productUtil.ts",
-      "norm_label": "productutil.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
       "source_location": "L1"
     },
     {
@@ -63729,6 +63804,15 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_productutil_ts",
+      "label": "productUtil.ts",
+      "norm_label": "productutil.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
       "norm_label": "promocode.ts",
@@ -63736,7 +63820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -63745,7 +63829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
@@ -63754,7 +63838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -63763,7 +63847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -63772,7 +63856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -63781,7 +63865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -63790,7 +63874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -63799,21 +63883,12 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
       "norm_label": "client.test.ts",
       "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_test_ts",
-      "label": "config.test.ts",
-      "norm_label": "config.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
       "source_location": "L1"
     },
     {
@@ -63882,6 +63957,15 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_test_ts",
+      "label": "config.test.ts",
+      "norm_label": "config.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
       "norm_label": "normalize.test.ts",
@@ -63889,7 +63973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -63898,7 +63982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -63907,7 +63991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -63916,7 +64000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -63925,7 +64009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -63934,7 +64018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -63943,7 +64027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -63952,21 +64036,12 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
       "norm_label": "dto.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/dto.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
-      "label": "getRegisterState.test.ts",
-      "norm_label": "getregisterstate.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/getRegisterState.test.ts",
       "source_location": "L1"
     },
     {
@@ -63976,7 +64051,7 @@
       "label": "appendWorkflowTraceEventWithCtx()",
       "norm_label": "appendworkflowtraceeventwithctx()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L130"
+      "source_location": "L133"
     },
     {
       "community": 78,
@@ -63985,7 +64060,7 @@
       "label": "createWorkflowTraceWithCtx()",
       "norm_label": "createworkflowtracewithctx()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L77"
+      "source_location": "L80"
     },
     {
       "community": 78,
@@ -64021,7 +64096,7 @@
       "label": "registerWorkflowTraceLookupWithCtx()",
       "norm_label": "registerworkflowtracelookupwithctx()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L100"
+      "source_location": "L103"
     },
     {
       "community": 78,
@@ -64035,6 +64110,15 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
+      "label": "getRegisterState.test.ts",
+      "norm_label": "getregisterstate.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/getRegisterState.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -64042,7 +64126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -64051,7 +64135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
@@ -64060,7 +64144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -64069,7 +64153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -64078,7 +64162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -64087,7 +64171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -64096,7 +64180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -64105,21 +64189,12 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
       "norm_label": "appverificationcode.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/appVerificationCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
-      "label": "athenaUser.ts",
-      "norm_label": "athenauser.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/athenaUser.ts",
       "source_location": "L1"
     },
     {
@@ -64188,6 +64263,15 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
+      "label": "athenaUser.ts",
+      "norm_label": "athenauser.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/athenaUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
@@ -64195,7 +64279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -64204,7 +64288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -64213,7 +64297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -64222,7 +64306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -64231,7 +64315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -64240,7 +64324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -64249,7 +64333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -64258,21 +64342,12 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
       "norm_label": "invitecode.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/organization.ts",
       "source_location": "L1"
     },
     {
@@ -64539,6 +64614,15 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/organization.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
       "norm_label": "organizationmember.ts",
@@ -64546,7 +64630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -64555,7 +64639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -64564,7 +64648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -64573,7 +64657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -64582,7 +64666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -64591,7 +64675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -64600,7 +64684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -64609,21 +64693,12 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
       "norm_label": "workflowtraceevent.ts",
       "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceEvent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
-      "label": "workflowTraceLookup.ts",
-      "norm_label": "workflowtracelookup.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceLookup.ts",
       "source_location": "L1"
     },
     {
@@ -64692,6 +64767,15 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
+      "label": "workflowTraceLookup.ts",
+      "norm_label": "workflowtracelookup.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceLookup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
       "norm_label": "approvalrequest.ts",
@@ -64699,7 +64783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -64708,7 +64792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -64717,7 +64801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -64726,7 +64810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -64735,7 +64819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -64744,7 +64828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -64753,7 +64837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -64762,21 +64846,12 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
       "norm_label": "staffprofile.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/staffProfile.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
-      "label": "staffRoleAssignment.ts",
-      "norm_label": "staffroleassignment.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/staffRoleAssignment.ts",
       "source_location": "L1"
     },
     {
@@ -64845,6 +64920,15 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
+      "label": "staffRoleAssignment.ts",
+      "norm_label": "staffroleassignment.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/staffRoleAssignment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
       "norm_label": "mtncollections.ts",
@@ -64852,7 +64936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -64861,7 +64945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -64870,7 +64954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -64879,7 +64963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -64888,7 +64972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -64897,7 +64981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -64906,7 +64990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -64915,21 +64999,12 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
       "norm_label": "possessionitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posSessionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
-      "label": "posTerminal.ts",
-      "norm_label": "posterminal.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",
       "source_location": "L1"
     },
     {
@@ -64998,6 +65073,15 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
+      "label": "posTerminal.ts",
+      "norm_label": "posterminal.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
       "norm_label": "postransaction.ts",
@@ -65005,7 +65089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -65014,7 +65098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -65023,7 +65107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -65032,7 +65116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -65041,7 +65125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -65050,7 +65134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -65059,7 +65143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -65068,7 +65152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -65077,169 +65161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
-      "label": "purchaseOrder.ts",
-      "norm_label": "purchaseorder.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrder.ts",
-      "source_location": "L1"
-    },
-    {
       "community": 84,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 840,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
-      "label": "purchaseOrderLineItem.ts",
-      "norm_label": "purchaseorderlineitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrderLineItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 841,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
-      "label": "receivingBatch.ts",
-      "norm_label": "receivingbatch.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/receivingBatch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 842,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
-      "label": "stockAdjustmentBatch.ts",
-      "norm_label": "stockadjustmentbatch.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/stockAdjustmentBatch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 843,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
-      "label": "vendor.ts",
-      "norm_label": "vendor.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/vendor.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 844,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 845,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 846,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 847,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 848,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
-      "label": "checkoutSessionItem.ts",
-      "norm_label": "checkoutsessionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
-      "label": "customer.ts",
-      "norm_label": "customer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 85,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
       "label": "reference-fixtures.tsx",
@@ -65248,7 +65170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 85,
+      "community": 84,
       "file_type": "code",
       "id": "reference_fixtures_compacttable",
       "label": "CompactTable()",
@@ -65257,7 +65179,7 @@
       "source_location": "L263"
     },
     {
-      "community": 85,
+      "community": 84,
       "file_type": "code",
       "id": "reference_fixtures_framecard",
       "label": "FrameCard()",
@@ -65266,7 +65188,7 @@
       "source_location": "L163"
     },
     {
-      "community": 85,
+      "community": 84,
       "file_type": "code",
       "id": "reference_fixtures_lanecard",
       "label": "LaneCard()",
@@ -65275,7 +65197,7 @@
       "source_location": "L213"
     },
     {
-      "community": 85,
+      "community": 84,
       "file_type": "code",
       "id": "reference_fixtures_metrictile",
       "label": "MetricTile()",
@@ -65284,7 +65206,7 @@
       "source_location": "L194"
     },
     {
-      "community": 85,
+      "community": 84,
       "file_type": "code",
       "id": "reference_fixtures_minitrendchart",
       "label": "MiniTrendChart()",
@@ -65293,7 +65215,7 @@
       "source_location": "L240"
     },
     {
-      "community": 85,
+      "community": 84,
       "file_type": "code",
       "id": "reference_fixtures_referencepageshell",
       "label": "ReferencePageShell()",
@@ -65302,97 +65224,97 @@
       "source_location": "L145"
     },
     {
-      "community": 850,
+      "community": 840,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
+      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
+      "label": "purchaseOrder.ts",
+      "norm_label": "purchaseorder.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrder.ts",
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 841,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
+      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
+      "label": "purchaseOrderLineItem.ts",
+      "norm_label": "purchaseorderlineitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrderLineItem.ts",
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 842,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
-      "label": "offer.ts",
-      "norm_label": "offer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
+      "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
+      "label": "receivingBatch.ts",
+      "norm_label": "receivingbatch.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/receivingBatch.ts",
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 843,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrder.ts",
+      "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
+      "label": "stockAdjustmentBatch.ts",
+      "norm_label": "stockadjustmentbatch.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/stockAdjustmentBatch.ts",
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 844,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
-      "label": "onlineOrderItem.ts",
-      "norm_label": "onlineorderitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrderItem.ts",
+      "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
+      "label": "vendor.ts",
+      "norm_label": "vendor.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/vendor.ts",
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 845,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
-      "label": "review.ts",
-      "norm_label": "review.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/review.ts",
+      "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/analytics.ts",
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 846,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/rewards.ts",
+      "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bag.ts",
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 847,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
+      "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 848,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
-      "label": "savedBagItem.ts",
-      "norm_label": "savedbagitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
+      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
       "source_location": "L1"
     },
     {
-      "community": 859,
+      "community": 849,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
-      "label": "storeFrontSession.ts",
-      "norm_label": "storefrontsession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
+      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
+      "label": "checkoutSessionItem.ts",
+      "norm_label": "checkoutsessionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
       "source_location": "L1"
     },
     {
-      "community": 86,
+      "community": 85,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
       "label": "savedBag.ts",
@@ -65401,7 +65323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 86,
+      "community": 85,
       "file_type": "code",
       "id": "savedbag_additemtosavedbag",
       "label": "addItemToSavedBag()",
@@ -65410,7 +65332,7 @@
       "source_location": "L25"
     },
     {
-      "community": 86,
+      "community": 85,
       "file_type": "code",
       "id": "savedbag_getactivesavedbag",
       "label": "getActiveSavedBag()",
@@ -65419,7 +65341,7 @@
       "source_location": "L10"
     },
     {
-      "community": 86,
+      "community": 85,
       "file_type": "code",
       "id": "savedbag_getbaseurl",
       "label": "getBaseUrl()",
@@ -65428,7 +65350,7 @@
       "source_location": "L8"
     },
     {
-      "community": 86,
+      "community": 85,
       "file_type": "code",
       "id": "savedbag_removeitemfromsavedbag",
       "label": "removeItemFromSavedBag()",
@@ -65437,7 +65359,7 @@
       "source_location": "L91"
     },
     {
-      "community": 86,
+      "community": 85,
       "file_type": "code",
       "id": "savedbag_updatesavedbagitem",
       "label": "updateSavedBagItem()",
@@ -65446,7 +65368,7 @@
       "source_location": "L61"
     },
     {
-      "community": 86,
+      "community": 85,
       "file_type": "code",
       "id": "savedbag_updatesavedbagowner",
       "label": "updateSavedBagOwner()",
@@ -65455,7 +65377,169 @@
       "source_location": "L109"
     },
     {
+      "community": 850,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
+      "label": "customer.ts",
+      "norm_label": "customer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/customer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 852,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 853,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
+      "label": "offer.ts",
+      "norm_label": "offer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 854,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 855,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
+      "label": "onlineOrderItem.ts",
+      "norm_label": "onlineorderitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrderItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 856,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
+      "label": "review.ts",
+      "norm_label": "review.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/review.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 857,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 858,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 859,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
+      "label": "savedBagItem.ts",
+      "norm_label": "savedbagitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
+    },
+    {
       "community": 860,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
+      "label": "storeFrontSession.ts",
+      "norm_label": "storefrontsession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -65464,7 +65548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -65473,7 +65557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -65482,7 +65566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -65491,7 +65575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -65500,7 +65584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -65509,7 +65593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -65518,7 +65602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -65527,21 +65611,12 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
       "norm_label": "onlineorderutilfns.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
-      "label": "orderOperations.test.ts",
-      "norm_label": "orderoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/orderOperations.test.ts",
       "source_location": "L1"
     },
     {
@@ -65610,6 +65685,15 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
+      "label": "orderOperations.test.ts",
+      "norm_label": "orderoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/orderOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
       "norm_label": "payment.ts",
@@ -65617,7 +65701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -65626,7 +65710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -65635,7 +65719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -65644,7 +65728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -65653,7 +65737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -65662,21 +65746,12 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
       "norm_label": "presentation.test.ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 877,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
-      "label": "public.ts",
-      "norm_label": "public.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/public.ts",
       "source_location": "L1"
     },
     {

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1430
-- Graph nodes: 3510
-- Graph edges: 3003
+- Graph nodes: 3513
+- Graph edges: 3007
 - Communities: 1345
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1425
-- Graph nodes: 3497
-- Graph edges: 2993
-- Communities: 1340
+- Code files discovered: 1430
+- Graph nodes: 3510
+- Graph edges: 3003
+- Communities: 1345
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 30) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 221) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 222) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 30) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 30) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 30) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -168,6 +168,10 @@ import type * as schemas_inventory_promoCode from "../schemas/inventory/promoCod
 import type * as schemas_inventory_redeemedPromoCode from "../schemas/inventory/redeemedPromoCode.js";
 import type * as schemas_inventory_store from "../schemas/inventory/store.js";
 import type * as schemas_inventory_subcategory from "../schemas/inventory/subcategory.js";
+import type * as schemas_observability_index from "../schemas/observability/index.js";
+import type * as schemas_observability_workflowTrace from "../schemas/observability/workflowTrace.js";
+import type * as schemas_observability_workflowTraceEvent from "../schemas/observability/workflowTraceEvent.js";
+import type * as schemas_observability_workflowTraceLookup from "../schemas/observability/workflowTraceLookup.js";
 import type * as schemas_operations_approvalRequest from "../schemas/operations/approvalRequest.js";
 import type * as schemas_operations_customerProfile from "../schemas/operations/customerProfile.js";
 import type * as schemas_operations_index from "../schemas/operations/index.js";
@@ -266,6 +270,9 @@ import type * as storeFront_userOffers from "../storeFront/userOffers.js";
 import type * as storeFront_users from "../storeFront/users.js";
 import type * as types_payment from "../types/payment.js";
 import type * as utils from "../utils.js";
+import type * as workflowTraces_core from "../workflowTraces/core.js";
+import type * as workflowTraces_presentation from "../workflowTraces/presentation.js";
+import type * as workflowTraces_public from "../workflowTraces/public.js";
 
 import type {
   ApiFromModules,
@@ -434,6 +441,10 @@ declare const fullApi: ApiFromModules<{
   "schemas/inventory/redeemedPromoCode": typeof schemas_inventory_redeemedPromoCode;
   "schemas/inventory/store": typeof schemas_inventory_store;
   "schemas/inventory/subcategory": typeof schemas_inventory_subcategory;
+  "schemas/observability/index": typeof schemas_observability_index;
+  "schemas/observability/workflowTrace": typeof schemas_observability_workflowTrace;
+  "schemas/observability/workflowTraceEvent": typeof schemas_observability_workflowTraceEvent;
+  "schemas/observability/workflowTraceLookup": typeof schemas_observability_workflowTraceLookup;
   "schemas/operations/approvalRequest": typeof schemas_operations_approvalRequest;
   "schemas/operations/customerProfile": typeof schemas_operations_customerProfile;
   "schemas/operations/index": typeof schemas_operations_index;
@@ -532,6 +543,9 @@ declare const fullApi: ApiFromModules<{
   "storeFront/users": typeof storeFront_users;
   "types/payment": typeof types_payment;
   utils: typeof utils;
+  "workflowTraces/core": typeof workflowTraces_core;
+  "workflowTraces/presentation": typeof workflowTraces_presentation;
+  "workflowTraces/public": typeof workflowTraces_public;
 }>;
 
 /**

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -277,6 +277,7 @@ const schema = defineSchema({
     .index("by_primarySubject", ["primarySubjectType", "primarySubjectId"]),
   workflowTraceEvent: defineTable(workflowTraceEventSchema)
     .index("by_storeId_traceId_occurredAt", ["storeId", "traceId", "occurredAt"])
+    .index("by_storeId_traceId_sequence", ["storeId", "traceId", "sequence"])
     .index("by_traceId_sequence", ["traceId", "sequence"]),
   workflowTraceLookup: defineTable(workflowTraceLookupSchema)
     .index("by_storeId_workflowType_lookup", [

--- a/packages/athena-webapp/convex/workflowTraces/core.ts
+++ b/packages/athena-webapp/convex/workflowTraces/core.ts
@@ -69,6 +69,7 @@ export async function listWorkflowTraceEventsWithCtx(
     traceId: string;
   }
 ) {
+  // eslint-disable-next-line @convex-dev/no-collect-in-query -- Trace timelines are loaded one trace at a time and stay bounded by a single workflow instance.
   return ctx.db
     .query("workflowTraceEvent")
     .withIndex("by_storeId_traceId_sequence", (q) =>
@@ -93,7 +94,7 @@ export async function createWorkflowTraceWithCtx(
   });
 
   if (existing) {
-    await ctx.db.patch(existing._id, normalizedTrace);
+    await ctx.db.patch("workflowTrace", existing._id, normalizedTrace);
     return existing._id;
   }
 
@@ -121,7 +122,7 @@ export async function registerWorkflowTraceLookupWithCtx(
 
   if (existing) {
     if (existing.traceId !== normalizedLookup.traceId) {
-      await ctx.db.patch(existing._id, normalizedLookup);
+      await ctx.db.patch("workflowTraceLookup", existing._id, normalizedLookup);
     }
 
     return existing._id;

--- a/packages/athena-webapp/convex/workflowTraces/core.ts
+++ b/packages/athena-webapp/convex/workflowTraces/core.ts
@@ -65,12 +65,15 @@ export async function getWorkflowTraceByLookupWithCtx(
 export async function listWorkflowTraceEventsWithCtx(
   ctx: WorkflowTraceReaderCtx,
   input: {
+    storeId: Id<"store">;
     traceId: string;
   }
 ) {
   return ctx.db
     .query("workflowTraceEvent")
-    .withIndex("by_traceId_sequence", (q) => q.eq("traceId", input.traceId))
+    .withIndex("by_storeId_traceId_sequence", (q) =>
+      q.eq("storeId", input.storeId).eq("traceId", input.traceId)
+    )
     .collect();
 }
 
@@ -133,7 +136,9 @@ export async function appendWorkflowTraceEventWithCtx(
 ) {
   const latest = await ctx.db
     .query("workflowTraceEvent")
-    .withIndex("by_traceId_sequence", (q) => q.eq("traceId", input.traceId))
+    .withIndex("by_storeId_traceId_sequence", (q) =>
+      q.eq("storeId", input.storeId).eq("traceId", input.traceId)
+    )
     .order("desc")
     .first();
 

--- a/packages/athena-webapp/convex/workflowTraces/core.ts
+++ b/packages/athena-webapp/convex/workflowTraces/core.ts
@@ -1,0 +1,144 @@
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+
+import { normalizeWorkflowTraceLookupValue } from "../../shared/workflowTrace";
+
+type WorkflowTraceReaderCtx = MutationCtx | QueryCtx;
+type WorkflowTraceInput = Omit<Doc<"workflowTrace">, "_id" | "_creationTime">;
+type WorkflowTraceLookupInput = Omit<
+  Doc<"workflowTraceLookup">,
+  "_id" | "_creationTime"
+>;
+type WorkflowTraceEventInput = Omit<
+  Doc<"workflowTraceEvent">,
+  "_id" | "_creationTime" | "sequence"
+>;
+
+export async function getWorkflowTraceByIdWithCtx(
+  ctx: WorkflowTraceReaderCtx,
+  input: {
+    storeId: Id<"store">;
+    traceId: string;
+  }
+) {
+  return ctx.db
+    .query("workflowTrace")
+    .withIndex("by_storeId_traceId", (q) =>
+      q.eq("storeId", input.storeId).eq("traceId", input.traceId)
+    )
+    .unique();
+}
+
+export async function getWorkflowTraceByLookupWithCtx(
+  ctx: WorkflowTraceReaderCtx,
+  input: {
+    storeId: Id<"store">;
+    workflowType: string;
+    lookupType: string;
+    lookupValue: string;
+  }
+) {
+  const lookup = await ctx.db
+    .query("workflowTraceLookup")
+    .withIndex("by_storeId_workflowType_lookup", (q) =>
+      q
+        .eq("storeId", input.storeId)
+        .eq("workflowType", input.workflowType)
+        .eq("lookupType", input.lookupType)
+        .eq(
+          "lookupValue",
+          normalizeWorkflowTraceLookupValue(input.lookupValue)
+        )
+    )
+    .unique();
+
+  if (!lookup) {
+    return null;
+  }
+
+  return getWorkflowTraceByIdWithCtx(ctx, {
+    storeId: input.storeId,
+    traceId: lookup.traceId,
+  });
+}
+
+export async function listWorkflowTraceEventsWithCtx(
+  ctx: WorkflowTraceReaderCtx,
+  input: {
+    traceId: string;
+  }
+) {
+  return ctx.db
+    .query("workflowTraceEvent")
+    .withIndex("by_traceId_sequence", (q) => q.eq("traceId", input.traceId))
+    .collect();
+}
+
+export async function createWorkflowTraceWithCtx(
+  ctx: MutationCtx,
+  input: WorkflowTraceInput
+) {
+  const normalizedTrace = {
+    ...input,
+    primaryLookupValue: normalizeWorkflowTraceLookupValue(
+      input.primaryLookupValue
+    ),
+  };
+  const existing = await getWorkflowTraceByIdWithCtx(ctx, {
+    storeId: normalizedTrace.storeId,
+    traceId: normalizedTrace.traceId,
+  });
+
+  if (existing) {
+    await ctx.db.patch(existing._id, normalizedTrace);
+    return existing._id;
+  }
+
+  return ctx.db.insert("workflowTrace", normalizedTrace);
+}
+
+export async function registerWorkflowTraceLookupWithCtx(
+  ctx: MutationCtx,
+  input: WorkflowTraceLookupInput
+) {
+  const normalizedLookup = {
+    ...input,
+    lookupValue: normalizeWorkflowTraceLookupValue(input.lookupValue),
+  };
+  const existing = await ctx.db
+    .query("workflowTraceLookup")
+    .withIndex("by_storeId_workflowType_lookup", (q) =>
+      q
+        .eq("storeId", normalizedLookup.storeId)
+        .eq("workflowType", normalizedLookup.workflowType)
+        .eq("lookupType", normalizedLookup.lookupType)
+        .eq("lookupValue", normalizedLookup.lookupValue)
+    )
+    .unique();
+
+  if (existing) {
+    if (existing.traceId !== normalizedLookup.traceId) {
+      await ctx.db.patch(existing._id, normalizedLookup);
+    }
+
+    return existing._id;
+  }
+
+  return ctx.db.insert("workflowTraceLookup", normalizedLookup);
+}
+
+export async function appendWorkflowTraceEventWithCtx(
+  ctx: MutationCtx,
+  input: WorkflowTraceEventInput
+) {
+  const latest = await ctx.db
+    .query("workflowTraceEvent")
+    .withIndex("by_traceId_sequence", (q) => q.eq("traceId", input.traceId))
+    .order("desc")
+    .first();
+
+  return ctx.db.insert("workflowTraceEvent", {
+    ...input,
+    sequence: (latest?.sequence ?? 0) + 1,
+  });
+}

--- a/packages/athena-webapp/convex/workflowTraces/presentation.test.ts
+++ b/packages/athena-webapp/convex/workflowTraces/presentation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { buildWorkflowTraceViewModel } from "./presentation";
+
+describe("buildWorkflowTraceViewModel", () => {
+  it("sorts events by occurredAt and sequence and preserves trace health", () => {
+    const view = buildWorkflowTraceViewModel({
+      trace: {
+        traceId: "pos_sale:pos-123456",
+        workflowType: "pos_sale",
+        title: "POS sale POS-123456",
+        status: "succeeded",
+        health: "partial",
+        primaryLookupType: "transaction_number",
+        primaryLookupValue: "POS-123456",
+      },
+      events: [
+        {
+          traceId: "pos_sale:pos-123456",
+          workflowType: "pos_sale",
+          occurredAt: 200,
+          sequence: 2,
+          kind: "system_action",
+          step: "transaction_persisted",
+          status: "succeeded",
+          message: "Transaction persisted",
+          source: "workflow.posSale",
+        },
+        {
+          traceId: "pos_sale:pos-123456",
+          workflowType: "pos_sale",
+          occurredAt: 200,
+          sequence: 1,
+          kind: "milestone",
+          step: "sale_completion_started",
+          status: "started",
+          message: "Sale completion started",
+          source: "workflow.posSale",
+        },
+      ],
+    });
+
+    expect(view.header.traceId).toBe("pos_sale:pos-123456");
+    expect(view.header.health).toBe("partial");
+    expect(view.events.map((event) => event.message)).toEqual([
+      "Sale completion started",
+      "Transaction persisted",
+    ]);
+  });
+});

--- a/packages/athena-webapp/convex/workflowTraces/presentation.test.ts
+++ b/packages/athena-webapp/convex/workflowTraces/presentation.test.ts
@@ -6,45 +6,45 @@ describe("buildWorkflowTraceViewModel", () => {
   it("sorts events by occurredAt and sequence and preserves trace health", () => {
     const view = buildWorkflowTraceViewModel({
       trace: {
-        traceId: "pos_sale:pos-123456",
-        workflowType: "pos_sale",
-        title: "POS sale POS-123456",
+        traceId: "repair_order:job-42",
+        workflowType: "repair_order",
+        title: "Repair order JOB-42",
         status: "succeeded",
         health: "partial",
-        primaryLookupType: "transaction_number",
-        primaryLookupValue: "POS-123456",
+        primaryLookupType: "reference_number",
+        primaryLookupValue: "JOB-42",
       },
       events: [
         {
-          traceId: "pos_sale:pos-123456",
-          workflowType: "pos_sale",
+          traceId: "repair_order:job-42",
+          workflowType: "repair_order",
           occurredAt: 200,
           sequence: 2,
           kind: "system_action",
-          step: "transaction_persisted",
+          step: "repair_order_persisted",
           status: "succeeded",
-          message: "Transaction persisted",
-          source: "workflow.posSale",
+          message: "Repair order persisted",
+          source: "workflow.shared",
         },
         {
-          traceId: "pos_sale:pos-123456",
-          workflowType: "pos_sale",
+          traceId: "repair_order:job-42",
+          workflowType: "repair_order",
           occurredAt: 200,
           sequence: 1,
           kind: "milestone",
-          step: "sale_completion_started",
+          step: "workflow_started",
           status: "started",
-          message: "Sale completion started",
-          source: "workflow.posSale",
+          message: "Workflow started",
+          source: "workflow.shared",
         },
       ],
     });
 
-    expect(view.header.traceId).toBe("pos_sale:pos-123456");
+    expect(view.header.traceId).toBe("repair_order:job-42");
     expect(view.header.health).toBe("partial");
     expect(view.events.map((event) => event.message)).toEqual([
-      "Sale completion started",
-      "Transaction persisted",
+      "Workflow started",
+      "Repair order persisted",
     ]);
   });
 });

--- a/packages/athena-webapp/convex/workflowTraces/presentation.ts
+++ b/packages/athena-webapp/convex/workflowTraces/presentation.ts
@@ -1,0 +1,53 @@
+import type { Doc } from "../_generated/dataModel";
+
+export type WorkflowTracePresentationInput = {
+  trace: Pick<
+    Doc<"workflowTrace">,
+    | "traceId"
+    | "workflowType"
+    | "title"
+    | "status"
+    | "health"
+    | "primaryLookupType"
+    | "primaryLookupValue"
+    | "summary"
+  >;
+  events: Array<
+    Pick<
+      Doc<"workflowTraceEvent">,
+      | "traceId"
+      | "workflowType"
+      | "occurredAt"
+      | "sequence"
+      | "kind"
+      | "step"
+      | "status"
+      | "message"
+      | "source"
+    >
+  >;
+};
+
+export function buildWorkflowTraceViewModel(input: WorkflowTracePresentationInput) {
+  const events = [...input.events].sort((left, right) => {
+    if (left.occurredAt !== right.occurredAt) {
+      return left.occurredAt - right.occurredAt;
+    }
+
+    return left.sequence - right.sequence;
+  });
+
+  return {
+    header: {
+      traceId: input.trace.traceId,
+      workflowType: input.trace.workflowType,
+      title: input.trace.title,
+      status: input.trace.status,
+      health: input.trace.health,
+      primaryLookupType: input.trace.primaryLookupType,
+      primaryLookupValue: input.trace.primaryLookupValue,
+      summary: input.trace.summary,
+    },
+    events,
+  };
+}

--- a/packages/athena-webapp/convex/workflowTraces/public.ts
+++ b/packages/athena-webapp/convex/workflowTraces/public.ts
@@ -1,34 +1,75 @@
 import { v } from "convex/values";
 
+import type { Id } from "../_generated/dataModel";
+import type { QueryCtx } from "../_generated/server";
 import { query } from "../_generated/server";
 import { normalizeWorkflowTraceLookupValue } from "../../shared/workflowTrace";
+import { listWorkflowTraceEventsWithCtx } from "./core";
 import { buildWorkflowTraceViewModel } from "./presentation";
+
+export async function getWorkflowTraceViewByIdWithCtx(
+  ctx: QueryCtx,
+  args: {
+    storeId: Id<"store">;
+    traceId: string;
+  },
+) {
+  const trace = await ctx.db
+    .query("workflowTrace")
+    .withIndex("by_storeId_traceId", (q) =>
+      q.eq("storeId", args.storeId).eq("traceId", args.traceId)
+    )
+    .unique();
+
+  if (!trace) {
+    return null;
+  }
+
+  const events = await listWorkflowTraceEventsWithCtx(ctx as never, {
+    storeId: args.storeId,
+    traceId: trace.traceId,
+  });
+
+  return buildWorkflowTraceViewModel({ trace, events });
+}
 
 export const getWorkflowTraceViewById = query({
   args: {
     storeId: v.id("store"),
     traceId: v.string(),
   },
-  handler: async (ctx, args) => {
-    const trace = await ctx.db
-      .query("workflowTrace")
-      .withIndex("by_storeId_traceId", (q) =>
-        q.eq("storeId", args.storeId).eq("traceId", args.traceId)
-      )
-      .unique();
-
-    if (!trace) {
-      return null;
-    }
-
-    const events = await ctx.db
-      .query("workflowTraceEvent")
-      .withIndex("by_traceId_sequence", (q) => q.eq("traceId", trace.traceId))
-      .collect();
-
-    return buildWorkflowTraceViewModel({ trace, events });
-  },
+  handler: (ctx, args) => getWorkflowTraceViewByIdWithCtx(ctx, args),
 });
+
+export async function getWorkflowTraceViewByLookupWithCtx(
+  ctx: QueryCtx,
+  args: {
+    storeId: Id<"store">;
+    workflowType: string;
+    lookupType: string;
+    lookupValue: string;
+  },
+) {
+  const lookup = await ctx.db
+    .query("workflowTraceLookup")
+    .withIndex("by_storeId_workflowType_lookup", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("workflowType", args.workflowType)
+        .eq("lookupType", args.lookupType)
+        .eq("lookupValue", normalizeWorkflowTraceLookupValue(args.lookupValue))
+    )
+    .unique();
+
+  if (!lookup) {
+    return null;
+  }
+
+  return getWorkflowTraceViewByIdWithCtx(ctx as never, {
+    storeId: args.storeId,
+    traceId: lookup.traceId,
+  });
+}
 
 export const getWorkflowTraceByLookup = query({
   args: {
@@ -37,38 +78,5 @@ export const getWorkflowTraceByLookup = query({
     lookupType: v.string(),
     lookupValue: v.string(),
   },
-  handler: async (ctx, args) => {
-    const lookup = await ctx.db
-      .query("workflowTraceLookup")
-      .withIndex("by_storeId_workflowType_lookup", (q) =>
-        q
-          .eq("storeId", args.storeId)
-          .eq("workflowType", args.workflowType)
-          .eq("lookupType", args.lookupType)
-          .eq("lookupValue", normalizeWorkflowTraceLookupValue(args.lookupValue))
-      )
-      .unique();
-
-    if (!lookup) {
-      return null;
-    }
-
-    const trace = await ctx.db
-      .query("workflowTrace")
-      .withIndex("by_storeId_traceId", (q) =>
-        q.eq("storeId", args.storeId).eq("traceId", lookup.traceId)
-      )
-      .unique();
-
-    if (!trace) {
-      return null;
-    }
-
-    const events = await ctx.db
-      .query("workflowTraceEvent")
-      .withIndex("by_traceId_sequence", (q) => q.eq("traceId", trace.traceId))
-      .collect();
-
-    return buildWorkflowTraceViewModel({ trace, events });
-  },
+  handler: (ctx, args) => getWorkflowTraceViewByLookupWithCtx(ctx, args),
 });

--- a/packages/athena-webapp/convex/workflowTraces/public.ts
+++ b/packages/athena-webapp/convex/workflowTraces/public.ts
@@ -1,0 +1,74 @@
+import { v } from "convex/values";
+
+import { query } from "../_generated/server";
+import { normalizeWorkflowTraceLookupValue } from "../../shared/workflowTrace";
+import { buildWorkflowTraceViewModel } from "./presentation";
+
+export const getWorkflowTraceViewById = query({
+  args: {
+    storeId: v.id("store"),
+    traceId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const trace = await ctx.db
+      .query("workflowTrace")
+      .withIndex("by_storeId_traceId", (q) =>
+        q.eq("storeId", args.storeId).eq("traceId", args.traceId)
+      )
+      .unique();
+
+    if (!trace) {
+      return null;
+    }
+
+    const events = await ctx.db
+      .query("workflowTraceEvent")
+      .withIndex("by_traceId_sequence", (q) => q.eq("traceId", trace.traceId))
+      .collect();
+
+    return buildWorkflowTraceViewModel({ trace, events });
+  },
+});
+
+export const getWorkflowTraceByLookup = query({
+  args: {
+    storeId: v.id("store"),
+    workflowType: v.string(),
+    lookupType: v.string(),
+    lookupValue: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const lookup = await ctx.db
+      .query("workflowTraceLookup")
+      .withIndex("by_storeId_workflowType_lookup", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("workflowType", args.workflowType)
+          .eq("lookupType", args.lookupType)
+          .eq("lookupValue", normalizeWorkflowTraceLookupValue(args.lookupValue))
+      )
+      .unique();
+
+    if (!lookup) {
+      return null;
+    }
+
+    const trace = await ctx.db
+      .query("workflowTrace")
+      .withIndex("by_storeId_traceId", (q) =>
+        q.eq("storeId", args.storeId).eq("traceId", lookup.traceId)
+      )
+      .unique();
+
+    if (!trace) {
+      return null;
+    }
+
+    const events = await ctx.db
+      .query("workflowTraceEvent")
+      .withIndex("by_traceId_sequence", (q) => q.eq("traceId", trace.traceId))
+      .collect();
+
+    return buildWorkflowTraceViewModel({ trace, events });
+  },
+});

--- a/packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts
+++ b/packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts
@@ -1,24 +1,362 @@
 import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
 
-function getSource(relativePath: string) {
-  return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+import type { Id } from "../_generated/dataModel";
+import {
+  appendWorkflowTraceEventWithCtx,
+  createWorkflowTraceWithCtx,
+  registerWorkflowTraceLookupWithCtx,
+} from "./core";
+import {
+  getWorkflowTraceViewByIdWithCtx,
+  getWorkflowTraceViewByLookupWithCtx,
+} from "./public";
+
+type WorkflowTraceDoc = {
+  _id: string;
+  _creationTime: number;
+  storeId: Id<"store">;
+  organizationId?: Id<"organization">;
+  traceId: string;
+  workflowType: string;
+  title: string;
+  status: string;
+  health: string;
+  startedAt: number;
+  completedAt?: number;
+  primaryLookupType: string;
+  primaryLookupValue: string;
+  primarySubjectType?: string;
+  primarySubjectId?: string;
+  summary?: string;
+};
+
+type WorkflowTraceEventDoc = {
+  _id: string;
+  _creationTime: number;
+  storeId: Id<"store">;
+  traceId: string;
+  workflowType: string;
+  sequence: number;
+  kind: string;
+  step: string;
+  status: string;
+  message: string;
+  occurredAt: number;
+  details?: Record<string, unknown>;
+  source: string;
+  subjectRefs?: Record<string, string>;
+  actorRefs?: Record<string, string>;
+};
+
+type WorkflowTraceLookupDoc = {
+  _id: string;
+  _creationTime: number;
+  storeId: Id<"store">;
+  workflowType: string;
+  lookupType: string;
+  lookupValue: string;
+  traceId: string;
+};
+
+type WorkflowTraceTables = {
+  workflowTrace: WorkflowTraceDoc[];
+  workflowTraceEvent: WorkflowTraceEventDoc[];
+  workflowTraceLookup: WorkflowTraceLookupDoc[];
+};
+
+const INDEX_FIELDS = {
+  workflowTrace: {
+    by_storeId_traceId: ["storeId", "traceId"],
+  },
+  workflowTraceEvent: {
+    by_storeId_traceId_sequence: ["storeId", "traceId", "sequence"],
+  },
+  workflowTraceLookup: {
+    by_storeId_workflowType_lookup: [
+      "storeId",
+      "workflowType",
+      "lookupType",
+      "lookupValue",
+    ],
+  },
+} as const;
+
+function compareByFields(
+  fields: readonly string[],
+  left: Record<string, unknown>,
+  right: Record<string, unknown>,
+) {
+  for (const field of fields) {
+    if (left[field] === right[field]) {
+      continue;
+    }
+
+    return left[field]! < right[field]! ? -1 : 1;
+  }
+
+  return 0;
 }
 
-describe("workflow trace core and public query usage", () => {
-  it("uses indexed trace, event, and lookup access patterns", () => {
-    const coreSource = getSource("./core.ts");
-    const publicSource = getSource("./public.ts");
+function createTestCtx(seed?: Partial<WorkflowTraceTables>) {
+  const tables: WorkflowTraceTables = {
+    workflowTrace: [...(seed?.workflowTrace ?? [])],
+    workflowTraceEvent: [...(seed?.workflowTraceEvent ?? [])],
+    workflowTraceLookup: [...(seed?.workflowTraceLookup ?? [])],
+  };
+  let idCounter = 100;
 
-    expect(coreSource).toContain('.withIndex("by_storeId_traceId"');
-    expect(coreSource).toContain('.withIndex("by_storeId_workflowType_lookup"');
-    expect(coreSource).toContain('.withIndex("by_traceId_sequence"');
+  const db = {
+    insert(tableName: keyof WorkflowTraceTables, value: Record<string, unknown>) {
+      idCounter += 1;
+      const row = {
+        _id: `${tableName}:${idCounter}`,
+        _creationTime: idCounter,
+        ...value,
+      } as WorkflowTraceDoc & WorkflowTraceEventDoc & WorkflowTraceLookupDoc;
+      tables[tableName].push(row as never);
+      return Promise.resolve(row._id);
+    },
+    patch(id: string, value: Record<string, unknown>) {
+      for (const tableName of Object.keys(tables) as Array<
+        keyof WorkflowTraceTables
+      >) {
+        const row = tables[tableName].find((entry) => entry._id === id);
 
-    expect(publicSource).toContain('.withIndex("by_storeId_traceId"');
-    expect(publicSource).toContain('.withIndex("by_traceId_sequence"');
-    expect(publicSource).toContain('.withIndex("by_storeId_workflowType_lookup"');
-    expect(publicSource).toContain(
-      "normalizeWorkflowTraceLookupValue(args.lookupValue)",
+        if (row) {
+          Object.assign(row, value);
+          return Promise.resolve();
+        }
+      }
+
+      throw new Error(`Unknown row ${id}`);
+    },
+    query(tableName: keyof WorkflowTraceTables) {
+      return {
+        withIndex(
+          indexName: string,
+          apply: (builder: { eq(field: string, value: unknown): typeof builder }) => void,
+        ) {
+          const filters: Array<{ field: string; value: unknown }> = [];
+          const builder = {
+            eq(field: string, value: unknown) {
+              filters.push({ field, value });
+              return builder;
+            },
+          };
+
+          apply(builder);
+
+          const rows = tables[tableName]
+            .filter((row) =>
+              filters.every((filter) => row[filter.field as keyof typeof row] === filter.value)
+            )
+            .sort((left, right) =>
+              compareByFields(
+                INDEX_FIELDS[tableName][
+                  indexName as keyof (typeof INDEX_FIELDS)[typeof tableName]
+                ] ?? [],
+                left,
+                right,
+              ),
+            );
+
+          return {
+            collect: async () => rows,
+            first: async () => rows[0] ?? null,
+            unique: async () => rows[0] ?? null,
+            order(direction: "asc" | "desc") {
+              const ordered = direction === "desc" ? [...rows].reverse() : rows;
+              return {
+                first: async () => ordered[0] ?? null,
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return { db, tables };
+}
+
+describe("workflow trace core and public helpers", () => {
+  it("updates existing traces instead of duplicating the same store-scoped trace id", async () => {
+    const storeId = "store-a" as Id<"store">;
+    const ctx = createTestCtx();
+
+    await createWorkflowTraceWithCtx(ctx as never, {
+      storeId,
+      traceId: "repair_order:job-42",
+      workflowType: "repair_order",
+      title: "Repair order JOB-42",
+      status: "started",
+      health: "healthy",
+      startedAt: 100,
+      primaryLookupType: "reference_number",
+      primaryLookupValue: " JOB-42 ",
+    });
+
+    await createWorkflowTraceWithCtx(ctx as never, {
+      storeId,
+      traceId: "repair_order:job-42",
+      workflowType: "repair_order",
+      title: "Repair order JOB-42",
+      status: "succeeded",
+      health: "partial",
+      startedAt: 100,
+      completedAt: 200,
+      primaryLookupType: "reference_number",
+      primaryLookupValue: "JOB-42",
+      summary: "Updated",
+    });
+
+    expect(ctx.tables.workflowTrace).toHaveLength(1);
+    expect(ctx.tables.workflowTrace[0]?.health).toBe("partial");
+    expect(ctx.tables.workflowTrace[0]?.primaryLookupValue).toBe("job-42");
+  });
+
+  it("uses store-scoped sequence assignment when appending events", async () => {
+    const storeA = "store-a" as Id<"store">;
+    const storeB = "store-b" as Id<"store">;
+    const ctx = createTestCtx({
+      workflowTraceEvent: [
+        {
+          _id: "event-1",
+          _creationTime: 1,
+          storeId: storeA,
+          traceId: "repair_order:job-42",
+          workflowType: "repair_order",
+          sequence: 1,
+          kind: "milestone",
+          step: "workflow_started",
+          status: "started",
+          message: "Workflow started",
+          occurredAt: 100,
+          source: "workflow.shared",
+        },
+        {
+          _id: "event-2",
+          _creationTime: 2,
+          storeId: storeB,
+          traceId: "repair_order:job-42",
+          workflowType: "repair_order",
+          sequence: 9,
+          kind: "milestone",
+          step: "workflow_started",
+          status: "started",
+          message: "Other store workflow started",
+          occurredAt: 110,
+          source: "workflow.shared",
+        },
+      ],
+    });
+
+    const eventId = await appendWorkflowTraceEventWithCtx(ctx as never, {
+      storeId: storeA,
+      traceId: "repair_order:job-42",
+      workflowType: "repair_order",
+      kind: "system_action",
+      step: "repair_order_persisted",
+      status: "succeeded",
+      message: "Repair order persisted",
+      occurredAt: 200,
+      source: "workflow.shared",
+    });
+
+    const inserted = ctx.tables.workflowTraceEvent.find(
+      (event) => event._id === eventId,
     );
+
+    expect(inserted?.sequence).toBe(2);
+  });
+
+  it("resolves trace views by id and normalized lookup value without leaking another store's events", async () => {
+    const storeA = "store-a" as Id<"store">;
+    const storeB = "store-b" as Id<"store">;
+    const ctx = createTestCtx();
+
+    await createWorkflowTraceWithCtx(ctx as never, {
+      storeId: storeA,
+      traceId: "repair_order:job-42",
+      workflowType: "repair_order",
+      title: "Repair order JOB-42",
+      status: "succeeded",
+      health: "partial",
+      startedAt: 100,
+      primaryLookupType: "reference_number",
+      primaryLookupValue: "JOB-42",
+    });
+    await createWorkflowTraceWithCtx(ctx as never, {
+      storeId: storeB,
+      traceId: "repair_order:job-42",
+      workflowType: "repair_order",
+      title: "Repair order JOB-42 other store",
+      status: "started",
+      health: "healthy",
+      startedAt: 100,
+      primaryLookupType: "reference_number",
+      primaryLookupValue: "JOB-42",
+    });
+    await registerWorkflowTraceLookupWithCtx(ctx as never, {
+      storeId: storeA,
+      workflowType: "repair_order",
+      lookupType: "reference_number",
+      lookupValue: " JOB-42 ",
+      traceId: "repair_order:job-42",
+    });
+    await appendWorkflowTraceEventWithCtx(ctx as never, {
+      storeId: storeA,
+      traceId: "repair_order:job-42",
+      workflowType: "repair_order",
+      kind: "milestone",
+      step: "workflow_started",
+      status: "started",
+      message: "Workflow started",
+      occurredAt: 100,
+      source: "workflow.shared",
+    });
+    await appendWorkflowTraceEventWithCtx(ctx as never, {
+      storeId: storeA,
+      traceId: "repair_order:job-42",
+      workflowType: "repair_order",
+      kind: "system_action",
+      step: "repair_order_persisted",
+      status: "succeeded",
+      message: "Repair order persisted",
+      occurredAt: 200,
+      source: "workflow.shared",
+    });
+    await appendWorkflowTraceEventWithCtx(ctx as never, {
+      storeId: storeB,
+      traceId: "repair_order:job-42",
+      workflowType: "repair_order",
+      kind: "system_action",
+      step: "other_store_event",
+      status: "info",
+      message: "Other store event",
+      occurredAt: 150,
+      source: "workflow.shared",
+    });
+
+    const byLookup = await getWorkflowTraceViewByLookupWithCtx(ctx as never, {
+      storeId: storeA,
+      workflowType: "repair_order",
+      lookupType: "reference_number",
+      lookupValue: " job-42 ",
+    });
+    const byId = await getWorkflowTraceViewByIdWithCtx(ctx as never, {
+      storeId: storeA,
+      traceId: "repair_order:job-42",
+    });
+
+    expect(byLookup?.header.traceId).toBe("repair_order:job-42");
+    expect(byLookup?.events.map((event) => event.message)).toEqual([
+      "Workflow started",
+      "Repair order persisted",
+    ]);
+    expect(byId?.events.map((event) => event.message)).toEqual([
+      "Workflow started",
+      "Repair order persisted",
+    ]);
   });
 });

--- a/packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts
+++ b/packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+function getSource(relativePath: string) {
+  return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+describe("workflow trace core and public query usage", () => {
+  it("uses indexed trace, event, and lookup access patterns", () => {
+    const coreSource = getSource("./core.ts");
+    const publicSource = getSource("./public.ts");
+
+    expect(coreSource).toContain('.withIndex("by_storeId_traceId"');
+    expect(coreSource).toContain('.withIndex("by_storeId_workflowType_lookup"');
+    expect(coreSource).toContain('.withIndex("by_traceId_sequence"');
+
+    expect(publicSource).toContain('.withIndex("by_storeId_traceId"');
+    expect(publicSource).toContain('.withIndex("by_traceId_sequence"');
+    expect(publicSource).toContain('.withIndex("by_storeId_workflowType_lookup"');
+    expect(publicSource).toContain(
+      "normalizeWorkflowTraceLookupValue(args.lookupValue)",
+    );
+  });
+});

--- a/packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts
+++ b/packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts
@@ -116,10 +116,19 @@ function createTestCtx(seed?: Partial<WorkflowTraceTables>) {
       tables[tableName].push(row as never);
       return Promise.resolve(row._id);
     },
-    patch(id: string, value: Record<string, unknown>) {
-      for (const tableName of Object.keys(tables) as Array<
-        keyof WorkflowTraceTables
-      >) {
+    patch(
+      tableOrId: keyof WorkflowTraceTables | string,
+      idOrValue: string | Record<string, unknown>,
+      maybeValue?: Record<string, unknown>,
+    ) {
+      const tableNames =
+        maybeValue && tableOrId in tables
+          ? [tableOrId as keyof WorkflowTraceTables]
+          : (Object.keys(tables) as Array<keyof WorkflowTraceTables>);
+      const id = (maybeValue ? idOrValue : tableOrId) as string;
+      const value = (maybeValue ?? idOrValue) as Record<string, unknown>;
+
+      for (const tableName of tableNames) {
         const row = tables[tableName].find((entry) => entry._id === id);
 
         if (row) {

--- a/packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts
+++ b/packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts
@@ -23,6 +23,10 @@ describe("workflow trace schema indexes", () => {
       indexDescriptor: "by_traceId_sequence",
       fields: ["traceId", "sequence"],
     });
+    expect(getTableIndexes("workflowTraceEvent")).toContainEqual({
+      indexDescriptor: "by_storeId_traceId_sequence",
+      fields: ["storeId", "traceId", "sequence"],
+    });
     expect(getTableIndexes("workflowTraceLookup")).toContainEqual({
       indexDescriptor: "by_storeId_workflowType_lookup",
       fields: ["storeId", "workflowType", "lookupType", "lookupValue"],

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -20,7 +20,7 @@ This key-folder index highlights the main directories agents are likely to need 
 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 12 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, purchaseOrders.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 322 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 327 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 6 file(s); key children: README.md, SUMMARY.md, pos.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -62,6 +62,8 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/storeFront/returnExchangeOperations.test.ts`](../../convex/storeFront/returnExchangeOperations.test.ts)
 - [`convex/storeFront/storefrontObservabilityReport.test.ts`](../../convex/storeFront/storefrontObservabilityReport.test.ts)
 - [`convex/storeFront/timeQueryRefactors.test.ts`](../../convex/storeFront/timeQueryRefactors.test.ts)
+- [`convex/workflowTraces/presentation.test.ts`](../../convex/workflowTraces/presentation.test.ts)
+- [`convex/workflowTraces/queryUsage.test.ts`](../../convex/workflowTraces/queryUsage.test.ts)
 - [`convex/workflowTraces/schemaIndexes.test.ts`](../../convex/workflowTraces/schemaIndexes.test.ts)
 
 ## Section `src`


### PR DESCRIPTION
## Summary
- harden the workflow trace core helpers around store-scoped trace/event access
- expose reusable query helpers for trace lookup by id and normalized primary lookup
- replace source-string assertions with runtime-style helper tests and register the new event index coverage

## Why
- V26-312 needs the shared query surface to be stable before the route, POS adapter, and link tickets build on it
- the initial pass needed store-scoped event sequencing and stronger regression coverage before merge

## Validation
- bun run --filter '@athena/webapp' test -- convex/workflowTraces/presentation.test.ts convex/workflowTraces/queryUsage.test.ts convex/workflowTraces/schemaIndexes.test.ts
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run --filter '@athena/webapp' lint:convex:changed
- git diff --check
- git push -u origin codex/v26-312-workflow-trace-core

Linear: https://linear.app/v26-labs/issue/V26-312/build-the-workflow-trace-core-helpers-and-public-query-surface