### PR TITLE
[codex] Ignore .playwright-cli workspace state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,7 @@ packages/.claude/worktrees/
 /worktrees/
 /.worktrees/
 .dual-graph/
+.playwright-cli/
 graphify-out/cache/
 artifacts/harness-inferential-review/
 artifacts/harness-scorecard/


### PR DESCRIPTION
## Summary
- ignore the local `.playwright-cli/` workspace directory at the repo root

## Why
This directory is local tool state and should not keep showing up as untracked repo noise.

## Validation
- `git check-ignore -v .playwright-cli/`
- `git diff --check -- .gitignore`
- `git push -u origin codex/gitignore-playwright-cli` (includes `pre-push:review`)
