### PR TITLE
[V26-319]: Close local parity gap for harness inferential review on repo-level script changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Key repo-level commands:
 - `bun run pr:athena`
 - `bun run graphify:check`
 
+For repo-harness edits such as `scripts/harness-app-registry.ts`, keep
+`bun run harness:review --base origin/main` and
+`bun run harness:inferential-review` in the local ladder so a missing sibling
+test update like `scripts/harness-app-registry.test.ts` fails before push.
+
 `bun run harness:test` is the canonical harness implementation gate for harness scripts, graphify tooling, and pre-push review wiring.
 It targets repo-root `scripts/*.test.ts` files only (excluding cloned worktree trees).
 Use `bun run harness:test -- --dry-run` to print the selected files without executing tests.

--- a/scripts/harness-inferential-review.test.ts
+++ b/scripts/harness-inferential-review.test.ts
@@ -312,6 +312,26 @@ describe("runHarnessInferentialReview", () => {
     expect(result.humanReport).toContain("Harness script changed without test update");
   });
 
+  it("fails when scripts/harness-app-registry.ts changes without scripts/harness-app-registry.test.ts", async () => {
+    const rootDir = await createFixtureRepo();
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => ["scripts/harness-app-registry.ts"],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.status).toBe("fail");
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "missing-harness-script-test-update-scripts-harness-app-registry-ts",
+        severity: "medium",
+        filePath: "scripts/harness-app-registry.ts",
+      })
+    );
+    expect(result.humanReport).toContain("scripts/harness-app-registry.test.ts");
+  });
+
   it("fails when the PR workflow omits semantic shadow mode on inferential review", async () => {
     const rootDir = await createFixtureRepo();
     await write(


### PR DESCRIPTION
## Summary
- add an inferential-review regression for `scripts/harness-app-registry.ts` changing without `scripts/harness-app-registry.test.ts`
- document the repo-harness local validation ladder in the README so `harness:review --base origin/main` and `harness:inferential-review` stay in the pre-publish path
- keep Graphify artifacts current after the repo-harness test change

## Why
- PR #209 showed that repo-level harness script edits could look locally green when the validation ladder skipped the inferential gate CI still enforced
- the inferential implementation already knew how to flag the missing sibling test; what was missing was an explicit regression for this script and clearer local guidance
- this closes that gap before the next repo-harness script change reaches CI

## Validation
- `bun test scripts/harness-inferential-review.test.ts`
- `bun run harness:test`
- `bun run graphify:check`
- `git diff --check`

https://linear.app/v26-labs/issue/V26-319/close-local-parity-gap-for-harness-inferential-review-on-repo-level
