### PR TITLE
[V26-318]: Extend harness auto-repair coverage to all generated Athena agent docs

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -33983,7 +33983,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L586",
+      "source_location": "L591",
       "target": "pre_push_review_test_error",
       "weight": 1
     },
@@ -33995,7 +33995,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L584",
+      "source_location": "L589",
       "target": "pre_push_review_test_log",
       "weight": 1
     },
@@ -34007,7 +34007,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L585",
+      "source_location": "L590",
       "target": "pre_push_review_test_warn",
       "weight": 1
     },
@@ -48601,7 +48601,7 @@
       "label": "error()",
       "norm_label": "error()",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L90"
+      "source_location": "L95"
     },
     {
       "community": 231,
@@ -48610,7 +48610,7 @@
       "label": "log()",
       "norm_label": "log()",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L88"
+      "source_location": "L93"
     },
     {
       "community": 231,
@@ -48619,7 +48619,7 @@
       "label": "warn()",
       "norm_label": "warn()",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L89"
+      "source_location": "L94"
     },
     {
       "community": 231,

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -5,6 +5,11 @@ import { describe, expect, it } from "vitest";
 import * as prePushReview from "./pre-push-review";
 
 const ROOT_DIR = path.resolve(import.meta.dirname, "..");
+const ATHENA_GENERATED_DOC_PATHS = [
+  "packages/athena-webapp/docs/agent/route-index.md",
+  "packages/athena-webapp/docs/agent/test-index.md",
+  "packages/athena-webapp/docs/agent/key-folder-index.md",
+] as const;
 
 describe("pre-push review wiring", () => {
   it("exports testable helpers for pre-push orchestration", () => {
@@ -235,85 +240,85 @@ describe("pre-push review wiring", () => {
     ]);
   });
 
-  it("blocks after auto-repairing stale generated docs during harness:self-review until they are committed", async () => {
-    const steps: string[] = [];
-    let selfReviewRuns = 0;
-    let generatedDocsPending = false;
-    const reviewChangedFiles: string[][] = [];
+  it.each(ATHENA_GENERATED_DOC_PATHS)(
+    "blocks after auto-repairing stale Athena generated docs (%s) during harness:self-review until they are committed",
+    async (generatedDocPath) => {
+      const steps: string[] = [];
+      let selfReviewRuns = 0;
+      let generatedDocsPending = false;
+      const reviewChangedFiles: string[][] = [];
 
-    await expect(
-      prePushReview.runPrePushReview(ROOT_DIR, {
-        getChangedFiles: async () => {
-          steps.push("changed-files:base");
-          return ["packages/athena-webapp/src/main.tsx"];
-        },
-        getChangedFilesForRepairedTree: async () => {
-          steps.push("changed-files:repaired");
-          return [
-            "packages/athena-webapp/src/main.tsx",
-            "packages/athena-webapp/docs/agent/test-index.md",
-          ];
-        },
-        getLocalChangedFiles: async () =>
-          generatedDocsPending
-            ? ["packages/athena-webapp/docs/agent/test-index.md"]
-            : [],
-        runGraphifyCheck: async () => {
-          steps.push("graphify:check");
-        },
-        runHarnessSelfReview: async () => {
-          selfReviewRuns += 1;
-          steps.push(`harness:self-review:${selfReviewRuns}`);
-          return {
-            blockers:
-              selfReviewRuns === 1 ? ["harness:check failed: generated docs drift"] : [],
-          };
-        },
-        validateHarnessDocs: async () => [
-          "Stale generated harness doc: packages/athena-webapp/docs/agent/test-index.md",
-        ],
-        runHarnessGenerate: async () => {
-          generatedDocsPending = true;
-          steps.push("harness:generate");
-        },
-        runArchitectureCheck: async () => {
-          steps.push("architecture:check");
-        },
-        runHarnessReview: async (rootDir, options) => {
-          reviewChangedFiles.push(
-            (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? []
-          );
-          steps.push(`harness:review:${options.baseRef}`);
-        },
-        runHarnessInferentialReview: async () => {
-          steps.push("harness:inferential-review");
-        },
-        logger: {
-          log() {},
-          warn() {},
-          error() {},
-        },
-      } as any)
-    ).rejects.toThrow(
-      "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again."
-    );
+      await expect(
+        prePushReview.runPrePushReview(ROOT_DIR, {
+          getChangedFiles: async () => {
+            steps.push("changed-files:base");
+            return ["packages/athena-webapp/src/main.tsx"];
+          },
+          getChangedFilesForRepairedTree: async () => {
+            steps.push("changed-files:repaired");
+            return [
+              "packages/athena-webapp/src/main.tsx",
+              generatedDocPath,
+            ];
+          },
+          getLocalChangedFiles: async () =>
+            generatedDocsPending ? [generatedDocPath] : [],
+          runGraphifyCheck: async () => {
+            steps.push("graphify:check");
+          },
+          runHarnessSelfReview: async () => {
+            selfReviewRuns += 1;
+            steps.push(`harness:self-review:${selfReviewRuns}`);
+            return {
+              blockers:
+                selfReviewRuns === 1
+                  ? ["harness:check failed: generated docs drift"]
+                  : [],
+            };
+          },
+          validateHarnessDocs: async () => [
+            `Stale generated harness doc: ${generatedDocPath}`,
+          ],
+          runHarnessGenerate: async () => {
+            generatedDocsPending = true;
+            steps.push("harness:generate");
+          },
+          runArchitectureCheck: async () => {
+            steps.push("architecture:check");
+          },
+          runHarnessReview: async (rootDir, options) => {
+            reviewChangedFiles.push(
+              (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? []
+            );
+            steps.push(`harness:review:${options.baseRef}`);
+          },
+          runHarnessInferentialReview: async () => {
+            steps.push("harness:inferential-review");
+          },
+          logger: {
+            log() {},
+            warn() {},
+            error() {},
+          },
+        } as any)
+      ).rejects.toThrow(
+        "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again."
+      );
 
-    expect(steps).toEqual([
-      "graphify:check",
-      "harness:self-review:1",
-      "harness:generate",
-      "changed-files:repaired",
-      "harness:self-review:2",
-      "architecture:check",
-      "harness:review:origin/main",
-    ]);
-    expect(reviewChangedFiles).toEqual([
-      [
-        "packages/athena-webapp/src/main.tsx",
-        "packages/athena-webapp/docs/agent/test-index.md",
-      ],
-    ]);
-  });
+      expect(steps).toEqual([
+        "graphify:check",
+        "harness:self-review:1",
+        "harness:generate",
+        "changed-files:repaired",
+        "harness:self-review:2",
+        "architecture:check",
+        "harness:review:origin/main",
+      ]);
+      expect(reviewChangedFiles).toEqual([
+        ["packages/athena-webapp/src/main.tsx", generatedDocPath],
+      ]);
+    }
+  );
 
   it("blocks when harness:self-review reports non-repairable blockers", async () => {
     const steps: string[] = [];


### PR DESCRIPTION
## Summary
- broaden the pre-push stale-doc regression to cover Athena's generated `route-index.md`, `test-index.md`, and `key-folder-index.md`
- prove the repaired-tree change set includes each generated doc before the push path returns the commit blocker
- refresh Graphify artifacts after the new regression coverage

## Why
- `V26-313` and `V26-314` showed that Athena route, test, and key-folder edits can drift generated agent docs before CI catches them
- the pre-push logic on `origin/main` already blocks that drift, but the regression only named `test-index.md`
- parameterizing the regression over the historical doc set keeps the guard honest for the exact failure modes that prompted `V26-318`

## Validation
- `bun test scripts/pre-push-review.test.ts`
- `bun run harness:test`
- `bun run graphify:check`
- `git diff --check`

https://linear.app/v26-labs/issue/V26-318/extend-harness-auto-repair-coverage-to-all-generated-athena-agent-docs
