### PR TITLE
[V26-317]: Harden harness auto-repair so generated doc fixes cannot slip past local push and fail CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The repo pins Bun via `package.json` (`bun@1.1.29` today), and GitHub Actions re
 
 `pre-commit:generated-artifacts` automatically runs `bun run graphify:rebuild` and stages the tracked graphify outputs before the commit is finalized, so the pushed ref includes the refreshed graph artifacts.
 `pre-push:review` uses `bun run graphify:check` as a non-mutating freshness gate before the rest of the local validation suite.
-If `harness:self-review` or `harness:review` gets blocked by stale generated harness docs, the hook runs `bun run harness:generate` once and retries the blocked step.
+If `harness:self-review` or `harness:review` gets blocked by stale generated harness docs, the hook runs `bun run harness:generate` once, retries the blocked step on the repaired tree, and then stops so you can commit the repaired generated docs before pushing again.
 
 List runtime behavior scenarios with `bun run harness:behavior --list`.
 Bundled scenarios include:

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -28367,7 +28367,7 @@
       "relation": "calls",
       "source": "pre_push_review_formatblockerlist",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L239",
+      "source_location": "L241",
       "target": "pre_push_review_runprepushreview",
       "weight": 1
     },
@@ -33455,7 +33455,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L406",
+      "source_location": "L414",
       "target": "pre_push_review_test_error",
       "weight": 1
     },
@@ -33467,7 +33467,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L404",
+      "source_location": "L412",
       "target": "pre_push_review_test_log",
       "weight": 1
     },
@@ -33479,7 +33479,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L405",
+      "source_location": "L413",
       "target": "pre_push_review_test_warn",
       "weight": 1
     },
@@ -33491,7 +33491,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L135",
+      "source_location": "L137",
       "target": "pre_push_review_collectrepairableharnessdocerrors",
       "weight": 1
     },
@@ -33503,7 +33503,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L167",
+      "source_location": "L169",
       "target": "pre_push_review_formatblockerlist",
       "weight": 1
     },
@@ -33515,7 +33515,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L48",
+      "source_location": "L50",
       "target": "pre_push_review_getchangedfilesvsoriginmain",
       "weight": 1
     },
@@ -33527,7 +33527,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L89",
+      "source_location": "L91",
       "target": "pre_push_review_runarchitecturecheck",
       "weight": 1
     },
@@ -33539,7 +33539,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L107",
+      "source_location": "L109",
       "target": "pre_push_review_runharnessgenerate",
       "weight": 1
     },
@@ -33551,7 +33551,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L111",
+      "source_location": "L113",
       "target": "pre_push_review_runharnessimplementationtests",
       "weight": 1
     },
@@ -33563,7 +33563,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L123",
+      "source_location": "L125",
       "target": "pre_push_review_runharnessinferentialreview",
       "weight": 1
     },
@@ -33575,7 +33575,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L101",
+      "source_location": "L103",
       "target": "pre_push_review_runharnessselfreview",
       "weight": 1
     },
@@ -33587,7 +33587,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L171",
+      "source_location": "L173",
       "target": "pre_push_review_runprepushreview",
       "weight": 1
     },
@@ -56251,7 +56251,7 @@
       "label": "collectRepairableHarnessDocErrors()",
       "norm_label": "collectrepairableharnessdocerrors()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L135"
+      "source_location": "L137"
     },
     {
       "community": 48,
@@ -56260,7 +56260,7 @@
       "label": "formatBlockerList()",
       "norm_label": "formatblockerlist()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L167"
+      "source_location": "L169"
     },
     {
       "community": 48,
@@ -56269,7 +56269,7 @@
       "label": "getChangedFilesVsOriginMain()",
       "norm_label": "getchangedfilesvsoriginmain()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L48"
+      "source_location": "L50"
     },
     {
       "community": 48,
@@ -56278,7 +56278,7 @@
       "label": "runArchitectureCheck()",
       "norm_label": "runarchitecturecheck()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L89"
+      "source_location": "L91"
     },
     {
       "community": 48,
@@ -56287,7 +56287,7 @@
       "label": "runHarnessGenerate()",
       "norm_label": "runharnessgenerate()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L107"
+      "source_location": "L109"
     },
     {
       "community": 48,
@@ -56296,7 +56296,7 @@
       "label": "runHarnessImplementationTests()",
       "norm_label": "runharnessimplementationtests()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L111"
+      "source_location": "L113"
     },
     {
       "community": 48,
@@ -56305,7 +56305,7 @@
       "label": "runHarnessInferentialReview()",
       "norm_label": "runharnessinferentialreview()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L123"
+      "source_location": "L125"
     },
     {
       "community": 48,
@@ -56314,7 +56314,7 @@
       "label": "runHarnessSelfReview()",
       "norm_label": "runharnessselfreview()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L101"
+      "source_location": "L103"
     },
     {
       "community": 48,
@@ -56323,7 +56323,7 @@
       "label": "runPrePushReview()",
       "norm_label": "runprepushreview()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L171"
+      "source_location": "L173"
     },
     {
       "community": 48,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -28367,7 +28367,7 @@
       "relation": "calls",
       "source": "pre_push_review_formatblockerlist",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L241",
+      "source_location": "L291",
       "target": "pre_push_review_runprepushreview",
       "weight": 1
     },
@@ -33455,7 +33455,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L414",
+      "source_location": "L586",
       "target": "pre_push_review_test_error",
       "weight": 1
     },
@@ -33467,7 +33467,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L412",
+      "source_location": "L584",
       "target": "pre_push_review_test_log",
       "weight": 1
     },
@@ -33479,7 +33479,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L413",
+      "source_location": "L585",
       "target": "pre_push_review_test_warn",
       "weight": 1
     },
@@ -33491,7 +33491,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L137",
+      "source_location": "L145",
       "target": "pre_push_review_collectrepairableharnessdocerrors",
       "weight": 1
     },
@@ -33503,7 +33503,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L169",
+      "source_location": "L177",
       "target": "pre_push_review_formatblockerlist",
       "weight": 1
     },
@@ -33515,7 +33515,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L50",
+      "source_location": "L58",
       "target": "pre_push_review_getchangedfilesvsoriginmain",
       "weight": 1
     },
@@ -33527,7 +33527,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L91",
+      "source_location": "L99",
       "target": "pre_push_review_runarchitecturecheck",
       "weight": 1
     },
@@ -33539,7 +33539,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L109",
+      "source_location": "L117",
       "target": "pre_push_review_runharnessgenerate",
       "weight": 1
     },
@@ -33551,7 +33551,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L113",
+      "source_location": "L121",
       "target": "pre_push_review_runharnessimplementationtests",
       "weight": 1
     },
@@ -33563,7 +33563,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L125",
+      "source_location": "L133",
       "target": "pre_push_review_runharnessinferentialreview",
       "weight": 1
     },
@@ -33575,7 +33575,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L103",
+      "source_location": "L111",
       "target": "pre_push_review_runharnessselfreview",
       "weight": 1
     },
@@ -33587,7 +33587,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L173",
+      "source_location": "L181",
       "target": "pre_push_review_runprepushreview",
       "weight": 1
     },
@@ -56251,7 +56251,7 @@
       "label": "collectRepairableHarnessDocErrors()",
       "norm_label": "collectrepairableharnessdocerrors()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L137"
+      "source_location": "L145"
     },
     {
       "community": 48,
@@ -56260,7 +56260,7 @@
       "label": "formatBlockerList()",
       "norm_label": "formatblockerlist()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L169"
+      "source_location": "L177"
     },
     {
       "community": 48,
@@ -56269,7 +56269,7 @@
       "label": "getChangedFilesVsOriginMain()",
       "norm_label": "getchangedfilesvsoriginmain()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L50"
+      "source_location": "L58"
     },
     {
       "community": 48,
@@ -56278,7 +56278,7 @@
       "label": "runArchitectureCheck()",
       "norm_label": "runarchitecturecheck()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L91"
+      "source_location": "L99"
     },
     {
       "community": 48,
@@ -56287,7 +56287,7 @@
       "label": "runHarnessGenerate()",
       "norm_label": "runharnessgenerate()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L109"
+      "source_location": "L117"
     },
     {
       "community": 48,
@@ -56296,7 +56296,7 @@
       "label": "runHarnessImplementationTests()",
       "norm_label": "runharnessimplementationtests()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L113"
+      "source_location": "L121"
     },
     {
       "community": 48,
@@ -56305,7 +56305,7 @@
       "label": "runHarnessInferentialReview()",
       "norm_label": "runharnessinferentialreview()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L125"
+      "source_location": "L133"
     },
     {
       "community": 48,
@@ -56314,7 +56314,7 @@
       "label": "runHarnessSelfReview()",
       "norm_label": "runharnessselfreview()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L103"
+      "source_location": "L111"
     },
     {
       "community": 48,
@@ -56323,7 +56323,7 @@
       "label": "runPrePushReview()",
       "norm_label": "runprepushreview()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L173"
+      "source_location": "L181"
     },
     {
       "community": 48,

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -238,13 +238,26 @@ describe("pre-push review wiring", () => {
   it("blocks after auto-repairing stale generated docs during harness:self-review until they are committed", async () => {
     const steps: string[] = [];
     let selfReviewRuns = 0;
+    let generatedDocsPending = false;
+    const reviewChangedFiles: string[][] = [];
 
     await expect(
       prePushReview.runPrePushReview(ROOT_DIR, {
         getChangedFiles: async () => {
-          steps.push("changed-files");
+          steps.push("changed-files:base");
           return ["packages/athena-webapp/src/main.tsx"];
         },
+        getChangedFilesForRepairedTree: async () => {
+          steps.push("changed-files:repaired");
+          return [
+            "packages/athena-webapp/src/main.tsx",
+            "packages/athena-webapp/docs/agent/test-index.md",
+          ];
+        },
+        getLocalChangedFiles: async () =>
+          generatedDocsPending
+            ? ["packages/athena-webapp/docs/agent/test-index.md"]
+            : [],
         runGraphifyCheck: async () => {
           steps.push("graphify:check");
         },
@@ -260,12 +273,16 @@ describe("pre-push review wiring", () => {
           "Stale generated harness doc: packages/athena-webapp/docs/agent/test-index.md",
         ],
         runHarnessGenerate: async () => {
+          generatedDocsPending = true;
           steps.push("harness:generate");
         },
         runArchitectureCheck: async () => {
           steps.push("architecture:check");
         },
-        runHarnessReview: async (_rootDir, options) => {
+        runHarnessReview: async (rootDir, options) => {
+          reviewChangedFiles.push(
+            (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? []
+          );
           steps.push(`harness:review:${options.baseRef}`);
         },
         runHarnessInferentialReview: async () => {
@@ -285,11 +302,16 @@ describe("pre-push review wiring", () => {
       "graphify:check",
       "harness:self-review:1",
       "harness:generate",
+      "changed-files:repaired",
       "harness:self-review:2",
       "architecture:check",
-      "changed-files",
       "harness:review:origin/main",
-      "harness:inferential-review",
+    ]);
+    expect(reviewChangedFiles).toEqual([
+      [
+        "packages/athena-webapp/src/main.tsx",
+        "packages/athena-webapp/docs/agent/test-index.md",
+      ],
     ]);
   });
 
@@ -338,13 +360,26 @@ describe("pre-push review wiring", () => {
   it("blocks after auto-repairing stale generated docs during harness:review until they are committed", async () => {
     const steps: string[] = [];
     let reviewRuns = 0;
+    let generatedDocsPending = false;
+    const reviewChangedFiles: string[][] = [];
 
     await expect(
       prePushReview.runPrePushReview(ROOT_DIR, {
         getChangedFiles: async () => {
-          steps.push("changed-files");
+          steps.push("changed-files:base");
           return ["packages/athena-webapp/src/main.tsx"];
         },
+        getChangedFilesForRepairedTree: async () => {
+          steps.push("changed-files:repaired");
+          return [
+            "packages/athena-webapp/src/main.tsx",
+            "packages/athena-webapp/docs/agent/validation-map.json",
+          ];
+        },
+        getLocalChangedFiles: async () =>
+          generatedDocsPending
+            ? ["packages/athena-webapp/docs/agent/validation-map.json"]
+            : [],
         runGraphifyCheck: async () => {
           steps.push("graphify:check");
         },
@@ -355,8 +390,11 @@ describe("pre-push review wiring", () => {
         runArchitectureCheck: async () => {
           steps.push("architecture:check");
         },
-        runHarnessReview: async (_rootDir, options) => {
+        runHarnessReview: async (rootDir, options) => {
           reviewRuns += 1;
+          reviewChangedFiles.push(
+            (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? []
+          );
           steps.push(`harness:review:${options.baseRef}:${reviewRuns}`);
           if (reviewRuns === 1) {
             throw new Error("harness review drift");
@@ -366,6 +404,7 @@ describe("pre-push review wiring", () => {
           "Missing required harness file: packages/athena-webapp/docs/agent/validation-map.json",
         ],
         runHarnessGenerate: async () => {
+          generatedDocsPending = true;
           steps.push("harness:generate");
         },
         runHarnessInferentialReview: async () => {
@@ -385,12 +424,145 @@ describe("pre-push review wiring", () => {
       "graphify:check",
       "harness:self-review",
       "architecture:check",
-      "changed-files",
+      "changed-files:base",
       "harness:review:origin/main:1",
       "harness:generate",
+      "changed-files:repaired",
       "harness:review:origin/main:2",
-      "harness:inferential-review",
     ]);
+    expect(reviewChangedFiles).toEqual([
+      ["packages/athena-webapp/src/main.tsx"],
+      [
+        "packages/athena-webapp/src/main.tsx",
+        "packages/athena-webapp/docs/agent/validation-map.json",
+      ],
+    ]);
+  });
+
+  it("blocks when generated harness docs are already locally modified from a prior repair run", async () => {
+    const steps: string[] = [];
+    const reviewChangedFiles: string[][] = [];
+
+    await expect(
+      prePushReview.runPrePushReview(ROOT_DIR, {
+        getChangedFiles: async () => {
+          steps.push("changed-files:base");
+          return ["packages/athena-webapp/src/main.tsx"];
+        },
+        getChangedFilesForRepairedTree: async () => {
+          steps.push("changed-files:repaired");
+          return [
+            "packages/athena-webapp/src/main.tsx",
+            "packages/athena-webapp/docs/agent/test-index.md",
+          ];
+        },
+        getLocalChangedFiles: async () => [
+          "packages/athena-webapp/docs/agent/test-index.md",
+        ],
+        runGraphifyCheck: async () => {
+          steps.push("graphify:check");
+        },
+        runHarnessSelfReview: async () => {
+          steps.push("harness:self-review");
+          return { blockers: [] };
+        },
+        runArchitectureCheck: async () => {
+          steps.push("architecture:check");
+        },
+        runHarnessReview: async (rootDir, options) => {
+          reviewChangedFiles.push(
+            (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? []
+          );
+          steps.push(`harness:review:${options.baseRef}`);
+        },
+        runHarnessInferentialReview: async () => {
+          steps.push("harness:inferential-review");
+        },
+        logger: {
+          log() {},
+          warn() {},
+          error() {},
+        },
+      } as any)
+    ).rejects.toThrow(
+      "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again."
+    );
+
+    expect(steps).toEqual([
+      "graphify:check",
+      "harness:self-review",
+      "changed-files:repaired",
+      "architecture:check",
+      "harness:review:origin/main",
+    ]);
+    expect(reviewChangedFiles).toEqual([
+      [
+        "packages/athena-webapp/src/main.tsx",
+        "packages/athena-webapp/docs/agent/test-index.md",
+      ],
+    ]);
+  });
+
+  it("falls back to local working tree changes when repaired-doc diffing against origin/main fails", async () => {
+    const steps: string[] = [];
+    const warnings: string[] = [];
+    const reviewChangedFiles: string[][] = [];
+
+    await expect(
+      prePushReview.runPrePushReview(ROOT_DIR, {
+        getChangedFilesForRepairedTree: async () => {
+          throw new Error("Base ref check failed for origin/main: missing ref");
+        },
+        getLocalChangedFiles: async () => {
+          steps.push("changed-files:local");
+          return ["packages/athena-webapp/docs/agent/test-index.md"];
+        },
+        runGraphifyCheck: async () => {
+          steps.push("graphify:check");
+        },
+        runHarnessSelfReview: async () => {
+          steps.push("harness:self-review");
+          return { blockers: [] };
+        },
+        runArchitectureCheck: async () => {
+          steps.push("architecture:check");
+        },
+        runHarnessReview: async (rootDir, options) => {
+          reviewChangedFiles.push(
+            (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? []
+          );
+          steps.push(`harness:review:${options.baseRef}`);
+        },
+        runHarnessInferentialReview: async () => {
+          steps.push("harness:inferential-review");
+        },
+        logger: {
+          log() {},
+          warn(message: string) {
+            warnings.push(message);
+          },
+          error() {},
+        },
+      } as any)
+    ).rejects.toThrow(
+      "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again."
+    );
+
+    expect(steps).toEqual([
+      "graphify:check",
+      "harness:self-review",
+      "changed-files:local",
+      "changed-files:local",
+      "architecture:check",
+      "harness:review:origin/main",
+      "changed-files:local",
+    ]);
+    expect(reviewChangedFiles).toEqual([
+      ["packages/athena-webapp/docs/agent/test-index.md"],
+    ]);
+    expect(warnings[0]).toContain(
+      "Falling back to local working tree changes"
+    );
   });
 
   it("does not pass the base ref into default-style changed-file helpers", async () => {

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -235,47 +235,51 @@ describe("pre-push review wiring", () => {
     ]);
   });
 
-  it("auto-repairs stale generated harness docs after harness:self-review blockers and retries once", async () => {
+  it("blocks after auto-repairing stale generated docs during harness:self-review until they are committed", async () => {
     const steps: string[] = [];
     let selfReviewRuns = 0;
 
-    await prePushReview.runPrePushReview(ROOT_DIR, {
-      getChangedFiles: async () => {
-        steps.push("changed-files");
-        return ["packages/athena-webapp/src/main.tsx"];
-      },
-      runGraphifyCheck: async () => {
-        steps.push("graphify:check");
-      },
-      runHarnessSelfReview: async () => {
-        selfReviewRuns += 1;
-        steps.push(`harness:self-review:${selfReviewRuns}`);
-        return {
-          blockers:
-            selfReviewRuns === 1 ? ["harness:check failed: generated docs drift"] : [],
-        };
-      },
-      validateHarnessDocs: async () => [
-        "Stale generated harness doc: packages/athena-webapp/docs/agent/test-index.md",
-      ],
-      runHarnessGenerate: async () => {
-        steps.push("harness:generate");
-      },
-      runArchitectureCheck: async () => {
-        steps.push("architecture:check");
-      },
-      runHarnessReview: async (_rootDir, options) => {
-        steps.push(`harness:review:${options.baseRef}`);
-      },
-      runHarnessInferentialReview: async () => {
-        steps.push("harness:inferential-review");
-      },
-      logger: {
-        log() {},
-        warn() {},
-        error() {},
-      },
-    } as any);
+    await expect(
+      prePushReview.runPrePushReview(ROOT_DIR, {
+        getChangedFiles: async () => {
+          steps.push("changed-files");
+          return ["packages/athena-webapp/src/main.tsx"];
+        },
+        runGraphifyCheck: async () => {
+          steps.push("graphify:check");
+        },
+        runHarnessSelfReview: async () => {
+          selfReviewRuns += 1;
+          steps.push(`harness:self-review:${selfReviewRuns}`);
+          return {
+            blockers:
+              selfReviewRuns === 1 ? ["harness:check failed: generated docs drift"] : [],
+          };
+        },
+        validateHarnessDocs: async () => [
+          "Stale generated harness doc: packages/athena-webapp/docs/agent/test-index.md",
+        ],
+        runHarnessGenerate: async () => {
+          steps.push("harness:generate");
+        },
+        runArchitectureCheck: async () => {
+          steps.push("architecture:check");
+        },
+        runHarnessReview: async (_rootDir, options) => {
+          steps.push(`harness:review:${options.baseRef}`);
+        },
+        runHarnessInferentialReview: async () => {
+          steps.push("harness:inferential-review");
+        },
+        logger: {
+          log() {},
+          warn() {},
+          error() {},
+        },
+      } as any)
+    ).rejects.toThrow(
+      "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again."
+    );
 
     expect(steps).toEqual([
       "graphify:check",
@@ -331,47 +335,51 @@ describe("pre-push review wiring", () => {
     expect(steps).toEqual(["graphify:check", "harness:self-review"]);
   });
 
-  it("auto-repairs stale generated harness docs after harness:review fails and retries once", async () => {
+  it("blocks after auto-repairing stale generated docs during harness:review until they are committed", async () => {
     const steps: string[] = [];
     let reviewRuns = 0;
 
-    await prePushReview.runPrePushReview(ROOT_DIR, {
-      getChangedFiles: async () => {
-        steps.push("changed-files");
-        return ["packages/athena-webapp/src/main.tsx"];
-      },
-      runGraphifyCheck: async () => {
-        steps.push("graphify:check");
-      },
-      runHarnessSelfReview: async () => {
-        steps.push("harness:self-review");
-        return { blockers: [] };
-      },
-      runArchitectureCheck: async () => {
-        steps.push("architecture:check");
-      },
-      runHarnessReview: async (_rootDir, options) => {
-        reviewRuns += 1;
-        steps.push(`harness:review:${options.baseRef}:${reviewRuns}`);
-        if (reviewRuns === 1) {
-          throw new Error("harness review drift");
-        }
-      },
-      validateHarnessDocs: async () => [
-        "Missing required harness file: packages/athena-webapp/docs/agent/validation-map.json",
-      ],
-      runHarnessGenerate: async () => {
-        steps.push("harness:generate");
-      },
-      runHarnessInferentialReview: async () => {
-        steps.push("harness:inferential-review");
-      },
-      logger: {
-        log() {},
-        warn() {},
-        error() {},
-      },
-    } as any);
+    await expect(
+      prePushReview.runPrePushReview(ROOT_DIR, {
+        getChangedFiles: async () => {
+          steps.push("changed-files");
+          return ["packages/athena-webapp/src/main.tsx"];
+        },
+        runGraphifyCheck: async () => {
+          steps.push("graphify:check");
+        },
+        runHarnessSelfReview: async () => {
+          steps.push("harness:self-review");
+          return { blockers: [] };
+        },
+        runArchitectureCheck: async () => {
+          steps.push("architecture:check");
+        },
+        runHarnessReview: async (_rootDir, options) => {
+          reviewRuns += 1;
+          steps.push(`harness:review:${options.baseRef}:${reviewRuns}`);
+          if (reviewRuns === 1) {
+            throw new Error("harness review drift");
+          }
+        },
+        validateHarnessDocs: async () => [
+          "Missing required harness file: packages/athena-webapp/docs/agent/validation-map.json",
+        ],
+        runHarnessGenerate: async () => {
+          steps.push("harness:generate");
+        },
+        runHarnessInferentialReview: async () => {
+          steps.push("harness:inferential-review");
+        },
+        logger: {
+          log() {},
+          warn() {},
+          error() {},
+        },
+      } as any)
+    ).rejects.toThrow(
+      "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again."
+    );
 
     expect(steps).toEqual([
       "graphify:check",
@@ -495,7 +503,7 @@ describe("repo harness ergonomics", () => {
       "`pre-commit:generated-artifacts` automatically runs `bun run graphify:rebuild`"
     );
     expect(readme).toContain(
-      "runs `bun run harness:generate` once and retries the blocked step"
+      "runs `bun run harness:generate` once, retries the blocked step on the repaired tree, and then stops"
     );
     expect(readme).toContain("`pre-push:review` uses `bun run graphify:check`");
     expect(readme).toContain("bun run graphify:check");

--- a/scripts/pre-push-review.ts
+++ b/scripts/pre-push-review.ts
@@ -11,6 +11,8 @@ const BASE_REF = "origin/main";
 const GENERATED_HARNESS_DOC_PATHS = new Set(
   HARNESS_APP_REGISTRY.flatMap((app) => app.harnessDocs.generatedDocs)
 );
+const REPAIRED_DOCS_COMMIT_BLOCKER =
+  "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again.";
 
 type SpawnedProcess = {
   exited: Promise<number>;
@@ -282,6 +284,13 @@ export async function runPrePushReview(
   } else {
     logger.log("[pre-push] Step 6/6: harness:inferential-review");
     await runInferentialReview(rootDir);
+  }
+
+  if (repairedGeneratedHarnessDocs) {
+    logger.log(
+      "\n[pre-push] Generated harness docs were repaired and revalidated locally."
+    );
+    throw new Error(REPAIRED_DOCS_COMMIT_BLOCKER);
   }
 
   logger.log("\n[pre-push] All checks passed.");

--- a/scripts/pre-push-review.ts
+++ b/scripts/pre-push-review.ts
@@ -4,7 +4,10 @@ import { writeGeneratedHarnessDocs } from "./harness-generate";
 import { runGraphifyCheck } from "./graphify-check";
 import { collectHarnessRepoValidationSelection } from "./harness-repo-validation";
 import { runHarnessSelfReview as runStructuredHarnessSelfReview } from "./harness-self-review";
-import { runHarnessReview } from "./harness-review";
+import {
+  getChangedFilesForHarnessReview,
+  runHarnessReview,
+} from "./harness-review";
 
 const ROOT_DIR = process.cwd();
 const BASE_REF = "origin/main";
@@ -28,6 +31,11 @@ type HarnessSelfReviewSummary = {
 
 type PrePushReviewOptions = {
   getChangedFiles?: (rootDir: string) => Promise<string[]>;
+  getChangedFilesForRepairedTree?: (
+    rootDir: string,
+    baseRef: string
+  ) => Promise<string[]>;
+  getLocalChangedFiles?: (rootDir: string) => Promise<string[]>;
   runGraphifyCheck?: (rootDir: string) => Promise<void>;
   runArchitectureCheck?: (rootDir: string) => Promise<void>;
   runHarnessInferentialReview?: (rootDir: string) => Promise<void>;
@@ -176,6 +184,13 @@ export async function runPrePushReview(
 ) {
   const logger = options.logger ?? console;
   const getChangedFiles = options.getChangedFiles ?? getChangedFilesVsOriginMain;
+  const getChangedFilesForRepairedTree =
+    options.getChangedFilesForRepairedTree ??
+    ((nextRootDir: string, baseRef: string) =>
+      getChangedFilesForHarnessReview(nextRootDir, baseRef));
+  const getLocalChangedFiles =
+    options.getLocalChangedFiles ??
+    ((nextRootDir: string) => getChangedFilesForHarnessReview(nextRootDir));
   const runGraphifyFreshnessCheck =
     options.runGraphifyCheck ?? runGraphifyCheck;
   const runArchitecture = options.runArchitectureCheck ?? runArchitectureCheck;
@@ -189,18 +204,52 @@ export async function runPrePushReview(
     options.validateHarnessDocs ?? validateHarnessDocs;
   let changedFilesPromise: Promise<string[]> | undefined;
   let repairedGeneratedHarnessDocs = false;
+  let usingWorkingTreeChangedFiles = false;
 
   const loadChangedFiles = () => {
     changedFilesPromise ??= getChangedFiles(rootDir);
     return changedFilesPromise;
   };
 
-  const getChangedFilesForHarnessReview = async (nextRootDir: string) => {
+  const getChangedFilesForReviewStep = async (nextRootDir: string) => {
     if (nextRootDir === rootDir) {
       return loadChangedFiles();
     }
 
     return getChangedFiles(nextRootDir);
+  };
+
+  const refreshChangedFilesForWorkingTree = () => {
+    if (usingWorkingTreeChangedFiles) {
+      return changedFilesPromise ?? Promise.resolve([]);
+    }
+
+    changedFilesPromise = (async () => {
+      try {
+        return await getChangedFilesForRepairedTree(rootDir, BASE_REF);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn(
+          `[pre-push] Warning: unable to diff repaired generated docs against ${BASE_REF}. Falling back to local working tree changes. (${message})`
+        );
+        return getLocalChangedFiles(rootDir);
+      }
+    })();
+    usingWorkingTreeChangedFiles = true;
+    return changedFilesPromise;
+  };
+
+  const getPendingGeneratedHarnessDocs = async () => {
+    const localChangedFiles = await getLocalChangedFiles(rootDir);
+    const pendingGeneratedDocs = localChangedFiles.filter((filePath) =>
+      GENERATED_HARNESS_DOC_PATHS.has(filePath)
+    );
+
+    if (pendingGeneratedDocs.length > 0) {
+      refreshChangedFilesForWorkingTree();
+    }
+
+    return pendingGeneratedDocs;
   };
 
   const maybeRepairGeneratedHarnessDocs = async (reason: string) => {
@@ -217,6 +266,7 @@ export async function runPrePushReview(
 
     logger.log(`[pre-push] Auto-repair: harness:generate (${reason})`);
     await runHarnessGenerateStep(rootDir);
+    await getPendingGeneratedHarnessDocs();
     repairedGeneratedHarnessDocs = true;
     return true;
   };
@@ -242,6 +292,8 @@ export async function runPrePushReview(
     );
   }
 
+  await getPendingGeneratedHarnessDocs();
+
   logger.log("[pre-push] Step 3/6: architecture:check");
   await runArchitecture(rootDir);
 
@@ -261,7 +313,7 @@ export async function runPrePushReview(
   try {
     await review(rootDir, {
       baseRef: BASE_REF,
-      getChangedFiles: getChangedFilesForHarnessReview,
+      getChangedFiles: getChangedFilesForReviewStep,
     });
   } catch (error) {
     const repaired = await maybeRepairGeneratedHarnessDocs(
@@ -273,11 +325,14 @@ export async function runPrePushReview(
 
     await review(rootDir, {
       baseRef: BASE_REF,
-      getChangedFiles: getChangedFilesForHarnessReview,
+      getChangedFiles: getChangedFilesForReviewStep,
     });
   }
 
-  if (repoValidation.matchedFiles.length > 0) {
+  const finalChangedFiles = await loadChangedFiles();
+  const finalRepoValidation = collectHarnessRepoValidationSelection(finalChangedFiles);
+
+  if (finalRepoValidation.matchedFiles.length > 0) {
     logger.log(
       "[pre-push] Step 6/6: harness:inferential-review skipped (repo harness validations already ran in harness:review)"
     );
@@ -286,7 +341,9 @@ export async function runPrePushReview(
     await runInferentialReview(rootDir);
   }
 
-  if (repairedGeneratedHarnessDocs) {
+  const pendingGeneratedHarnessDocs = await getPendingGeneratedHarnessDocs();
+
+  if (repairedGeneratedHarnessDocs || pendingGeneratedHarnessDocs.length > 0) {
     logger.log(
       "\n[pre-push] Generated harness docs were repaired and revalidated locally."
     );


### PR DESCRIPTION
## Summary
- block pre-push success when generated harness docs are locally repaired but not yet committed
- revalidate repaired working-tree docs with the same changed-file selection the next push will use
- add regressions for same-run repair, prior-run pending docs, and unreachable-base fallback behavior

## Why
- V26-311 exposed a gap where local pre-push auto-repair could fix generated harness docs without those fixes being committed, which then let CI fail on the PR branch
- this ticket makes the repaired local state explicit and safe instead of letting stale generated docs slip through

## Validation
- bun test scripts/pre-push-review.test.ts
- bun run harness:test
- git diff --check
- git push -u origin codex/v26-317-harness-auto-repair

Linear: https://linear.app/v26-labs/issue/V26-317/harden-harness-auto-repair-so-generated-doc-fixes-cannot-slip-past