### PR TITLE
[V26-329]: Bind POS sale sessions to register sessions and carry the drawer id through checkout

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3623 nodes · 3101 edges · 1386 communities detected
+- 3633 nodes · 3120 edges · 1386 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1472,52 +1472,52 @@ Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.13
-Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
+Cohesion: 0.21
+Nodes (16): buildCompleteTransactionResult(), buildPosSaleTraceEvent(), buildPosSaleTraceRecord(), calculateTotalPaid(), completeTransaction(), createTransactionFromSessionHandler(), isUsableRegisterSession(), normalizeRegisterNumber() (+8 more)
 
 ### Community 13 - "Community 13"
+Cohesion: 0.2
+Nodes (16): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), normalizeRegisterNumber(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding() (+8 more)
+
+### Community 14 - "Community 14"
+Cohesion: 0.12
+Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
+
+### Community 15 - "Community 15"
 Cohesion: 0.16
 Nodes (9): checkIfItemsHaveChanged(), createOnlineOrder(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems(), updateExistingSession() (+1 more)
 
-### Community 14 - "Community 14"
+### Community 16 - "Community 16"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 15 - "Community 15"
+### Community 17 - "Community 17"
 Cohesion: 0.12
 Nodes (0):
 
-### Community 16 - "Community 16"
+### Community 18 - "Community 18"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 17 - "Community 17"
+### Community 19 - "Community 19"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 18 - "Community 18"
+### Community 20 - "Community 20"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 19 - "Community 19"
+### Community 21 - "Community 21"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 20 - "Community 20"
+### Community 22 - "Community 22"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 21 - "Community 21"
+### Community 23 - "Community 23"
 Cohesion: 0.23
 Nodes (12): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionTransactionPatch() (+4 more)
-
-### Community 22 - "Community 22"
-Cohesion: 0.27
-Nodes (12): buildCompleteTransactionResult(), buildPosSaleTraceEvent(), buildPosSaleTraceRecord(), calculateTotalPaid(), completeTransaction(), createTransactionFromSessionHandler(), persistWorkflowTraceIdBestEffort(), recordPosSaleTraceBestEffort() (+4 more)
-
-### Community 23 - "Community 23"
-Cohesion: 0.25
-Nodes (12): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isSessionExpired(), runHoldSessionCommand(), runRemoveSessionItemCommand(), runResumeSessionCommand(), runStartSessionCommand() (+4 more)
 
 ### Community 24 - "Community 24"
 Cohesion: 0.13
@@ -1665,67 +1665,67 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 60 - "Community 60"
 Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
 ### Community 61 - "Community 61"
 Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
 ### Community 62 - "Community 62"
-Cohesion: 0.43
-Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 63 - "Community 63"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 64 - "Community 64"
+Cohesion: 0.43
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+
+### Community 65 - "Community 65"
 Cohesion: 0.36
 Nodes (4): buildPendingSkuContextById(), listPurchaseOrderLineItems(), listReplenishmentRecommendationsWithCtx(), listStoreProductSkus()
 
-### Community 65 - "Community 65"
-Cohesion: 0.25
-Nodes (1): DataTableRowActions()
-
 ### Community 66 - "Community 66"
 Cohesion: 0.25
-Nodes (0):
+Nodes (1): DataTableRowActions()
 
 ### Community 67 - "Community 67"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 68 - "Community 68"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 69 - "Community 69"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 70 - "Community 70"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 69 - "Community 69"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 70 - "Community 70"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 71 - "Community 71"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 72 - "Community 72"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.52
 Nodes (5): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), releaseInventoryHold(), validateInventoryAvailability()
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.52
 Nodes (5): buildTraceEvent(), buildTraceRecord(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
-
-### Community 75 - "Community 75"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 76 - "Community 76"
 Cohesion: 0.48
@@ -1776,16 +1776,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 88 - "Community 88"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 89 - "Community 89"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 90 - "Community 90"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 91 - "Community 91"
 Cohesion: 0.52
@@ -2132,44 +2132,44 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 177 - "Community 177"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
-
-### Community 178 - "Community 178"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 179 - "Community 179"
+### Community 178 - "Community 178"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 180 - "Community 180"
+### Community 179 - "Community 179"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 181 - "Community 181"
+### Community 180 - "Community 180"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 182 - "Community 182"
+### Community 181 - "Community 181"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 183 - "Community 183"
+### Community 182 - "Community 182"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 184 - "Community 184"
+### Community 183 - "Community 183"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 185 - "Community 185"
+### Community 184 - "Community 184"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 186 - "Community 186"
+### Community 185 - "Community 185"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+
+### Community 186 - "Community 186"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 187 - "Community 187"
 Cohesion: 0.5
@@ -2180,16 +2180,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 189 - "Community 189"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 190 - "Community 190"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 191 - "Community 191"
+### Community 190 - "Community 190"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+
+### Community 191 - "Community 191"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 192 - "Community 192"
 Cohesion: 0.5
@@ -2212,24 +2212,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 197 - "Community 197"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 198 - "Community 198"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
+
+### Community 198 - "Community 198"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 199 - "Community 199"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 200 - "Community 200"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 201 - "Community 201"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), resetReplacementFields()
+
+### Community 201 - "Community 201"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 202 - "Community 202"
 Cohesion: 0.5
@@ -2252,20 +2252,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 207 - "Community 207"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 208 - "Community 208"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), parseDateTimeLocal()
 
-### Community 209 - "Community 209"
+### Community 208 - "Community 208"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 210 - "Community 210"
+### Community 209 - "Community 209"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
+
+### Community 210 - "Community 210"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 211 - "Community 211"
 Cohesion: 0.5
@@ -2276,36 +2276,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 213 - "Community 213"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 214 - "Community 214"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 215 - "Community 215"
+### Community 214 - "Community 214"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 216 - "Community 216"
+### Community 215 - "Community 215"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 217 - "Community 217"
+### Community 216 - "Community 216"
 Cohesion: 0.67
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 218 - "Community 218"
+### Community 217 - "Community 217"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 219 - "Community 219"
+### Community 218 - "Community 218"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 220 - "Community 220"
+### Community 219 - "Community 219"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+
+### Community 220 - "Community 220"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 221 - "Community 221"
 Cohesion: 0.5
@@ -2328,8 +2328,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 226 - "Community 226"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 227 - "Community 227"
 Cohesion: 0.67
@@ -9016,9 +9016,9 @@ _Questions this graph is uniquely positioned to answer:_
   _Cohesion score 0.13 - nodes in this community are weakly interconnected._
 - **Should `Community 10` be split into smaller, more focused modules?**
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
-- **Should `Community 12` be split into smaller, more focused modules?**
-  _Cohesion score 0.13 - nodes in this community are weakly interconnected._
-- **Should `Community 15` be split into smaller, more focused modules?**
+- **Should `Community 14` be split into smaller, more focused modules?**
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._
-- **Should `Community 16` be split into smaller, more focused modules?**
+- **Should `Community 17` be split into smaller, more focused modules?**
+  _Cohesion score 0.12 - nodes in this community are weakly interconnected._
+- **Should `Community 18` be split into smaller, more focused modules?**
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9839,7 +9839,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L224",
+      "source_location": "L225",
       "target": "possessiontracing_buildpossessiontraceevent",
       "weight": 1
     },
@@ -9851,7 +9851,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L140",
+      "source_location": "L141",
       "target": "possessiontracing_buildpossessiontracerecord",
       "weight": 1
     },
@@ -9863,7 +9863,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L103",
+      "source_location": "L104",
       "target": "possessiontracing_buildtracesummary",
       "weight": 1
     },
@@ -9875,7 +9875,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L557",
+      "source_location": "L558",
       "target": "possessiontracing_createpossessiontracerecorder",
       "weight": 1
     },
@@ -9887,7 +9887,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L216",
+      "source_location": "L217",
       "target": "possessiontracing_formatpaymentmethod",
       "weight": 1
     },
@@ -9899,7 +9899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L530",
+      "source_location": "L531",
       "target": "possessiontracing_recordpossessiontracebesteffort",
       "weight": 1
     },
@@ -9911,7 +9911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L522",
+      "source_location": "L523",
       "target": "possessiontracing_safetracewrite",
       "weight": 1
     },
@@ -29615,7 +29615,7 @@
       "relation": "calls",
       "source": "possessiontracing_formatpaymentmethod",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L358",
+      "source_location": "L359",
       "target": "possessiontracing_buildpossessiontraceevent",
       "weight": 1
     },
@@ -29627,7 +29627,7 @@
       "relation": "calls",
       "source": "possessiontracing_buildtracesummary",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L148",
+      "source_location": "L149",
       "target": "possessiontracing_buildpossessiontracerecord",
       "weight": 1
     },
@@ -29639,7 +29639,7 @@
       "relation": "calls",
       "source": "possessiontracing_buildpossessiontraceevent",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L535",
+      "source_location": "L536",
       "target": "possessiontracing_recordpossessiontracebesteffort",
       "weight": 1
     },
@@ -29651,7 +29651,7 @@
       "relation": "calls",
       "source": "possessiontracing_buildpossessiontracerecord",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L534",
+      "source_location": "L535",
       "target": "possessiontracing_recordpossessiontracebesteffort",
       "weight": 1
     },
@@ -29663,7 +29663,7 @@
       "relation": "calls",
       "source": "possessiontracing_safetracewrite",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L538",
+      "source_location": "L539",
       "target": "possessiontracing_recordpossessiontracebesteffort",
       "weight": 1
     },
@@ -62572,7 +62572,7 @@
       "label": "buildPosSessionTraceEvent()",
       "norm_label": "buildpossessiontraceevent()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L224"
+      "source_location": "L225"
     },
     {
       "community": 61,
@@ -62581,7 +62581,7 @@
       "label": "buildPosSessionTraceRecord()",
       "norm_label": "buildpossessiontracerecord()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L140"
+      "source_location": "L141"
     },
     {
       "community": 61,
@@ -62590,7 +62590,7 @@
       "label": "buildTraceSummary()",
       "norm_label": "buildtracesummary()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L103"
+      "source_location": "L104"
     },
     {
       "community": 61,
@@ -62599,7 +62599,7 @@
       "label": "createPosSessionTraceRecorder()",
       "norm_label": "createpossessiontracerecorder()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L557"
+      "source_location": "L558"
     },
     {
       "community": 61,
@@ -62608,7 +62608,7 @@
       "label": "formatPaymentMethod()",
       "norm_label": "formatpaymentmethod()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L216"
+      "source_location": "L217"
     },
     {
       "community": 61,
@@ -62617,7 +62617,7 @@
       "label": "recordPosSessionTraceBestEffort()",
       "norm_label": "recordpossessiontracebesteffort()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L530"
+      "source_location": "L531"
     },
     {
       "community": 61,
@@ -62626,7 +62626,7 @@
       "label": "safeTraceWrite()",
       "norm_label": "safetracewrite()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L522"
+      "source_location": "L523"
     },
     {
       "community": 610,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -959,7 +959,7 @@
       "relation": "calls",
       "source": "completetransaction_buildcompletetransactionresult",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L404",
+      "source_location": "L487",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -971,7 +971,7 @@
       "relation": "calls",
       "source": "completetransaction_calculatetotalpaid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L334",
+      "source_location": "L417",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -983,7 +983,7 @@
       "relation": "calls",
       "source": "completetransaction_persistworkflowtraceidbesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L388",
+      "source_location": "L471",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -995,7 +995,7 @@
       "relation": "calls",
       "source": "completetransaction_recordpossaletracebesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L382",
+      "source_location": "L465",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -1007,7 +1007,7 @@
       "relation": "calls",
       "source": "completetransaction_recordregistersessionsale",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L394",
+      "source_location": "L477",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -1019,7 +1019,7 @@
       "relation": "calls",
       "source": "completetransaction_buildcompletetransactionresult",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L674",
+      "source_location": "L760",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1031,7 +1031,7 @@
       "relation": "calls",
       "source": "completetransaction_calculatetotalpaid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L600",
+      "source_location": "L688",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1043,7 +1043,7 @@
       "relation": "calls",
       "source": "completetransaction_persistworkflowtraceidbesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L658",
+      "source_location": "L746",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1055,7 +1055,7 @@
       "relation": "calls",
       "source": "completetransaction_recordpossaletracebesteffort",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L652",
+      "source_location": "L740",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1067,7 +1067,19 @@
       "relation": "calls",
       "source": "completetransaction_recordregistersessionsale",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L664",
+      "source_location": "L751",
+      "target": "completetransaction_createtransactionfromsessionhandler",
+      "weight": 1
+    },
+    {
+      "_src": "completetransaction_createtransactionfromsessionhandler",
+      "_tgt": "completetransaction_resolvesessionregistersessionid",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "completetransaction_resolvesessionregistersessionid",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L657",
       "target": "completetransaction_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -1079,7 +1091,7 @@
       "relation": "calls",
       "source": "completetransaction_safetracewrite",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L194",
+      "source_location": "L238",
       "target": "completetransaction_persistworkflowtraceidbesteffort",
       "weight": 1
     },
@@ -1091,7 +1103,7 @@
       "relation": "calls",
       "source": "completetransaction_buildpossaletraceevent",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L156",
+      "source_location": "L200",
       "target": "completetransaction_recordpossaletracebesteffort",
       "weight": 1
     },
@@ -1103,8 +1115,44 @@
       "relation": "calls",
       "source": "completetransaction_buildpossaletracerecord",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L155",
+      "source_location": "L199",
       "target": "completetransaction_recordpossaletracebesteffort",
+      "weight": 1
+    },
+    {
+      "_src": "completetransaction_registersessionmatchesidentity",
+      "_tgt": "completetransaction_normalizeregisternumber",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "completetransaction_normalizeregisternumber",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L90",
+      "target": "completetransaction_registersessionmatchesidentity",
+      "weight": 1
+    },
+    {
+      "_src": "completetransaction_resolvesessionregistersessionid",
+      "_tgt": "completetransaction_isusableregistersession",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "completetransaction_isusableregistersession",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L272",
+      "target": "completetransaction_resolvesessionregistersessionid",
+      "weight": 1
+    },
+    {
+      "_src": "completetransaction_resolvesessionregistersessionid",
+      "_tgt": "completetransaction_registersessionmatchesidentity",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "completetransaction_registersessionmatchesidentity",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L273",
+      "target": "completetransaction_resolvesessionregistersessionid",
       "weight": 1
     },
     {
@@ -1115,7 +1163,7 @@
       "relation": "calls",
       "source": "completetransaction_recordregistersessionvoid",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L510",
+      "source_location": "L593",
       "target": "completetransaction_voidtransaction",
       "weight": 1
     },
@@ -9587,7 +9635,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L49",
+      "source_location": "L50",
       "target": "completetransaction_buildcompletetransactionresult",
       "weight": 1
     },
@@ -9599,7 +9647,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L106",
+      "source_location": "L150",
       "target": "completetransaction_buildpossaletraceevent",
       "weight": 1
     },
@@ -9611,7 +9659,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L85",
+      "source_location": "L129",
       "target": "completetransaction_buildpossaletracerecord",
       "weight": 1
     },
@@ -9623,7 +9671,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L70",
+      "source_location": "L71",
       "target": "completetransaction_calculatetotalpaid",
       "weight": 1
     },
@@ -9635,7 +9683,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L281",
+      "source_location": "L364",
       "target": "completetransaction_completetransaction",
       "weight": 1
     },
@@ -9647,8 +9695,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L555",
+      "source_location": "L638",
       "target": "completetransaction_createtransactionfromsessionhandler",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
+      "_tgt": "completetransaction_isusableregistersession",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L114",
+      "target": "completetransaction_isusableregistersession",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
+      "_tgt": "completetransaction_normalizeregisternumber",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L75",
+      "target": "completetransaction_normalizeregisternumber",
       "weight": 1
     },
     {
@@ -9659,7 +9731,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L182",
+      "source_location": "L226",
       "target": "completetransaction_persistworkflowtraceidbesteffort",
       "weight": 1
     },
@@ -9671,7 +9743,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L146",
+      "source_location": "L190",
       "target": "completetransaction_recordpossaletracebesteffort",
       "weight": 1
     },
@@ -9683,7 +9755,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L201",
+      "source_location": "L284",
       "target": "completetransaction_recordregistersessionsale",
       "weight": 1
     },
@@ -9695,8 +9767,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L226",
+      "source_location": "L309",
       "target": "completetransaction_recordregistersessionvoid",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
+      "_tgt": "completetransaction_registersessionmatchesidentity",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L80",
+      "target": "completetransaction_registersessionmatchesidentity",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
+      "_tgt": "completetransaction_resolvesessionregistersessionid",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L245",
+      "target": "completetransaction_resolvesessionregistersessionid",
       "weight": 1
     },
     {
@@ -9707,7 +9803,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L74",
+      "source_location": "L118",
       "target": "completetransaction_safetracewrite",
       "weight": 1
     },
@@ -9719,7 +9815,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L251",
+      "source_location": "L334",
       "target": "completetransaction_updateinventory",
       "weight": 1
     },
@@ -9731,7 +9827,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L486",
+      "source_location": "L569",
       "target": "completetransaction_voidtransaction",
       "weight": 1
     },
@@ -9839,7 +9935,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L539",
+      "source_location": "L603",
       "target": "sessioncommands_buildnextsessionnumber",
       "weight": 1
     },
@@ -9851,7 +9947,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L497",
+      "source_location": "L561",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -9863,7 +9959,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L130",
+      "source_location": "L131",
       "target": "sessioncommands_createpossessioncommandservice",
       "weight": 1
     },
@@ -9875,8 +9971,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L638",
+      "source_location": "L778",
       "target": "sessioncommands_failure",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
+      "_tgt": "sessioncommands_isactiveregistersession",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L619",
+      "target": "sessioncommands_isactiveregistersession",
       "weight": 1
     },
     {
@@ -9887,8 +9995,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L550",
+      "source_location": "L690",
       "target": "sessioncommands_issessionexpired",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
+      "_tgt": "sessioncommands_normalizeregisternumber",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L614",
+      "target": "sessioncommands_normalizeregisternumber",
       "weight": 1
     },
     {
@@ -9899,8 +10019,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L509",
+      "source_location": "L573",
       "target": "sessioncommands_recordsessionlifecyclebesteffort",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
+      "_tgt": "sessioncommands_registersessionmatchesidentity",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L625",
+      "target": "sessioncommands_registersessionmatchesidentity",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
+      "_tgt": "sessioncommands_resolveregistersessionbinding",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L656",
+      "target": "sessioncommands_resolveregistersessionbinding",
       "weight": 1
     },
     {
@@ -9911,7 +10055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L472",
+      "source_location": "L536",
       "target": "sessioncommands_runholdsessioncommand",
       "weight": 1
     },
@@ -9923,7 +10067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L490",
+      "source_location": "L554",
       "target": "sessioncommands_runremovesessionitemcommand",
       "weight": 1
     },
@@ -9935,7 +10079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L476",
+      "source_location": "L540",
       "target": "sessioncommands_runresumesessioncommand",
       "weight": 1
     },
@@ -9947,7 +10091,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L465",
+      "source_location": "L529",
       "target": "sessioncommands_runstartsessioncommand",
       "weight": 1
     },
@@ -9959,7 +10103,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L483",
+      "source_location": "L547",
       "target": "sessioncommands_runupsertsessionitemcommand",
       "weight": 1
     },
@@ -9971,7 +10115,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L631",
+      "source_location": "L771",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -9983,7 +10127,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L554",
+      "source_location": "L694",
       "target": "sessioncommands_validateactivesession",
       "weight": 1
     },
@@ -9995,7 +10139,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L598",
+      "source_location": "L738",
       "target": "sessioncommands_validatemodifiablesession",
       "weight": 1
     },
@@ -10271,8 +10415,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L766",
+      "source_location": "L880",
       "target": "sessioncommands_test_builditem",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "_tgt": "sessioncommands_test_buildregistersession",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L874",
+      "target": "sessioncommands_test_buildregistersession",
       "weight": 1
     },
     {
@@ -10283,7 +10439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L762",
+      "source_location": "L870",
       "target": "sessioncommands_test_buildsession",
       "weight": 1
     },
@@ -10295,7 +10451,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L776",
+      "source_location": "L890",
       "target": "sessioncommands_test_createcommandservice",
       "weight": 1
     },
@@ -10307,7 +10463,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L585",
+      "source_location": "L650",
       "target": "sessioncommands_test_createdependencies",
       "weight": 1
     },
@@ -10319,7 +10475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L662",
+      "source_location": "L727",
       "target": "sessioncommands_test_createfakerepository",
       "weight": 1
     },
@@ -10331,7 +10487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L567",
+      "source_location": "L632",
       "target": "sessioncommands_test_loadcommandservice",
       "weight": 1
     },
@@ -10751,7 +10907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L140",
+      "source_location": "L162",
       "target": "sessioncommandrepository_collectsessionitemsfrompages",
       "weight": 1
     },
@@ -10763,7 +10919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L47",
+      "source_location": "L56",
       "target": "sessioncommandrepository_createsessioncommandrepository",
       "weight": 1
     },
@@ -10775,7 +10931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L158",
+      "source_location": "L180",
       "target": "sessioncommandrepository_findsessionitembyskuinpages",
       "weight": 1
     },
@@ -10967,7 +11123,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L131",
+      "source_location": "L138",
       "target": "transactionrepository_createpostransaction",
       "weight": 1
     },
@@ -10979,7 +11135,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L138",
+      "source_location": "L145",
       "target": "transactionrepository_createpostransactionitem",
       "weight": 1
     },
@@ -10991,7 +11147,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L44",
+      "source_location": "L51",
       "target": "transactionrepository_getcashierbyid",
       "weight": 1
     },
@@ -11003,7 +11159,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L51",
+      "source_location": "L58",
       "target": "transactionrepository_getcustomerbyid",
       "weight": 1
     },
@@ -11045,6 +11201,18 @@
     },
     {
       "_src": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
+      "_tgt": "transactionrepository_getregistersessionbyid",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L44",
+      "target": "transactionrepository_getregistersessionbyid",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
       "_tgt": "transactionrepository_getstorebyid",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
@@ -11063,7 +11231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L94",
+      "source_location": "L101",
       "target": "transactionrepository_listcompletedtransactions",
       "weight": 1
     },
@@ -11075,7 +11243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L110",
+      "source_location": "L117",
       "target": "transactionrepository_listcompletedtransactionsforday",
       "weight": 1
     },
@@ -11087,7 +11255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L69",
+      "source_location": "L76",
       "target": "transactionrepository_listsessionitems",
       "weight": 1
     },
@@ -11099,7 +11267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L58",
+      "source_location": "L65",
       "target": "transactionrepository_listtransactionitems",
       "weight": 1
     },
@@ -11111,7 +11279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L80",
+      "source_location": "L87",
       "target": "transactionrepository_listtransactionsbystore",
       "weight": 1
     },
@@ -11123,7 +11291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L161",
+      "source_location": "L168",
       "target": "transactionrepository_patchpossession",
       "weight": 1
     },
@@ -11135,7 +11303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L153",
+      "source_location": "L160",
       "target": "transactionrepository_patchpostransaction",
       "weight": 1
     },
@@ -11147,7 +11315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L145",
+      "source_location": "L152",
       "target": "transactionrepository_patchproductsku",
       "weight": 1
     },
@@ -35075,8 +35243,68 @@
       "relation": "calls",
       "source": "sessioncommands_createpossessioncommandservice",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L500",
+      "source_location": "L564",
       "target": "sessioncommands_createdefaultsessioncommandservice",
+      "weight": 1
+    },
+    {
+      "_src": "sessioncommands_registersessionmatchesidentity",
+      "_tgt": "sessioncommands_normalizeregisternumber",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "sessioncommands_normalizeregisternumber",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L632",
+      "target": "sessioncommands_registersessionmatchesidentity",
+      "weight": 1
+    },
+    {
+      "_src": "sessioncommands_resolveregistersessionbinding",
+      "_tgt": "sessioncommands_failure",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "sessioncommands_resolveregistersessionbinding",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L682",
+      "target": "sessioncommands_failure",
+      "weight": 1
+    },
+    {
+      "_src": "sessioncommands_resolveregistersessionbinding",
+      "_tgt": "sessioncommands_isactiveregistersession",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "sessioncommands_isactiveregistersession",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L679",
+      "target": "sessioncommands_resolveregistersessionbinding",
+      "weight": 1
+    },
+    {
+      "_src": "sessioncommands_resolveregistersessionbinding",
+      "_tgt": "sessioncommands_registersessionmatchesidentity",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "sessioncommands_registersessionmatchesidentity",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L680",
+      "target": "sessioncommands_resolveregistersessionbinding",
+      "weight": 1
+    },
+    {
+      "_src": "sessioncommands_resolveregistersessionbinding",
+      "_tgt": "sessioncommands_success",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "sessioncommands_resolveregistersessionbinding",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L685",
+      "target": "sessioncommands_success",
       "weight": 1
     },
     {
@@ -35087,7 +35315,7 @@
       "relation": "calls",
       "source": "sessioncommands_runholdsessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L473",
+      "source_location": "L537",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -35099,7 +35327,7 @@
       "relation": "calls",
       "source": "sessioncommands_runremovesessionitemcommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L494",
+      "source_location": "L558",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -35111,7 +35339,7 @@
       "relation": "calls",
       "source": "sessioncommands_runresumesessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L480",
+      "source_location": "L544",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -35123,7 +35351,7 @@
       "relation": "calls",
       "source": "sessioncommands_runstartsessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L469",
+      "source_location": "L533",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -35135,7 +35363,7 @@
       "relation": "calls",
       "source": "sessioncommands_runupsertsessionitemcommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L487",
+      "source_location": "L551",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -35147,7 +35375,7 @@
       "relation": "calls",
       "source": "sessioncommands_validateactivesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L560",
+      "source_location": "L700",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -35159,7 +35387,7 @@
       "relation": "calls",
       "source": "sessioncommands_issessionexpired",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L573",
+      "source_location": "L713",
       "target": "sessioncommands_validateactivesession",
       "weight": 1
     },
@@ -35171,7 +35399,7 @@
       "relation": "calls",
       "source": "sessioncommands_validateactivesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L595",
+      "source_location": "L735",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -35183,7 +35411,7 @@
       "relation": "calls",
       "source": "sessioncommands_validatemodifiablesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L604",
+      "source_location": "L744",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -35195,7 +35423,7 @@
       "relation": "calls",
       "source": "sessioncommands_issessionexpired",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L614",
+      "source_location": "L754",
       "target": "sessioncommands_validatemodifiablesession",
       "weight": 1
     },
@@ -35207,7 +35435,7 @@
       "relation": "calls",
       "source": "sessioncommands_validatemodifiablesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L628",
+      "source_location": "L768",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -36995,7 +37223,7 @@
       "relation": "calls",
       "source": "transactionrepository_readallqueryresults",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L118",
+      "source_location": "L125",
       "target": "transactionrepository_listcompletedtransactionsforday",
       "weight": 1
     },
@@ -37007,7 +37235,7 @@
       "relation": "calls",
       "source": "transactionrepository_readallqueryresults",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L73",
+      "source_location": "L80",
       "target": "transactionrepository_listsessionitems",
       "weight": 1
     },
@@ -37019,7 +37247,7 @@
       "relation": "calls",
       "source": "transactionrepository_readallqueryresults",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L62",
+      "source_location": "L69",
       "target": "transactionrepository_listtransactionitems",
       "weight": 1
     },
@@ -41298,164 +41526,173 @@
     {
       "community": 12,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
-      "label": "transactionRepository.ts",
-      "norm_label": "transactionrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L1"
+      "id": "completetransaction_buildcompletetransactionresult",
+      "label": "buildCompleteTransactionResult()",
+      "norm_label": "buildcompletetransactionresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L50"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_createpostransaction",
-      "label": "createPosTransaction()",
-      "norm_label": "createpostransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L131"
+      "id": "completetransaction_buildpossaletraceevent",
+      "label": "buildPosSaleTraceEvent()",
+      "norm_label": "buildpossaletraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L150"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_createpostransactionitem",
-      "label": "createPosTransactionItem()",
-      "norm_label": "createpostransactionitem()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L138"
+      "id": "completetransaction_buildpossaletracerecord",
+      "label": "buildPosSaleTraceRecord()",
+      "norm_label": "buildpossaletracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L129"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_getcashierbyid",
-      "label": "getCashierById()",
-      "norm_label": "getcashierbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L44"
+      "id": "completetransaction_calculatetotalpaid",
+      "label": "calculateTotalPaid()",
+      "norm_label": "calculatetotalpaid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L71"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_getcustomerbyid",
-      "label": "getCustomerById()",
-      "norm_label": "getcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L51"
+      "id": "completetransaction_completetransaction",
+      "label": "completeTransaction()",
+      "norm_label": "completetransaction()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
+      "source_location": "L5"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_getpossessionbyid",
-      "label": "getPosSessionById()",
-      "norm_label": "getpossessionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L37"
+      "id": "completetransaction_createtransactionfromsessionhandler",
+      "label": "createTransactionFromSessionHandler()",
+      "norm_label": "createtransactionfromsessionhandler()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L638"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_getpostransactionbyid",
-      "label": "getPosTransactionById()",
-      "norm_label": "getpostransactionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L30"
+      "id": "completetransaction_isusableregistersession",
+      "label": "isUsableRegisterSession()",
+      "norm_label": "isusableregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L114"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_getproductskubyid",
-      "label": "getProductSkuById()",
-      "norm_label": "getproductskubyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L23"
+      "id": "completetransaction_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L75"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_getstorebyid",
-      "label": "getStoreById()",
-      "norm_label": "getstorebyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L16"
+      "id": "completetransaction_persistworkflowtraceidbesteffort",
+      "label": "persistWorkflowTraceIdBestEffort()",
+      "norm_label": "persistworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L226"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_listcompletedtransactions",
-      "label": "listCompletedTransactions()",
-      "norm_label": "listcompletedtransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L94"
+      "id": "completetransaction_recordpossaletracebesteffort",
+      "label": "recordPosSaleTraceBestEffort()",
+      "norm_label": "recordpossaletracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L190"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_listcompletedtransactionsforday",
-      "label": "listCompletedTransactionsForDay()",
-      "norm_label": "listcompletedtransactionsforday()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L110"
+      "id": "completetransaction_recordregistersessionsale",
+      "label": "recordRegisterSessionSale()",
+      "norm_label": "recordregistersessionsale()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L284"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_listsessionitems",
-      "label": "listSessionItems()",
-      "norm_label": "listsessionitems()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L69"
+      "id": "completetransaction_recordregistersessionvoid",
+      "label": "recordRegisterSessionVoid()",
+      "norm_label": "recordregistersessionvoid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L309"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_listtransactionitems",
-      "label": "listTransactionItems()",
-      "norm_label": "listtransactionitems()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "transactionrepository_listtransactionsbystore",
-      "label": "listTransactionsByStore()",
-      "norm_label": "listtransactionsbystore()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "id": "completetransaction_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
       "source_location": "L80"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_patchpossession",
-      "label": "patchPosSession()",
-      "norm_label": "patchpossession()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L161"
+      "id": "completetransaction_resolvesessionregistersessionid",
+      "label": "resolveSessionRegisterSessionId()",
+      "norm_label": "resolvesessionregistersessionid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L245"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_patchpostransaction",
-      "label": "patchPosTransaction()",
-      "norm_label": "patchpostransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L153"
+      "id": "completetransaction_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L118"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_patchproductsku",
-      "label": "patchProductSku()",
-      "norm_label": "patchproductsku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L145"
+      "id": "completetransaction_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L334"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "transactionrepository_readallqueryresults",
-      "label": "readAllQueryResults()",
-      "norm_label": "readallqueryresults()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L6"
+      "id": "completetransaction_voidtransaction",
+      "label": "voidTransaction()",
+      "norm_label": "voidtransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L569"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
+      "label": "completeTransaction.ts",
+      "norm_label": "completetransaction.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_completetransaction_ts",
+      "label": "completeTransaction.ts",
+      "norm_label": "completetransaction.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
+      "source_location": "L1"
     },
     {
       "community": 120,
@@ -42882,164 +43119,173 @@
     {
       "community": 13,
       "file_type": "code",
-      "id": "checkoutsession_calculatepromocodevalue",
-      "label": "calculatePromoCodeValue()",
-      "norm_label": "calculatepromocodevalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1447"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_checkadjustedavailability",
-      "label": "checkAdjustedAvailability()",
-      "norm_label": "checkadjustedavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L990"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_checkifitemshavechanged",
-      "label": "checkIfItemsHaveChanged()",
-      "norm_label": "checkifitemshavechanged()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_createonlineorder",
-      "label": "createOnlineOrder()",
-      "norm_label": "createonlineorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L765"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_createpatchobject",
-      "label": "createPatchObject()",
-      "norm_label": "createpatchobject()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L651"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_createsessionitems",
-      "label": "createSessionItems()",
-      "norm_label": "createsessionitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1102"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_fetchproductskus",
-      "label": "fetchProductSkus()",
-      "norm_label": "fetchproductskus()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L979"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_findbestvaluepromocode",
-      "label": "findBestValuePromoCode()",
-      "norm_label": "findbestvaluepromocode()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1495"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_handleexistingsession",
-      "label": "handleExistingSession()",
-      "norm_label": "handleexistingsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1161"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_handleordercreation",
-      "label": "handleOrderCreation()",
-      "norm_label": "handleordercreation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L734"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_handleplaceorder",
-      "label": "handlePlaceOrder()",
-      "norm_label": "handleplaceorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L698"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_listsessionitems",
-      "label": "listSessionItems()",
-      "norm_label": "listsessionitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_retrieveactivecheckoutsession",
-      "label": "retrieveActiveCheckoutSession()",
-      "norm_label": "retrieveactivecheckoutsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L951"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_updateavailability",
-      "label": "updateAvailability()",
-      "norm_label": "updateavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1140"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_updateexistingsession",
-      "label": "updateExistingSession()",
-      "norm_label": "updateexistingsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1020"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_updateproductavailability",
-      "label": "updateProductAvailability()",
-      "norm_label": "updateproductavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1123"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "checkoutsession_validateexistingdiscount",
-      "label": "validateExistingDiscount()",
-      "norm_label": "validateexistingdiscount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1321"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
+      "label": "sessionCommands.ts",
+      "norm_label": "sessioncommands.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_buildnextsessionnumber",
+      "label": "buildNextSessionNumber()",
+      "norm_label": "buildnextsessionnumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L603"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_createdefaultsessioncommandservice",
+      "label": "createDefaultSessionCommandService()",
+      "norm_label": "createdefaultsessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L561"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_createpossessioncommandservice",
+      "label": "createPosSessionCommandService()",
+      "norm_label": "createpossessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_failure",
+      "label": "failure()",
+      "norm_label": "failure()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L778"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_isactiveregistersession",
+      "label": "isActiveRegisterSession()",
+      "norm_label": "isactiveregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L619"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_issessionexpired",
+      "label": "isSessionExpired()",
+      "norm_label": "issessionexpired()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L690"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L614"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_recordsessionlifecyclebesteffort",
+      "label": "recordSessionLifecycleBestEffort()",
+      "norm_label": "recordsessionlifecyclebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L573"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L625"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_resolveregistersessionbinding",
+      "label": "resolveRegisterSessionBinding()",
+      "norm_label": "resolveregistersessionbinding()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L656"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_runholdsessioncommand",
+      "label": "runHoldSessionCommand()",
+      "norm_label": "runholdsessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L536"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_runremovesessionitemcommand",
+      "label": "runRemoveSessionItemCommand()",
+      "norm_label": "runremovesessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L554"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_runresumesessioncommand",
+      "label": "runResumeSessionCommand()",
+      "norm_label": "runresumesessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L540"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_runstartsessioncommand",
+      "label": "runStartSessionCommand()",
+      "norm_label": "runstartsessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L529"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_runupsertsessionitemcommand",
+      "label": "runUpsertSessionItemCommand()",
+      "norm_label": "runupsertsessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L547"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_success",
+      "label": "success()",
+      "norm_label": "success()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L771"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_validateactivesession",
+      "label": "validateActiveSession()",
+      "norm_label": "validateactivesession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L694"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "sessioncommands_validatemodifiablesession",
+      "label": "validateModifiableSession()",
+      "norm_label": "validatemodifiablesession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L738"
     },
     {
       "community": 130,
@@ -44268,164 +44514,173 @@
     {
       "community": 14,
       "file_type": "code",
-      "id": "graphify_wiki_builddegreeindex",
-      "label": "buildDegreeIndex()",
-      "norm_label": "builddegreeindex()",
-      "source_file": "scripts/graphify-wiki.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
+      "label": "transactionRepository.ts",
+      "norm_label": "transactionrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_createpostransaction",
+      "label": "createPosTransaction()",
+      "norm_label": "createpostransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_createpostransactionitem",
+      "label": "createPosTransactionItem()",
+      "norm_label": "createpostransactionitem()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_getcashierbyid",
+      "label": "getCashierById()",
+      "norm_label": "getcashierbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_getcustomerbyid",
+      "label": "getCustomerById()",
+      "norm_label": "getcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_getpossessionbyid",
+      "label": "getPosSessionById()",
+      "norm_label": "getpossessionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_getpostransactionbyid",
+      "label": "getPosTransactionById()",
+      "norm_label": "getpostransactionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_getproductskubyid",
+      "label": "getProductSkuById()",
+      "norm_label": "getproductskubyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_getregistersessionbyid",
+      "label": "getRegisterSessionById()",
+      "norm_label": "getregistersessionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_getstorebyid",
+      "label": "getStoreById()",
+      "norm_label": "getstorebyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_listcompletedtransactions",
+      "label": "listCompletedTransactions()",
+      "norm_label": "listcompletedtransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_listcompletedtransactionsforday",
+      "label": "listCompletedTransactionsForDay()",
+      "norm_label": "listcompletedtransactionsforday()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_listsessionitems",
+      "label": "listSessionItems()",
+      "norm_label": "listsessionitems()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_listtransactionitems",
+      "label": "listTransactionItems()",
+      "norm_label": "listtransactionitems()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_listtransactionsbystore",
+      "label": "listTransactionsByStore()",
+      "norm_label": "listtransactionsbystore()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_patchpossession",
+      "label": "patchPosSession()",
+      "norm_label": "patchpossession()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_patchpostransaction",
+      "label": "patchPosTransaction()",
+      "norm_label": "patchpostransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L160"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "transactionrepository_patchproductsku",
+      "label": "patchProductSku()",
+      "norm_label": "patchproductsku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
       "source_location": "L152"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "graphify_wiki_buildhotspotlines",
-      "label": "buildHotspotLines()",
-      "norm_label": "buildhotspotlines()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L190"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_buildpackagepage",
-      "label": "buildPackagePage()",
-      "norm_label": "buildpackagepage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L272"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_buildrootindexpage",
-      "label": "buildRootIndexPage()",
-      "norm_label": "buildrootindexpage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L227"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_comparehotspots",
-      "label": "compareHotspots()",
-      "norm_label": "comparehotspots()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_countcommunities",
-      "label": "countCommunities()",
-      "norm_label": "countcommunities()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_formatlist",
-      "label": "formatList()",
-      "norm_label": "formatlist()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_generategraphifywikipages",
-      "label": "generateGraphifyWikiPages()",
-      "norm_label": "generategraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L339"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_loadgraphifygraph",
-      "label": "loadGraphifyGraph()",
-      "norm_label": "loadgraphifygraph()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L213"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_readdir",
-      "label": "readDir()",
-      "norm_label": "readdir()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_scorenode",
-      "label": "scoreNode()",
-      "norm_label": "scorenode()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_tomarkdownlink",
-      "label": "toMarkdownLink()",
-      "norm_label": "tomarkdownlink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_tosourcelink",
-      "label": "toSourceLink()",
-      "norm_label": "tosourcelink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "graphify_wiki_writegraphifywikipages",
-      "label": "writeGraphifyWikiPages()",
-      "norm_label": "writegraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L371"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "scripts_graphify_wiki_ts",
-      "label": "graphify-wiki.ts",
-      "norm_label": "graphify-wiki.ts",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L1"
+      "id": "transactionrepository_readallqueryresults",
+      "label": "readAllQueryResults()",
+      "norm_label": "readallqueryresults()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L6"
     },
     {
       "community": 140,
@@ -44880,154 +45135,163 @@
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_createposcustomer",
-      "label": "createPosCustomer()",
-      "norm_label": "createposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L57"
+      "id": "checkoutsession_calculatepromocodevalue",
+      "label": "calculatePromoCodeValue()",
+      "norm_label": "calculatepromocodevalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1447"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_ensurecustomerprofilefromsources",
-      "label": "ensureCustomerProfileFromSources()",
-      "norm_label": "ensurecustomerprofilefromsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L214"
+      "id": "checkoutsession_checkadjustedavailability",
+      "label": "checkAdjustedAvailability()",
+      "norm_label": "checkadjustedavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L990"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_findcustomerbyemail",
-      "label": "findCustomerByEmail()",
-      "norm_label": "findcustomerbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L27"
+      "id": "checkoutsession_checkifitemshavechanged",
+      "label": "checkIfItemsHaveChanged()",
+      "norm_label": "checkifitemshavechanged()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L50"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_findcustomerbyphone",
-      "label": "findCustomerByPhone()",
-      "norm_label": "findcustomerbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L42"
+      "id": "checkoutsession_createonlineorder",
+      "label": "createOnlineOrder()",
+      "norm_label": "createonlineorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L765"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_findguestbyemail",
-      "label": "findGuestByEmail()",
-      "norm_label": "findguestbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L160"
+      "id": "checkoutsession_createpatchobject",
+      "label": "createPatchObject()",
+      "norm_label": "createpatchobject()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L651"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_findguestbyphone",
-      "label": "findGuestByPhone()",
-      "norm_label": "findguestbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L196"
+      "id": "checkoutsession_createsessionitems",
+      "label": "createSessionItems()",
+      "norm_label": "createsessionitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1102"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_findposcustomerbystorefrontuser",
-      "label": "findPosCustomerByStoreFrontUser()",
-      "norm_label": "findposcustomerbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L130"
+      "id": "checkoutsession_fetchproductskus",
+      "label": "fetchProductSkus()",
+      "norm_label": "fetchproductskus()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L979"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_findstorefrontuserbyemail",
-      "label": "findStoreFrontUserByEmail()",
-      "norm_label": "findstorefrontuserbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L142"
+      "id": "checkoutsession_findbestvaluepromocode",
+      "label": "findBestValuePromoCode()",
+      "norm_label": "findbestvaluepromocode()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1495"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_findstorefrontuserbyphone",
-      "label": "findStoreFrontUserByPhone()",
-      "norm_label": "findstorefrontuserbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L178"
+      "id": "checkoutsession_handleexistingsession",
+      "label": "handleExistingSession()",
+      "norm_label": "handleexistingsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1161"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_getguestbyid",
-      "label": "getGuestById()",
-      "norm_label": "getguestbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L126"
+      "id": "checkoutsession_handleordercreation",
+      "label": "handleOrderCreation()",
+      "norm_label": "handleordercreation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L734"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_getposcustomerbyid",
-      "label": "getPosCustomerById()",
-      "norm_label": "getposcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L20"
+      "id": "checkoutsession_handleplaceorder",
+      "label": "handlePlaceOrder()",
+      "norm_label": "handleplaceorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L698"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_getstorefrontuserbyid",
-      "label": "getStoreFrontUserById()",
-      "norm_label": "getstorefrontuserbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L119"
+      "id": "checkoutsession_listsessionitems",
+      "label": "listSessionItems()",
+      "norm_label": "listsessionitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L40"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_listactivecustomersforstore",
-      "label": "listActiveCustomersForStore()",
-      "norm_label": "listactivecustomersforstore()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L8"
+      "id": "checkoutsession_retrieveactivecheckoutsession",
+      "label": "retrieveActiveCheckoutSession()",
+      "norm_label": "retrieveactivecheckoutsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L951"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_listcompletedtransactionsforcustomer",
-      "label": "listCompletedTransactionsForCustomer()",
-      "norm_label": "listcompletedtransactionsforcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L94"
+      "id": "checkoutsession_updateavailability",
+      "label": "updateAvailability()",
+      "norm_label": "updateavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1140"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_patchposcustomer",
-      "label": "patchPosCustomer()",
-      "norm_label": "patchposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L64"
+      "id": "checkoutsession_updateexistingsession",
+      "label": "updateExistingSession()",
+      "norm_label": "updateexistingsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1020"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "customerrepository_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L72"
+      "id": "checkoutsession_updateproductavailability",
+      "label": "updateProductAvailability()",
+      "norm_label": "updateproductavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1123"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_customerrepository_ts",
-      "label": "customerRepository.ts",
-      "norm_label": "customerrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "id": "checkoutsession_validateexistingdiscount",
+      "label": "validateExistingDiscount()",
+      "norm_label": "validateexistingdiscount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1321"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1"
     },
     {
@@ -45483,154 +45747,163 @@
     {
       "community": 16,
       "file_type": "code",
-      "id": "data_table_view_options_datatableviewoptions",
-      "label": "DataTableViewOptions()",
-      "norm_label": "datatableviewoptions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
-      "source_location": "L18"
+      "id": "graphify_wiki_builddegreeindex",
+      "label": "buildDegreeIndex()",
+      "norm_label": "builddegreeindex()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L152"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_buildhotspotlines",
+      "label": "buildHotspotLines()",
+      "norm_label": "buildhotspotlines()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L190"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_buildpackagepage",
+      "label": "buildPackagePage()",
+      "norm_label": "buildpackagepage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L272"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_buildrootindexpage",
+      "label": "buildRootIndexPage()",
+      "norm_label": "buildrootindexpage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L227"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L88"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_comparehotspots",
+      "label": "compareHotspots()",
+      "norm_label": "comparehotspots()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L170"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_countcommunities",
+      "label": "countCommunities()",
+      "norm_label": "countcommunities()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L148"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L79"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_formatlist",
+      "label": "formatList()",
+      "norm_label": "formatlist()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L144"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_generategraphifywikipages",
+      "label": "generateGraphifyWikiPages()",
+      "norm_label": "generategraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L339"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_loadgraphifygraph",
+      "label": "loadGraphifyGraph()",
+      "norm_label": "loadgraphifygraph()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L213"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L127"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_readdir",
+      "label": "readDir()",
+      "norm_label": "readdir()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L122"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_scorenode",
+      "label": "scoreNode()",
+      "norm_label": "scorenode()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L163"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_tomarkdownlink",
+      "label": "toMarkdownLink()",
+      "norm_label": "tomarkdownlink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L131"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "graphify_wiki_tosourcelink",
+      "label": "toSourceLink()",
+      "norm_label": "tosourcelink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L139"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "id": "graphify_wiki_writegraphifywikipages",
+      "label": "writeGraphifyWikiPages()",
+      "norm_label": "writegraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L371"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "scripts_graphify_wiki_ts",
+      "label": "graphify-wiki.ts",
+      "norm_label": "graphify-wiki.ts",
+      "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L1"
     },
     {
@@ -46086,154 +46359,154 @@
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_buildsummary",
-      "label": "buildSummary()",
-      "norm_label": "buildsummary()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L215"
+      "id": "customerrepository_createposcustomer",
+      "label": "createPosCustomer()",
+      "norm_label": "createposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L57"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_comparesnapshots",
-      "label": "compareSnapshots()",
-      "norm_label": "comparesnapshots()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L107"
+      "id": "customerrepository_ensurecustomerprofilefromsources",
+      "label": "ensureCustomerProfileFromSources()",
+      "norm_label": "ensurecustomerprofilefromsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L214"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L79"
+      "id": "customerrepository_findcustomerbyemail",
+      "label": "findCustomerByEmail()",
+      "norm_label": "findcustomerbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L27"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_formatartifactlist",
-      "label": "formatArtifactList()",
-      "norm_label": "formatartifactlist()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L131"
+      "id": "customerrepository_findcustomerbyphone",
+      "label": "findCustomerByPhone()",
+      "norm_label": "findcustomerbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L42"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_formatdetaillines",
-      "label": "formatDetailLines()",
-      "norm_label": "formatdetaillines()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L124"
+      "id": "customerrepository_findguestbyemail",
+      "label": "findGuestByEmail()",
+      "norm_label": "findguestbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L160"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_formaterror",
-      "label": "formatError()",
-      "norm_label": "formaterror()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L69"
+      "id": "customerrepository_findguestbyphone",
+      "label": "findGuestByPhone()",
+      "norm_label": "findguestbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L196"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_formatharnessjanitorreport",
-      "label": "formatHarnessJanitorReport()",
-      "norm_label": "formatharnessjanitorreport()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L372"
+      "id": "customerrepository_findposcustomerbystorefrontuser",
+      "label": "findPosCustomerByStoreFrontUser()",
+      "norm_label": "findposcustomerbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L130"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_hasfailures",
-      "label": "hasFailures()",
-      "norm_label": "hasfailures()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L242"
+      "id": "customerrepository_findstorefrontuserbyemail",
+      "label": "findStoreFrontUserByEmail()",
+      "norm_label": "findstorefrontuserbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L142"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_parseharnessjanitorcliargs",
-      "label": "parseHarnessJanitorCliArgs()",
-      "norm_label": "parseharnessjanitorcliargs()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L342"
+      "id": "customerrepository_findstorefrontuserbyphone",
+      "label": "findStoreFrontUserByPhone()",
+      "norm_label": "findstorefrontuserbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L178"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_readutf8ornull",
-      "label": "readUtf8OrNull()",
-      "norm_label": "readutf8ornull()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L88"
+      "id": "customerrepository_getguestbyid",
+      "label": "getGuestById()",
+      "norm_label": "getguestbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L126"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_runcheckstep",
-      "label": "runCheckStep()",
-      "norm_label": "runcheckstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L163"
+      "id": "customerrepository_getposcustomerbyid",
+      "label": "getPosCustomerById()",
+      "norm_label": "getposcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L20"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_runharnessjanitor",
-      "label": "runHarnessJanitor()",
-      "norm_label": "runharnessjanitor()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L252"
+      "id": "customerrepository_getstorefrontuserbyid",
+      "label": "getStoreFrontUserById()",
+      "norm_label": "getstorefrontuserbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L119"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_runrepairstep",
-      "label": "runRepairStep()",
-      "norm_label": "runrepairstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L175"
+      "id": "customerrepository_listactivecustomersforstore",
+      "label": "listActiveCustomersForStore()",
+      "norm_label": "listactivecustomersforstore()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L8"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_snapshotfiles",
-      "label": "snapshotFiles()",
-      "norm_label": "snapshotfiles()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L96"
+      "id": "customerrepository_listcompletedtransactionsforcustomer",
+      "label": "listCompletedTransactionsForCustomer()",
+      "norm_label": "listcompletedtransactionsforcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L94"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L73"
+      "id": "customerrepository_patchposcustomer",
+      "label": "patchPosCustomer()",
+      "norm_label": "patchposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L64"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "harness_janitor_withcapturedconsole",
-      "label": "withCapturedConsole()",
-      "norm_label": "withcapturedconsole()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L139"
+      "id": "customerrepository_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L72"
     },
     {
       "community": 17,
       "file_type": "code",
-      "id": "scripts_harness_janitor_ts",
-      "label": "harness-janitor.ts",
-      "norm_label": "harness-janitor.ts",
-      "source_file": "scripts/harness-janitor.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_customerrepository_ts",
+      "label": "customerRepository.ts",
+      "norm_label": "customerrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
       "source_location": "L1"
     },
     {
@@ -46500,42 +46773,6 @@
     {
       "community": 177,
       "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
       "norm_label": "getcachedtokenrecord()",
@@ -46543,7 +46780,7 @@
       "source_location": "L26"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -46552,7 +46789,7 @@
       "source_location": "L79"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -46561,7 +46798,7 @@
       "source_location": "L33"
     },
     {
-      "community": 178,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -46570,7 +46807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -46579,7 +46816,7 @@
       "source_location": "L10"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -46588,7 +46825,7 @@
       "source_location": "L18"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -46597,7 +46834,7 @@
       "source_location": "L52"
     },
     {
-      "community": 179,
+      "community": 178,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -46606,160 +46843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_buildnumerictrendstats",
-      "label": "buildNumericTrendStats()",
-      "norm_label": "buildnumerictrendstats()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L202"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_buildregressionwarnings",
-      "label": "buildRegressionWarnings()",
-      "norm_label": "buildregressionwarnings()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L337"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_buildruntimetrendoutput",
-      "label": "buildRuntimeTrendOutput()",
-      "norm_label": "buildruntimetrendoutput()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L409"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_buildscenariotrend",
-      "label": "buildScenarioTrend()",
-      "norm_label": "buildscenariotrend()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_collectharnessruntimetrends",
-      "label": "collectHarnessRuntimeTrends()",
-      "norm_label": "collectharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L473"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatms",
-      "label": "formatMs()",
-      "norm_label": "formatms()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatpercent",
-      "label": "formatPercent()",
-      "norm_label": "formatpercent()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
-      "label": "isHarnessBehaviorScenarioReport()",
-      "norm_label": "isharnessbehaviorscenarioreport()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
-      "label": "parseHarnessBehaviorReportLines()",
-      "norm_label": "parseharnessbehaviorreportlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
-      "label": "parseHarnessRuntimeTrendsArgs()",
-      "norm_label": "parseharnessruntimetrendsargs()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L509"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_percentile",
-      "label": "percentile()",
-      "norm_label": "percentile()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_runharnessruntimetrends",
-      "label": "runHarnessRuntimeTrends()",
-      "norm_label": "runharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L481"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_sortcountentries",
-      "label": "sortCountEntries()",
-      "norm_label": "sortcountentries()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L227"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_sortunique",
-      "label": "sortUnique()",
-      "norm_label": "sortunique()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_splitinputlines",
-      "label": "splitInputLines()",
-      "norm_label": "splitinputlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "harness_runtime_trends_tohistoryfilestamp",
-      "label": "toHistoryFileStamp()",
-      "norm_label": "tohistoryfilestamp()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 18,
-      "file_type": "code",
-      "id": "scripts_harness_runtime_trends_ts",
-      "label": "harness-runtime-trends.ts",
-      "norm_label": "harness-runtime-trends.ts",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 180,
+      "community": 179,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -46768,7 +46852,7 @@
       "source_location": "L28"
     },
     {
-      "community": 180,
+      "community": 179,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -46777,7 +46861,7 @@
       "source_location": "L42"
     },
     {
-      "community": 180,
+      "community": 179,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -46786,7 +46870,7 @@
       "source_location": "L73"
     },
     {
-      "community": 180,
+      "community": 179,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -46795,7 +46879,160 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 18,
+      "file_type": "code",
+      "id": "data_table_view_options_datatableviewoptions",
+      "label": "DataTableViewOptions()",
+      "norm_label": "datatableviewoptions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 18,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 180,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -46804,7 +47041,7 @@
       "source_location": "L8"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -46813,7 +47050,7 @@
       "source_location": "L32"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -46822,7 +47059,7 @@
       "source_location": "L64"
     },
     {
-      "community": 181,
+      "community": 180,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -46831,7 +47068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -46840,7 +47077,7 @@
       "source_location": "L18"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -46849,7 +47086,7 @@
       "source_location": "L25"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -46858,7 +47095,7 @@
       "source_location": "L11"
     },
     {
-      "community": 182,
+      "community": 181,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -46867,7 +47104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -46876,7 +47113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -46885,7 +47122,7 @@
       "source_location": "L26"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -46894,7 +47131,7 @@
       "source_location": "L43"
     },
     {
-      "community": 183,
+      "community": 182,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -46903,7 +47140,7 @@
       "source_location": "L107"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -46912,7 +47149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -46921,7 +47158,7 @@
       "source_location": "L36"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -46930,7 +47167,7 @@
       "source_location": "L23"
     },
     {
-      "community": 184,
+      "community": 183,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -46939,7 +47176,7 @@
       "source_location": "L18"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
       "label": "terminals.ts",
@@ -46948,7 +47185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "terminals_deleteterminal",
       "label": "deleteTerminal()",
@@ -46957,7 +47194,7 @@
       "source_location": "L89"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "terminals_registerterminal",
       "label": "registerTerminal()",
@@ -46966,7 +47203,7 @@
       "source_location": "L13"
     },
     {
-      "community": 185,
+      "community": 184,
       "file_type": "code",
       "id": "terminals_updateterminal",
       "label": "updateTerminal()",
@@ -46975,7 +47212,7 @@
       "source_location": "L54"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -46984,7 +47221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -46993,7 +47230,7 @@
       "source_location": "L122"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -47002,7 +47239,7 @@
       "source_location": "L34"
     },
     {
-      "community": 186,
+      "community": 185,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -47011,7 +47248,7 @@
       "source_location": "L72"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -47020,34 +47257,34 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
       "norm_label": "collectsessionitemsfrompages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L140"
+      "source_location": "L162"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
       "norm_label": "createsessioncommandrepository()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L47"
+      "source_location": "L56"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "sessioncommandrepository_findsessionitembyskuinpages",
       "label": "findSessionItemBySkuInPages()",
       "norm_label": "findsessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
-      "source_location": "L158"
+      "source_location": "L180"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -47056,7 +47293,7 @@
       "source_location": "L30"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -47065,7 +47302,7 @@
       "source_location": "L175"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -47074,7 +47311,7 @@
       "source_location": "L26"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -47083,7 +47320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 189,
+      "community": 188,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -47092,7 +47329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 189,
+      "community": 188,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -47101,7 +47338,7 @@
       "source_location": "L23"
     },
     {
-      "community": 189,
+      "community": 188,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -47110,7 +47347,7 @@
       "source_location": "L9"
     },
     {
-      "community": 189,
+      "community": 188,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -47119,151 +47356,7 @@
       "source_location": "L13"
     },
     {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_assertvalidonlineorderstatustransition",
-      "label": "assertValidOnlineOrderStatusTransition()",
-      "norm_label": "assertvalidonlineorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentamount",
-      "label": "getOnlineOrderPaymentAmount()",
-      "norm_label": "getonlineorderpaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentmethodlabel",
-      "label": "getOnlineOrderPaymentMethodLabel()",
-      "norm_label": "getonlineorderpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderstatuseventtype",
-      "label": "getOnlineOrderStatusEventType()",
-      "norm_label": "getonlineorderstatuseventtype()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_getstoreorganizationid",
-      "label": "getStoreOrganizationId()",
-      "norm_label": "getstoreorganizationid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_ispaymentondeliveryorder",
-      "label": "isPaymentOnDeliveryOrder()",
-      "norm_label": "ispaymentondeliveryorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineordercreatedevent",
-      "label": "recordOnlineOrderCreatedEvent()",
-      "norm_label": "recordonlineordercreatedevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderfulfillmentmovement",
-      "label": "recordOnlineOrderFulfillmentMovement()",
-      "norm_label": "recordonlineorderfulfillmentmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L381"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentcollected",
-      "label": "recordOnlineOrderPaymentCollected()",
-      "norm_label": "recordonlineorderpaymentcollected()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L288"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentverified",
-      "label": "recordOnlineOrderPaymentVerified()",
-      "norm_label": "recordonlineorderpaymentverified()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L240"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderrefundallocation",
-      "label": "recordOnlineOrderRefundAllocation()",
-      "norm_label": "recordonlineorderrefundallocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L347"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderrestockmovement",
-      "label": "recordOnlineOrderRestockMovement()",
-      "norm_label": "recordonlineorderrestockmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L409"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderstatusevent",
-      "label": "recordOnlineOrderStatusEvent()",
-      "norm_label": "recordonlineorderstatusevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
-      "label": "resolveCustomerProfileForStoreFrontActor()",
-      "norm_label": "resolvecustomerprofileforstorefrontactor()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "orderoperations_resolveonlineordercontext",
-      "label": "resolveOnlineOrderContext()",
-      "norm_label": "resolveonlineordercontext()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
-      "label": "orderOperations.ts",
-      "norm_label": "orderoperations.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 190,
+      "community": 189,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -47272,7 +47365,7 @@
       "source_location": "L19"
     },
     {
-      "community": 190,
+      "community": 189,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -47281,7 +47374,7 @@
       "source_location": "L26"
     },
     {
-      "community": 190,
+      "community": 189,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -47290,7 +47383,7 @@
       "source_location": "L12"
     },
     {
-      "community": 190,
+      "community": 189,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -47299,7 +47392,160 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_buildsummary",
+      "label": "buildSummary()",
+      "norm_label": "buildsummary()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_comparesnapshots",
+      "label": "compareSnapshots()",
+      "norm_label": "comparesnapshots()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_formatartifactlist",
+      "label": "formatArtifactList()",
+      "norm_label": "formatartifactlist()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_formatdetaillines",
+      "label": "formatDetailLines()",
+      "norm_label": "formatdetaillines()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_formaterror",
+      "label": "formatError()",
+      "norm_label": "formaterror()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_formatharnessjanitorreport",
+      "label": "formatHarnessJanitorReport()",
+      "norm_label": "formatharnessjanitorreport()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L372"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_hasfailures",
+      "label": "hasFailures()",
+      "norm_label": "hasfailures()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L242"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_parseharnessjanitorcliargs",
+      "label": "parseHarnessJanitorCliArgs()",
+      "norm_label": "parseharnessjanitorcliargs()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L342"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_readutf8ornull",
+      "label": "readUtf8OrNull()",
+      "norm_label": "readutf8ornull()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_runcheckstep",
+      "label": "runCheckStep()",
+      "norm_label": "runcheckstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L163"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_runharnessjanitor",
+      "label": "runHarnessJanitor()",
+      "norm_label": "runharnessjanitor()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L252"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_runrepairstep",
+      "label": "runRepairStep()",
+      "norm_label": "runrepairstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L175"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_snapshotfiles",
+      "label": "snapshotFiles()",
+      "norm_label": "snapshotfiles()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_janitor_withcapturedconsole",
+      "label": "withCapturedConsole()",
+      "norm_label": "withcapturedconsole()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_ts",
+      "label": "harness-janitor.ts",
+      "norm_label": "harness-janitor.ts",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 190,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -47308,7 +47554,7 @@
       "source_location": "L21"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -47317,7 +47563,7 @@
       "source_location": "L63"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -47326,7 +47572,7 @@
       "source_location": "L71"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -47335,7 +47581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -47344,7 +47590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -47353,7 +47599,7 @@
       "source_location": "L13"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -47362,7 +47608,7 @@
       "source_location": "L31"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -47371,7 +47617,7 @@
       "source_location": "L9"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -47380,7 +47626,7 @@
       "source_location": "L228"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -47389,7 +47635,7 @@
       "source_location": "L45"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -47398,7 +47644,7 @@
       "source_location": "L26"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -47407,7 +47653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 193,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -47416,7 +47662,7 @@
       "source_location": "L55"
     },
     {
-      "community": 194,
+      "community": 193,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -47425,7 +47671,7 @@
       "source_location": "L32"
     },
     {
-      "community": 194,
+      "community": 193,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -47434,7 +47680,7 @@
       "source_location": "L210"
     },
     {
-      "community": 194,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -47443,7 +47689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 194,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -47452,7 +47698,7 @@
       "source_location": "L51"
     },
     {
-      "community": 195,
+      "community": 194,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -47461,7 +47707,7 @@
       "source_location": "L26"
     },
     {
-      "community": 195,
+      "community": 194,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -47470,7 +47716,7 @@
       "source_location": "L290"
     },
     {
-      "community": 195,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -47479,7 +47725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 195,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -47488,7 +47734,7 @@
       "source_location": "L48"
     },
     {
-      "community": 196,
+      "community": 195,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -47497,7 +47743,7 @@
       "source_location": "L88"
     },
     {
-      "community": 196,
+      "community": 195,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -47506,7 +47752,7 @@
       "source_location": "L14"
     },
     {
-      "community": 196,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -47515,7 +47761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -47524,7 +47770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 196,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -47533,7 +47779,7 @@
       "source_location": "L15"
     },
     {
-      "community": 197,
+      "community": 196,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -47542,7 +47788,7 @@
       "source_location": "L28"
     },
     {
-      "community": 197,
+      "community": 196,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -47551,7 +47797,7 @@
       "source_location": "L19"
     },
     {
-      "community": 198,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -47560,7 +47806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 198,
+      "community": 197,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -47569,7 +47815,7 @@
       "source_location": "L52"
     },
     {
-      "community": 198,
+      "community": 197,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -47578,7 +47824,7 @@
       "source_location": "L3"
     },
     {
-      "community": 198,
+      "community": 197,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -47587,7 +47833,7 @@
       "source_location": "L90"
     },
     {
-      "community": 199,
+      "community": 198,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -47596,7 +47842,7 @@
       "source_location": "L86"
     },
     {
-      "community": 199,
+      "community": 198,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -47605,7 +47851,7 @@
       "source_location": "L76"
     },
     {
-      "community": 199,
+      "community": 198,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -47614,13 +47860,49 @@
       "source_location": "L52"
     },
     {
-      "community": 199,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
       "norm_label": "maintenancemessageeditor.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
+      "label": "ShopLook.tsx",
+      "norm_label": "shoplook.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "shoplook_handlehighlighteditem",
+      "label": "handleHighlightedItem()",
+      "norm_label": "handlehighlighteditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "shoplook_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "shoplook_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L73"
     },
     {
       "community": 2,
@@ -47922,185 +48204,158 @@
     {
       "community": 20,
       "file_type": "code",
-      "id": "checkoutsession_checkoutsessionerror",
-      "label": "CheckoutSessionError",
-      "norm_label": "checkoutsessionerror",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L64"
+      "id": "harness_runtime_trends_buildnumerictrendstats",
+      "label": "buildNumericTrendStats()",
+      "norm_label": "buildnumerictrendstats()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L202"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "checkoutsession_checkoutsessionerror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L69"
+      "id": "harness_runtime_trends_buildregressionwarnings",
+      "label": "buildRegressionWarnings()",
+      "norm_label": "buildregressionwarnings()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L337"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "checkoutsession_createcheckoutsession",
-      "label": "createCheckoutSession()",
-      "norm_label": "createcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L184"
+      "id": "harness_runtime_trends_buildruntimetrendoutput",
+      "label": "buildRuntimeTrendOutput()",
+      "norm_label": "buildruntimetrendoutput()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L409"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "checkoutsession_defaultcheckoutactionmessage",
-      "label": "defaultCheckoutActionMessage()",
-      "norm_label": "defaultcheckoutactionmessage()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L135"
+      "id": "harness_runtime_trends_buildscenariotrend",
+      "label": "buildScenarioTrend()",
+      "norm_label": "buildscenariotrend()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L241"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "checkoutsession_getactivecheckoutsession",
-      "label": "getActiveCheckoutSession()",
-      "norm_label": "getactivecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L204"
+      "id": "harness_runtime_trends_collectharnessruntimetrends",
+      "label": "collectHarnessRuntimeTrends()",
+      "norm_label": "collectharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L473"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "checkoutsession_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L5"
+      "id": "harness_runtime_trends_formatms",
+      "label": "formatMs()",
+      "norm_label": "formatms()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L237"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "checkoutsession_getcheckoutactionerrormessage",
-      "label": "getCheckoutActionErrorMessage()",
-      "norm_label": "getcheckoutactionerrormessage()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L147"
+      "id": "harness_runtime_trends_formatpercent",
+      "label": "formatPercent()",
+      "norm_label": "formatpercent()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L233"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "label": "getCheckoutErrorMessageFromPayload()",
-      "norm_label": "getcheckouterrormessagefrompayload()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L98"
+      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
+      "label": "isHarnessBehaviorScenarioReport()",
+      "norm_label": "isharnessbehaviorscenarioreport()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L131"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "checkoutsession_getcheckoutsession",
-      "label": "getCheckoutSession()",
-      "norm_label": "getcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L226"
+      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
+      "label": "parseHarnessBehaviorReportLines()",
+      "norm_label": "parseharnessbehaviorreportlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L149"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "checkoutsession_getpendingcheckoutsessions",
-      "label": "getPendingCheckoutSessions()",
-      "norm_label": "getpendingcheckoutsessions()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L215"
+      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
+      "label": "parseHarnessRuntimeTrendsArgs()",
+      "norm_label": "parseharnessruntimetrendsargs()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L509"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "checkoutsession_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L78"
+      "id": "harness_runtime_trends_percentile",
+      "label": "percentile()",
+      "norm_label": "percentile()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L191"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "checkoutsession_parsecheckoutresponse",
-      "label": "parseCheckoutResponse()",
-      "norm_label": "parsecheckoutresponse()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "id": "harness_runtime_trends_runharnessruntimetrends",
+      "label": "runHarnessRuntimeTrends()",
+      "norm_label": "runharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L481"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_runtime_trends_sortcountentries",
+      "label": "sortCountEntries()",
+      "norm_label": "sortcountentries()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L227"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_runtime_trends_sortunique",
+      "label": "sortUnique()",
+      "norm_label": "sortunique()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_runtime_trends_splitinputlines",
+      "label": "splitInputLines()",
+      "norm_label": "splitinputlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_runtime_trends_tohistoryfilestamp",
+      "label": "toHistoryFileStamp()",
+      "norm_label": "tohistoryfilestamp()",
+      "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L115"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "checkoutsession_parsejson",
-      "label": "parseJson()",
-      "norm_label": "parsejson()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "checkoutsession_updatecheckoutsession",
-      "label": "updateCheckoutSession()",
-      "norm_label": "updatecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "checkoutsession_verifycheckoutsessionpayment",
-      "label": "verifyCheckoutSessionPayment()",
-      "norm_label": "verifycheckoutsessionpayment()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L274"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "id": "scripts_harness_runtime_trends_ts",
+      "label": "harness-runtime-trends.ts",
+      "norm_label": "harness-runtime-trends.ts",
+      "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L1"
     },
     {
       "community": 200,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
-      "label": "ShopLook.tsx",
-      "norm_label": "shoplook.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "shoplook_handlehighlighteditem",
-      "label": "handleHighlightedItem()",
-      "norm_label": "handlehighlighteditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "shoplook_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "shoplook_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -48109,7 +48364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 200,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -48118,7 +48373,7 @@
       "source_location": "L103"
     },
     {
-      "community": 201,
+      "community": 200,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -48127,7 +48382,7 @@
       "source_location": "L95"
     },
     {
-      "community": 201,
+      "community": 200,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -48136,7 +48391,7 @@
       "source_location": "L81"
     },
     {
-      "community": 202,
+      "community": 201,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -48145,7 +48400,7 @@
       "source_location": "L91"
     },
     {
-      "community": 202,
+      "community": 201,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -48154,7 +48409,7 @@
       "source_location": "L68"
     },
     {
-      "community": 202,
+      "community": 201,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -48163,7 +48418,7 @@
       "source_location": "L22"
     },
     {
-      "community": 202,
+      "community": 201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -48172,7 +48427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "ordersummary_handlecompletetransaction",
       "label": "handleCompleteTransaction()",
@@ -48181,7 +48436,7 @@
       "source_location": "L131"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "ordersummary_handleprintreceipt",
       "label": "handlePrintReceipt()",
@@ -48190,7 +48445,7 @@
       "source_location": "L154"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "ordersummary_handlestartnewtransaction",
       "label": "handleStartNewTransaction()",
@@ -48199,7 +48454,7 @@
       "source_location": "L148"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -48208,7 +48463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -48217,7 +48472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -48226,7 +48481,7 @@
       "source_location": "L247"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -48235,7 +48490,7 @@
       "source_location": "L284"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -48244,7 +48499,7 @@
       "source_location": "L166"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -48253,7 +48508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -48262,7 +48517,7 @@
       "source_location": "L78"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -48271,7 +48526,7 @@
       "source_location": "L118"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -48280,7 +48535,7 @@
       "source_location": "L89"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -48289,7 +48544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -48298,7 +48553,7 @@
       "source_location": "L63"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -48307,7 +48562,7 @@
       "source_location": "L54"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -48316,7 +48571,7 @@
       "source_location": "L11"
     },
     {
-      "community": 207,
+      "community": 206,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -48325,7 +48580,7 @@
       "source_location": "L16"
     },
     {
-      "community": 207,
+      "community": 206,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -48334,7 +48589,7 @@
       "source_location": "L35"
     },
     {
-      "community": 207,
+      "community": 206,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -48343,7 +48598,7 @@
       "source_location": "L6"
     },
     {
-      "community": 207,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -48352,7 +48607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "label": "ServiceAppointmentsView.tsx",
@@ -48361,7 +48616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 207,
       "file_type": "code",
       "id": "serviceappointmentsview_handlesubmit",
       "label": "handleSubmit()",
@@ -48370,7 +48625,7 @@
       "source_location": "L115"
     },
     {
-      "community": 208,
+      "community": 207,
       "file_type": "code",
       "id": "serviceappointmentsview_parsedatetimelocal",
       "label": "parseDateTimeLocal()",
@@ -48379,7 +48634,7 @@
       "source_location": "L77"
     },
     {
-      "community": 208,
+      "community": 207,
       "file_type": "code",
       "id": "serviceappointmentsview_withsavestate",
       "label": "withSaveState()",
@@ -48388,7 +48643,7 @@
       "source_location": "L448"
     },
     {
-      "community": 209,
+      "community": 208,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -48397,7 +48652,7 @@
       "source_location": "L75"
     },
     {
-      "community": 209,
+      "community": 208,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -48406,7 +48661,7 @@
       "source_location": "L82"
     },
     {
-      "community": 209,
+      "community": 208,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -48415,7 +48670,7 @@
       "source_location": "L93"
     },
     {
-      "community": 209,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -48424,142 +48679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 21,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessions_ts",
-      "label": "registerSessions.ts",
-      "norm_label": "registersessions.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_assertregistersessionidentity",
-      "label": "assertRegisterSessionIdentity()",
-      "norm_label": "assertregistersessionidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_assertregistersessionmatchestransaction",
-      "label": "assertRegisterSessionMatchesTransaction()",
-      "norm_label": "assertregistersessionmatchestransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_assertvalidregistersessiontransition",
-      "label": "assertValidRegisterSessionTransition()",
-      "norm_label": "assertvalidregistersessiontransition()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_buildclosedregistersessionpatch",
-      "label": "buildClosedRegisterSessionPatch()",
-      "norm_label": "buildclosedregistersessionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L250"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_buildregistersessioncloseoutpatch",
-      "label": "buildRegisterSessionCloseoutPatch()",
-      "norm_label": "buildregistersessioncloseoutpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L195"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_buildregistersessiondepositpatch",
-      "label": "buildRegisterSessionDepositPatch()",
-      "norm_label": "buildregistersessiondepositpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_buildregistersessiontransactionpatch",
-      "label": "buildRegisterSessionTransactionPatch()",
-      "norm_label": "buildregistersessiontransactionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L154"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_calculateregistersessioncashdelta",
-      "label": "calculateRegisterSessionCashDelta()",
-      "norm_label": "calculateregistersessioncashdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_findconflictingregistersession",
-      "label": "findConflictingRegisterSession()",
-      "norm_label": "findconflictingregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L276"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_normalizeregistersessionidentity",
-      "label": "normalizeRegisterSessionIdentity()",
-      "norm_label": "normalizeregistersessionidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_persistregistersessionworkflowtraceidbesteffort",
-      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_recordregistersessiondepositwithctx",
-      "label": "recordRegisterSessionDepositWithCtx()",
-      "norm_label": "recordregistersessiondepositwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L490"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "registersessions_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 210,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -48568,7 +48688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 210,
+      "community": 209,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -48577,7 +48697,7 @@
       "source_location": "L15"
     },
     {
-      "community": 210,
+      "community": 209,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -48586,7 +48706,7 @@
       "source_location": "L28"
     },
     {
-      "community": 210,
+      "community": 209,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -48595,7 +48715,151 @@
       "source_location": "L54"
     },
     {
-      "community": 211,
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_assertvalidonlineorderstatustransition",
+      "label": "assertValidOnlineOrderStatusTransition()",
+      "norm_label": "assertvalidonlineorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderpaymentamount",
+      "label": "getOnlineOrderPaymentAmount()",
+      "norm_label": "getonlineorderpaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderpaymentmethodlabel",
+      "label": "getOnlineOrderPaymentMethodLabel()",
+      "norm_label": "getonlineorderpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderstatuseventtype",
+      "label": "getOnlineOrderStatusEventType()",
+      "norm_label": "getonlineorderstatuseventtype()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_getstoreorganizationid",
+      "label": "getStoreOrganizationId()",
+      "norm_label": "getstoreorganizationid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_ispaymentondeliveryorder",
+      "label": "isPaymentOnDeliveryOrder()",
+      "norm_label": "ispaymentondeliveryorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineordercreatedevent",
+      "label": "recordOnlineOrderCreatedEvent()",
+      "norm_label": "recordonlineordercreatedevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderfulfillmentmovement",
+      "label": "recordOnlineOrderFulfillmentMovement()",
+      "norm_label": "recordonlineorderfulfillmentmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L381"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentcollected",
+      "label": "recordOnlineOrderPaymentCollected()",
+      "norm_label": "recordonlineorderpaymentcollected()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L288"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentverified",
+      "label": "recordOnlineOrderPaymentVerified()",
+      "norm_label": "recordonlineorderpaymentverified()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrefundallocation",
+      "label": "recordOnlineOrderRefundAllocation()",
+      "norm_label": "recordonlineorderrefundallocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L347"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrestockmovement",
+      "label": "recordOnlineOrderRestockMovement()",
+      "norm_label": "recordonlineorderrestockmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L409"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderstatusevent",
+      "label": "recordOnlineOrderStatusEvent()",
+      "norm_label": "recordonlineorderstatusevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
+      "label": "resolveCustomerProfileForStoreFrontActor()",
+      "norm_label": "resolvecustomerprofileforstorefrontactor()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "orderoperations_resolveonlineordercontext",
+      "label": "resolveOnlineOrderContext()",
+      "norm_label": "resolveonlineordercontext()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
+      "label": "orderOperations.ts",
+      "norm_label": "orderoperations.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 210,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -48604,7 +48868,7 @@
       "source_location": "L66"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -48613,7 +48877,7 @@
       "source_location": "L121"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -48622,7 +48886,7 @@
       "source_location": "L74"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -48631,7 +48895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -48640,7 +48904,7 @@
       "source_location": "L51"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -48649,7 +48913,7 @@
       "source_location": "L92"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -48658,7 +48922,7 @@
       "source_location": "L16"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -48667,7 +48931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -48676,7 +48940,7 @@
       "source_location": "L16"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -48685,7 +48949,7 @@
       "source_location": "L6"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -48694,7 +48958,7 @@
       "source_location": "L46"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -48703,7 +48967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -48712,7 +48976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -48721,7 +48985,7 @@
       "source_location": "L83"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -48730,7 +48994,7 @@
       "source_location": "L100"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -48739,7 +49003,7 @@
       "source_location": "L79"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -48748,7 +49012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -48757,7 +49021,7 @@
       "source_location": "L25"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -48766,7 +49030,7 @@
       "source_location": "L52"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -48775,7 +49039,7 @@
       "source_location": "L78"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -48784,7 +49048,7 @@
       "source_location": "L4"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -48793,7 +49057,7 @@
       "source_location": "L20"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -48802,7 +49066,7 @@
       "source_location": "L42"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -48811,7 +49075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -48820,7 +49084,7 @@
       "source_location": "L101"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -48829,7 +49093,7 @@
       "source_location": "L68"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -48838,7 +49102,7 @@
       "source_location": "L42"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -48847,7 +49111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -48856,7 +49120,7 @@
       "source_location": "L13"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -48865,7 +49129,7 @@
       "source_location": "L46"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -48874,7 +49138,7 @@
       "source_location": "L21"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -48883,7 +49147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -48892,7 +49156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -48901,7 +49165,7 @@
       "source_location": "L8"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -48910,7 +49174,7 @@
       "source_location": "L5"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -48919,142 +49183,7 @@
       "source_location": "L20"
     },
     {
-      "community": 22,
-      "file_type": "code",
-      "id": "completetransaction_buildcompletetransactionresult",
-      "label": "buildCompleteTransactionResult()",
-      "norm_label": "buildcompletetransactionresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "completetransaction_buildpossaletraceevent",
-      "label": "buildPosSaleTraceEvent()",
-      "norm_label": "buildpossaletraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "completetransaction_buildpossaletracerecord",
-      "label": "buildPosSaleTraceRecord()",
-      "norm_label": "buildpossaletracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "completetransaction_calculatetotalpaid",
-      "label": "calculateTotalPaid()",
-      "norm_label": "calculatetotalpaid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "completetransaction_completetransaction",
-      "label": "completeTransaction()",
-      "norm_label": "completetransaction()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "completetransaction_createtransactionfromsessionhandler",
-      "label": "createTransactionFromSessionHandler()",
-      "norm_label": "createtransactionfromsessionhandler()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L555"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "completetransaction_persistworkflowtraceidbesteffort",
-      "label": "persistWorkflowTraceIdBestEffort()",
-      "norm_label": "persistworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "completetransaction_recordpossaletracebesteffort",
-      "label": "recordPosSaleTraceBestEffort()",
-      "norm_label": "recordpossaletracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "completetransaction_recordregistersessionsale",
-      "label": "recordRegisterSessionSale()",
-      "norm_label": "recordregistersessionsale()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "completetransaction_recordregistersessionvoid",
-      "label": "recordRegisterSessionVoid()",
-      "norm_label": "recordregistersessionvoid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L226"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "completetransaction_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "completetransaction_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "completetransaction_voidtransaction",
-      "label": "voidTransaction()",
-      "norm_label": "voidtransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L486"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
-      "label": "completeTransaction.ts",
-      "norm_label": "completetransaction.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_completetransaction_ts",
-      "label": "completeTransaction.ts",
-      "norm_label": "completetransaction.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 220,
+      "community": 219,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -49063,7 +49192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 220,
+      "community": 219,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -49072,7 +49201,7 @@
       "source_location": "L11"
     },
     {
-      "community": 220,
+      "community": 219,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -49081,7 +49210,7 @@
       "source_location": "L9"
     },
     {
-      "community": 220,
+      "community": 219,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -49090,7 +49219,151 @@
       "source_location": "L25"
     },
     {
-      "community": 221,
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_checkoutsessionerror",
+      "label": "CheckoutSessionError",
+      "norm_label": "checkoutsessionerror",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_checkoutsessionerror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_createcheckoutsession",
+      "label": "createCheckoutSession()",
+      "norm_label": "createcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L184"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_defaultcheckoutactionmessage",
+      "label": "defaultCheckoutActionMessage()",
+      "norm_label": "defaultcheckoutactionmessage()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_getactivecheckoutsession",
+      "label": "getActiveCheckoutSession()",
+      "norm_label": "getactivecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L204"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_getcheckoutactionerrormessage",
+      "label": "getCheckoutActionErrorMessage()",
+      "norm_label": "getcheckoutactionerrormessage()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_getcheckouterrormessagefrompayload",
+      "label": "getCheckoutErrorMessageFromPayload()",
+      "norm_label": "getcheckouterrormessagefrompayload()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_getcheckoutsession",
+      "label": "getCheckoutSession()",
+      "norm_label": "getcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_getpendingcheckoutsessions",
+      "label": "getPendingCheckoutSessions()",
+      "norm_label": "getpendingcheckoutsessions()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_parsecheckoutresponse",
+      "label": "parseCheckoutResponse()",
+      "norm_label": "parsecheckoutresponse()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_parsejson",
+      "label": "parseJson()",
+      "norm_label": "parsejson()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_updatecheckoutsession",
+      "label": "updateCheckoutSession()",
+      "norm_label": "updatecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "checkoutsession_verifycheckoutsessionpayment",
+      "label": "verifyCheckoutSessionPayment()",
+      "norm_label": "verifycheckoutsessionpayment()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L274"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 220,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -49099,7 +49372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 220,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -49108,7 +49381,7 @@
       "source_location": "L50"
     },
     {
-      "community": 221,
+      "community": 220,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -49117,7 +49390,7 @@
       "source_location": "L92"
     },
     {
-      "community": 221,
+      "community": 220,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -49126,7 +49399,7 @@
       "source_location": "L74"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -49135,7 +49408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -49144,7 +49417,7 @@
       "source_location": "L62"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -49153,7 +49426,7 @@
       "source_location": "L109"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -49162,7 +49435,7 @@
       "source_location": "L177"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -49171,7 +49444,7 @@
       "source_location": "L18"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -49180,7 +49453,7 @@
       "source_location": "L52"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -49189,7 +49462,7 @@
       "source_location": "L68"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -49198,7 +49471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -49207,7 +49480,7 @@
       "source_location": "L68"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -49216,7 +49489,7 @@
       "source_location": "L26"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -49225,7 +49498,7 @@
       "source_location": "L7"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -49234,7 +49507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -49243,7 +49516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -49252,7 +49525,7 @@
       "source_location": "L43"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -49261,7 +49534,7 @@
       "source_location": "L13"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -49270,7 +49543,7 @@
       "source_location": "L88"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -49279,7 +49552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -49288,7 +49561,7 @@
       "source_location": "L111"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -49297,13 +49570,49 @@
       "source_location": "L66"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
       "norm_label": "handlesuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L127"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
     },
     {
       "community": 227,
@@ -49416,137 +49725,137 @@
     {
       "community": 23,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
-      "label": "sessionCommands.ts",
-      "norm_label": "sessioncommands.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessions_ts",
+      "label": "registerSessions.ts",
+      "norm_label": "registersessions.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "sessioncommands_buildnextsessionnumber",
-      "label": "buildNextSessionNumber()",
-      "norm_label": "buildnextsessionnumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L539"
+      "id": "registersessions_assertregistersessionidentity",
+      "label": "assertRegisterSessionIdentity()",
+      "norm_label": "assertregistersessionidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L54"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "sessioncommands_createdefaultsessioncommandservice",
-      "label": "createDefaultSessionCommandService()",
-      "norm_label": "createdefaultsessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L497"
+      "id": "registersessions_assertregistersessionmatchestransaction",
+      "label": "assertRegisterSessionMatchesTransaction()",
+      "norm_label": "assertregistersessionmatchestransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L64"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "sessioncommands_createpossessioncommandservice",
-      "label": "createPosSessionCommandService()",
-      "norm_label": "createpossessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L130"
+      "id": "registersessions_assertvalidregistersessiontransition",
+      "label": "assertValidRegisterSessionTransition()",
+      "norm_label": "assertvalidregistersessiontransition()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L135"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "sessioncommands_failure",
-      "label": "failure()",
-      "norm_label": "failure()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L638"
+      "id": "registersessions_buildclosedregistersessionpatch",
+      "label": "buildClosedRegisterSessionPatch()",
+      "norm_label": "buildclosedregistersessionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L250"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "sessioncommands_issessionexpired",
-      "label": "isSessionExpired()",
-      "norm_label": "issessionexpired()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L550"
+      "id": "registersessions_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L100"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "sessioncommands_recordsessionlifecyclebesteffort",
-      "label": "recordSessionLifecycleBestEffort()",
-      "norm_label": "recordsessionlifecyclebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L509"
+      "id": "registersessions_buildregistersessioncloseoutpatch",
+      "label": "buildRegisterSessionCloseoutPatch()",
+      "norm_label": "buildregistersessioncloseoutpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L195"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "sessioncommands_runholdsessioncommand",
-      "label": "runHoldSessionCommand()",
-      "norm_label": "runholdsessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L472"
+      "id": "registersessions_buildregistersessiondepositpatch",
+      "label": "buildRegisterSessionDepositPatch()",
+      "norm_label": "buildregistersessiondepositpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L221"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "sessioncommands_runremovesessionitemcommand",
-      "label": "runRemoveSessionItemCommand()",
-      "norm_label": "runremovesessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "id": "registersessions_buildregistersessiontransactionpatch",
+      "label": "buildRegisterSessionTransactionPatch()",
+      "norm_label": "buildregistersessiontransactionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "registersessions_calculateregistersessioncashdelta",
+      "label": "calculateRegisterSessionCashDelta()",
+      "norm_label": "calculateregistersessioncashdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "registersessions_findconflictingregistersession",
+      "label": "findConflictingRegisterSession()",
+      "norm_label": "findconflictingregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L276"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "registersessions_normalizeregistersessionidentity",
+      "label": "normalizeRegisterSessionIdentity()",
+      "norm_label": "normalizeregistersessionidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "registersessions_persistregistersessionworkflowtraceidbesteffort",
+      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "registersessions_recordregistersessiondepositwithctx",
+      "label": "recordRegisterSessionDepositWithCtx()",
+      "norm_label": "recordregistersessiondepositwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
       "source_location": "L490"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "sessioncommands_runresumesessioncommand",
-      "label": "runResumeSessionCommand()",
-      "norm_label": "runresumesessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L476"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "sessioncommands_runstartsessioncommand",
-      "label": "runStartSessionCommand()",
-      "norm_label": "runstartsessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L465"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "sessioncommands_runupsertsessionitemcommand",
-      "label": "runUpsertSessionItemCommand()",
-      "norm_label": "runupsertsessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L483"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "sessioncommands_success",
-      "label": "success()",
-      "norm_label": "success()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L631"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "sessioncommands_validateactivesession",
-      "label": "validateActiveSession()",
-      "norm_label": "validateactivesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L554"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "sessioncommands_validatemodifiablesession",
-      "label": "validateModifiableSession()",
-      "norm_label": "validatemodifiablesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L598"
+      "id": "registersessions_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L20"
     },
     {
       "community": 230,
@@ -61998,73 +62307,73 @@
     {
       "community": 60,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
     },
     {
       "community": 60,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {
@@ -62250,74 +62559,74 @@
     {
       "community": 61,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L224"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L103"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L557"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L216"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L530"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L522"
     },
     {
       "community": 610,
@@ -62502,74 +62811,74 @@
     {
       "community": 62,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "id": "gettransactions_formatcashiername",
+      "label": "formatCashierName()",
+      "norm_label": "formatcashiername()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "gettransactions_getcompletedtransactions",
+      "label": "getCompletedTransactions()",
+      "norm_label": "getcompletedtransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "gettransactions_getrecenttransactionswithcustomers",
+      "label": "getRecentTransactionsWithCustomers()",
+      "norm_label": "getrecenttransactionswithcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "gettransactions_gettodaysummary",
+      "label": "getTodaySummary()",
+      "norm_label": "gettodaysummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "gettransactions_gettransaction",
+      "label": "getTransaction()",
+      "norm_label": "gettransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionbyid",
+      "label": "getTransactionById()",
+      "norm_label": "gettransactionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionsbystore",
+      "label": "getTransactionsByStore()",
+      "norm_label": "gettransactionsbystore()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
+      "label": "getTransactions.ts",
+      "norm_label": "gettransactions.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L224"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L103"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L557"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L216"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L530"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L522"
     },
     {
       "community": 620,
@@ -62754,74 +63063,74 @@
     {
       "community": 63,
       "file_type": "code",
-      "id": "gettransactions_formatcashiername",
-      "label": "formatCashierName()",
-      "norm_label": "formatcashiername()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "gettransactions_getcompletedtransactions",
-      "label": "getCompletedTransactions()",
-      "norm_label": "getcompletedtransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "gettransactions_getrecenttransactionswithcustomers",
-      "label": "getRecentTransactionsWithCustomers()",
-      "norm_label": "getrecenttransactionswithcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "gettransactions_gettodaysummary",
-      "label": "getTodaySummary()",
-      "norm_label": "gettodaysummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "gettransactions_gettransaction",
-      "label": "getTransaction()",
-      "norm_label": "gettransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionbyid",
-      "label": "getTransactionById()",
-      "norm_label": "gettransactionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "gettransactions_gettransactionsbystore",
-      "label": "getTransactionsByStore()",
-      "norm_label": "gettransactionsbystore()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
-      "label": "getTransactions.ts",
-      "norm_label": "gettransactions.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "sessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L880"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L874"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L870"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "sessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L890"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "sessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L650"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "sessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L727"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "sessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L632"
     },
     {
       "community": 630,
@@ -63006,74 +63315,74 @@
     {
       "community": 64,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
-      "label": "replenishment.ts",
-      "norm_label": "replenishment.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 64,
       "file_type": "code",
-      "id": "replenishment_buildguidance",
-      "label": "buildGuidance()",
-      "norm_label": "buildguidance()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "replenishment_buildpendingskucontextbyid",
-      "label": "buildPendingSkuContextById()",
-      "norm_label": "buildpendingskucontextbyid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L111"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "replenishment_getstatusrank",
-      "label": "getStatusRank()",
-      "norm_label": "getstatusrank()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "replenishment_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "replenishment_listreplenishmentrecommendationswithctx",
-      "label": "listReplenishmentRecommendationsWithCtx()",
-      "norm_label": "listreplenishmentrecommendationswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "replenishment_liststoreproductskus",
-      "label": "listStoreProductSkus()",
-      "norm_label": "liststoreproductskus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "replenishment_liststorepurchaseordersbystatus",
-      "label": "listStorePurchaseOrdersByStatus()",
-      "norm_label": "liststorepurchaseordersbystatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L74"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 640,
@@ -63258,74 +63567,74 @@
     {
       "community": 65,
       "file_type": "code",
-      "id": "data_table_row_actions_datatablerowactions",
-      "label": "DataTableRowActions()",
-      "norm_label": "datatablerowactions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx",
+      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
+      "label": "replenishment.ts",
+      "norm_label": "replenishment.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
       "source_location": "L1"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_buildguidance",
+      "label": "buildGuidance()",
+      "norm_label": "buildguidance()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L42"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_buildpendingskucontextbyid",
+      "label": "buildPendingSkuContextById()",
+      "norm_label": "buildpendingskucontextbyid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L111"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_getstatusrank",
+      "label": "getStatusRank()",
+      "norm_label": "getstatusrank()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L31"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L94"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_listreplenishmentrecommendationswithctx",
+      "label": "listReplenishmentRecommendationsWithCtx()",
+      "norm_label": "listreplenishmentrecommendationswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L179"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
-      "source_location": "L1"
+      "id": "replenishment_liststoreproductskus",
+      "label": "listStoreProductSkus()",
+      "norm_label": "liststoreproductskus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "replenishment_liststorepurchaseordersbystatus",
+      "label": "listStorePurchaseOrdersByStatus()",
+      "norm_label": "liststorepurchaseordersbystatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L74"
     },
     {
       "community": 650,
@@ -63510,74 +63819,74 @@
     {
       "community": 66,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
-      "label": "welcome-offer-modal.tsx",
-      "norm_label": "welcome-offer-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "id": "data_table_row_actions_datatablerowactions",
+      "label": "DataTableRowActions()",
+      "norm_label": "datatablerowactions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx",
       "source_location": "L1"
     },
     {
       "community": 66,
       "file_type": "code",
-      "id": "welcome_offer_modal_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L76"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 66,
       "file_type": "code",
-      "id": "welcome_offer_modal_handlecolorchange",
-      "label": "handleColorChange()",
-      "norm_label": "handlecolorchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L92"
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 66,
       "file_type": "code",
-      "id": "welcome_offer_modal_handlenumberchange",
-      "label": "handleNumberChange()",
-      "norm_label": "handlenumberchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L83"
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 66,
       "file_type": "code",
-      "id": "welcome_offer_modal_handleselectchange",
-      "label": "handleSelectChange()",
-      "norm_label": "handleselectchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L96"
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 66,
       "file_type": "code",
-      "id": "welcome_offer_modal_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L104"
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 66,
       "file_type": "code",
-      "id": "welcome_offer_modal_handleswitchchange",
-      "label": "handleSwitchChange()",
-      "norm_label": "handleswitchchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L88"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "welcome_offer_modal_updateimages",
-      "label": "updateImages()",
-      "norm_label": "updateimages()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L100"
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
+      "source_location": "L1"
     },
     {
       "community": 660,
@@ -63762,74 +64071,74 @@
     {
       "community": 67,
       "file_type": "code",
-      "id": "foundations_content_colorrolecard",
-      "label": "ColorRoleCard()",
-      "norm_label": "colorrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L197"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "foundations_content_densitycard",
-      "label": "DensityCard()",
-      "norm_label": "densitycard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L258"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "foundations_content_hslvar",
-      "label": "hslVar()",
-      "norm_label": "hslvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L189"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "foundations_content_motioncard",
-      "label": "MotionCard()",
-      "norm_label": "motioncard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L317"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "foundations_content_spacetokenrow",
-      "label": "SpaceTokenRow()",
-      "norm_label": "spacetokenrow()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "foundations_content_textvar",
-      "label": "textVar()",
-      "norm_label": "textvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L193"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "foundations_content_typespecimencard",
-      "label": "TypeSpecimenCard()",
-      "norm_label": "typespecimencard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L221"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
-      "label": "foundations-content.tsx",
-      "norm_label": "foundations-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
+      "label": "welcome-offer-modal.tsx",
+      "norm_label": "welcome-offer-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlecolorchange",
+      "label": "handleColorChange()",
+      "norm_label": "handlecolorchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlenumberchange",
+      "label": "handleNumberChange()",
+      "norm_label": "handlenumberchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handleselectchange",
+      "label": "handleSelectChange()",
+      "norm_label": "handleselectchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L96"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handleswitchchange",
+      "label": "handleSwitchChange()",
+      "norm_label": "handleswitchchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "welcome_offer_modal_updateimages",
+      "label": "updateImages()",
+      "norm_label": "updateimages()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L100"
     },
     {
       "community": 670,
@@ -64014,73 +64323,73 @@
     {
       "community": 68,
       "file_type": "code",
-      "id": "bag_additemtobag",
-      "label": "addItemToBag()",
-      "norm_label": "additemtobag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L27"
+      "id": "foundations_content_colorrolecard",
+      "label": "ColorRoleCard()",
+      "norm_label": "colorrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L197"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "bag_clearbag",
-      "label": "clearBag()",
-      "norm_label": "clearbag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L106"
+      "id": "foundations_content_densitycard",
+      "label": "DensityCard()",
+      "norm_label": "densitycard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L258"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "bag_getactivebag",
-      "label": "getActiveBag()",
-      "norm_label": "getactivebag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L12"
+      "id": "foundations_content_hslvar",
+      "label": "hslVar()",
+      "norm_label": "hslvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L189"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "bag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L10"
+      "id": "foundations_content_motioncard",
+      "label": "MotionCard()",
+      "norm_label": "motioncard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L317"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "bag_removeitemfrombag",
-      "label": "removeItemFromBag()",
-      "norm_label": "removeitemfrombag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L90"
+      "id": "foundations_content_spacetokenrow",
+      "label": "SpaceTokenRow()",
+      "norm_label": "spacetokenrow()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L240"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "bag_updatebagitem",
-      "label": "updateBagItem()",
-      "norm_label": "updatebagitem()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L63"
+      "id": "foundations_content_textvar",
+      "label": "textVar()",
+      "norm_label": "textvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L193"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "bag_updatebagowner",
-      "label": "updateBagOwner()",
-      "norm_label": "updatebagowner()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L118"
+      "id": "foundations_content_typespecimencard",
+      "label": "TypeSpecimenCard()",
+      "norm_label": "typespecimencard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L221"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
+      "label": "foundations-content.tsx",
+      "norm_label": "foundations-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
       "source_location": "L1"
     },
     {
@@ -64266,74 +64575,74 @@
     {
       "community": 69,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L1"
+      "id": "bag_additemtobag",
+      "label": "addItemToBag()",
+      "norm_label": "additemtobag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L27"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "product_buildquerystring",
-      "label": "buildQueryString()",
-      "norm_label": "buildquerystring()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L5"
+      "id": "bag_clearbag",
+      "label": "clearBag()",
+      "norm_label": "clearbag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L106"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "product_getallproducts",
-      "label": "getAllProducts()",
-      "norm_label": "getallproducts()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L20"
+      "id": "bag_getactivebag",
+      "label": "getActiveBag()",
+      "norm_label": "getactivebag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L12"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "product_getbaseurl",
+      "id": "bag_getbaseurl",
       "label": "getBaseUrl()",
       "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L18"
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L10"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "product_getbestsellers",
-      "label": "getBestSellers()",
-      "norm_label": "getbestsellers()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L59"
+      "id": "bag_removeitemfrombag",
+      "label": "removeItemFromBag()",
+      "norm_label": "removeitemfrombag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L90"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "product_getfeatured",
-      "label": "getFeatured()",
-      "norm_label": "getfeatured()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L73"
+      "id": "bag_updatebagitem",
+      "label": "updateBagItem()",
+      "norm_label": "updatebagitem()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L63"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "product_getinventorybyskuids",
-      "label": "getInventoryBySkuIds()",
-      "norm_label": "getinventorybyskuids()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L93"
+      "id": "bag_updatebagowner",
+      "label": "updateBagOwner()",
+      "norm_label": "updatebagowner()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L118"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "product_getproduct",
-      "label": "getProduct()",
-      "norm_label": "getproduct()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L40"
+      "id": "packages_storefront_webapp_src_api_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L1"
     },
     {
       "community": 690,
@@ -64743,74 +65052,74 @@
     {
       "community": 70,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "label": "ShoppingBag.tsx",
-      "norm_label": "shoppingbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "id": "packages_storefront_webapp_src_api_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L1"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "shoppingbag_handleclickondiscountcode",
-      "label": "handleClickOnDiscountCode()",
-      "norm_label": "handleclickondiscountcode()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L553"
+      "id": "product_buildquerystring",
+      "label": "buildQueryString()",
+      "norm_label": "buildquerystring()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L5"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "shoppingbag_handledeleteitem",
-      "label": "handleDeleteItem()",
-      "norm_label": "handledeleteitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L594"
+      "id": "product_getallproducts",
+      "label": "getAllProducts()",
+      "norm_label": "getallproducts()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L20"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "shoppingbag_handlemovetosaved",
-      "label": "handleMoveToSaved()",
-      "norm_label": "handlemovetosaved()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L580"
+      "id": "product_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L18"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "shoppingbag_handleoncheckoutclick",
-      "label": "handleOnCheckoutClick()",
-      "norm_label": "handleoncheckoutclick()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L504"
+      "id": "product_getbestsellers",
+      "label": "getBestSellers()",
+      "norm_label": "getbestsellers()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L59"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "shoppingbag_isskuunavailable",
-      "label": "isSkuUnavailable()",
-      "norm_label": "isskuunavailable()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L565"
+      "id": "product_getfeatured",
+      "label": "getFeatured()",
+      "norm_label": "getfeatured()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L73"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "shoppingbag_pendingitem",
-      "label": "PendingItem()",
-      "norm_label": "pendingitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L62"
+      "id": "product_getinventorybyskuids",
+      "label": "getInventoryBySkuIds()",
+      "norm_label": "getinventorybyskuids()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L93"
     },
     {
       "community": 70,
       "file_type": "code",
-      "id": "shoppingbag_shoppingbagcheckoutbutton",
-      "label": "ShoppingBagCheckoutButton()",
-      "norm_label": "shoppingbagcheckoutbutton()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L110"
+      "id": "product_getproduct",
+      "label": "getProduct()",
+      "norm_label": "getproduct()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L40"
     },
     {
       "community": 700,
@@ -64995,74 +65304,74 @@
     {
       "community": 71,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "label": "storefrontObservability.ts",
-      "norm_label": "storefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
+      "label": "ShoppingBag.tsx",
+      "norm_label": "shoppingbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "label": "createStorefrontObservabilityContext()",
-      "norm_label": "createstorefrontobservabilitycontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L172"
+      "id": "shoppingbag_handleclickondiscountcode",
+      "label": "handleClickOnDiscountCode()",
+      "norm_label": "handleclickondiscountcode()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L553"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "label": "createStorefrontObservabilityPayload()",
-      "norm_label": "createstorefrontobservabilitypayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L200"
+      "id": "shoppingbag_handledeleteitem",
+      "label": "handleDeleteItem()",
+      "norm_label": "handledeleteitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L594"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "label": "getOrCreateStorefrontObservabilitySessionId()",
-      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L147"
+      "id": "shoppingbag_handlemovetosaved",
+      "label": "handleMoveToSaved()",
+      "norm_label": "handlemovetosaved()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L580"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "storefrontobservability_isbrowserautomationcontext",
-      "label": "isBrowserAutomationContext()",
-      "norm_label": "isbrowserautomationcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L115"
+      "id": "shoppingbag_handleoncheckoutclick",
+      "label": "handleOnCheckoutClick()",
+      "norm_label": "handleoncheckoutclick()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L504"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "storefrontobservability_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L111"
+      "id": "shoppingbag_isskuunavailable",
+      "label": "isSkuUnavailable()",
+      "norm_label": "isskuunavailable()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L565"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
-      "label": "resolveStorefrontAnalyticsOrigin()",
-      "norm_label": "resolvestorefrontanalyticsorigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L125"
+      "id": "shoppingbag_pendingitem",
+      "label": "PendingItem()",
+      "norm_label": "pendingitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L62"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "storefrontobservability_trackstorefrontevent",
-      "label": "trackStorefrontEvent()",
-      "norm_label": "trackstorefrontevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L236"
+      "id": "shoppingbag_shoppingbagcheckoutbutton",
+      "label": "ShoppingBagCheckoutButton()",
+      "norm_label": "shoppingbagcheckoutbutton()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L110"
     },
     {
       "community": 710,
@@ -65211,65 +65520,74 @@
     {
       "community": 72,
       "file_type": "code",
-      "id": "inventoryholds_acquireinventoryhold",
-      "label": "acquireInventoryHold()",
-      "norm_label": "acquireinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "inventoryholds_acquireinventoryholdsbatch",
-      "label": "acquireInventoryHoldsBatch()",
-      "norm_label": "acquireinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L190"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "inventoryholds_adjustinventoryhold",
-      "label": "adjustInventoryHold()",
-      "norm_label": "adjustinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "inventoryholds_releaseinventoryhold",
-      "label": "releaseInventoryHold()",
-      "norm_label": "releaseinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "inventoryholds_releaseinventoryholdsbatch",
-      "label": "releaseInventoryHoldsBatch()",
-      "norm_label": "releaseinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "inventoryholds_validateinventoryavailability",
-      "label": "validateInventoryAvailability()",
-      "norm_label": "validateinventoryavailability()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
-      "label": "inventoryHolds.ts",
-      "norm_label": "inventoryholds.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
+      "label": "storefrontObservability.ts",
+      "norm_label": "storefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitycontext",
+      "label": "createStorefrontObservabilityContext()",
+      "norm_label": "createstorefrontobservabilitycontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitypayload",
+      "label": "createStorefrontObservabilityPayload()",
+      "norm_label": "createstorefrontobservabilitypayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L200"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
+      "label": "getOrCreateStorefrontObservabilitySessionId()",
+      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "storefrontobservability_isbrowserautomationcontext",
+      "label": "isBrowserAutomationContext()",
+      "norm_label": "isbrowserautomationcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "storefrontobservability_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
+      "label": "resolveStorefrontAnalyticsOrigin()",
+      "norm_label": "resolvestorefrontanalyticsorigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "storefrontobservability_trackstorefrontevent",
+      "label": "trackStorefrontEvent()",
+      "norm_label": "trackstorefrontevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L236"
     },
     {
       "community": 720,
@@ -65364,64 +65682,64 @@
     {
       "community": 73,
       "file_type": "code",
-      "id": "client_buildheaders",
-      "label": "buildHeaders()",
-      "norm_label": "buildheaders()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "id": "inventoryholds_acquireinventoryhold",
+      "label": "acquireInventoryHold()",
+      "norm_label": "acquireinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "inventoryholds_acquireinventoryholdsbatch",
+      "label": "acquireInventoryHoldsBatch()",
+      "norm_label": "acquireinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L190"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "inventoryholds_adjustinventoryhold",
+      "label": "adjustInventoryHold()",
+      "norm_label": "adjustinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "inventoryholds_releaseinventoryhold",
+      "label": "releaseInventoryHold()",
+      "norm_label": "releaseinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "inventoryholds_releaseinventoryholdsbatch",
+      "label": "releaseInventoryHoldsBatch()",
+      "norm_label": "releaseinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "inventoryholds_validateinventoryavailability",
+      "label": "validateInventoryAvailability()",
+      "norm_label": "validateinventoryavailability()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L20"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "client_createcollectionsaccesstoken",
-      "label": "createCollectionsAccessToken()",
-      "norm_label": "createcollectionsaccesstoken()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "client_encodebasicauth",
-      "label": "encodeBasicAuth()",
-      "norm_label": "encodebasicauth()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "client_getrequesttopaystatus",
-      "label": "getRequestToPayStatus()",
-      "norm_label": "getrequesttopaystatus()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "client_requesttopay",
-      "label": "requestToPay()",
-      "norm_label": "requesttopay()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "client_toerror",
-      "label": "toError()",
-      "norm_label": "toerror()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_client_ts",
-      "label": "client.ts",
-      "norm_label": "client.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
+      "label": "inventoryHolds.ts",
+      "norm_label": "inventoryholds.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L1"
     },
     {
@@ -65517,65 +65835,65 @@
     {
       "community": 74,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "id": "client_buildheaders",
+      "label": "buildHeaders()",
+      "norm_label": "buildheaders()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "client_createcollectionsaccesstoken",
+      "label": "createCollectionsAccessToken()",
+      "norm_label": "createcollectionsaccesstoken()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "client_encodebasicauth",
+      "label": "encodeBasicAuth()",
+      "norm_label": "encodebasicauth()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "client_getrequesttopaystatus",
+      "label": "getRequestToPayStatus()",
+      "norm_label": "getrequesttopaystatus()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "client_requesttopay",
+      "label": "requestToPay()",
+      "norm_label": "requesttopay()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "client_toerror",
+      "label": "toError()",
+      "norm_label": "toerror()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_client_ts",
+      "label": "client.ts",
+      "norm_label": "client.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L72"
     },
     {
       "community": 740,
@@ -65670,65 +65988,65 @@
     {
       "community": 75,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
       "source_location": "L1"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "sessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L766"
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L81"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L762"
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L129"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L776"
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L94"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L585"
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L249"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L662"
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L56"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L567"
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L72"
     },
     {
       "community": 750,
@@ -67857,65 +68175,65 @@
     {
       "community": 88,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 880,
@@ -68010,65 +68328,65 @@
     {
       "community": 89,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 890,
@@ -68352,65 +68670,65 @@
     {
       "community": 90,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 90,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 900,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1471
-- Graph nodes: 3623
-- Graph edges: 3101
+- Graph nodes: 3633
+- Graph edges: 3120
 - Communities: 1386
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `storeConfigV2.ts` (27 edges, Community 4) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
 - `ProductStock.tsx` (19 edges, Community 10) - [`packages/athena-webapp/src/components/add-product/ProductStock.tsx`](../../../packages/athena-webapp/src/components/add-product/ProductStock.tsx)
-- `checkoutSession.ts` (17 edges, Community 13) - [`packages/athena-webapp/convex/storeFront/checkoutSession.ts`](../../../packages/athena-webapp/convex/storeFront/checkoutSession.ts)
-- `transactionRepository.ts` (17 edges, Community 12) - [`packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts`](../../../packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts)
-- `customerRepository.ts` (16 edges, Community 15) - [`packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts`](../../../packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts)
+- `sessionCommands.ts` (18 edges, Community 13) - [`packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`](../../../packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts)
+- `transactionRepository.ts` (18 edges, Community 14) - [`packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts`](../../../packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts)
+- `checkoutSession.ts` (17 edges, Community 15) - [`packages/athena-webapp/convex/storeFront/checkoutSession.ts`](../../../packages/athena-webapp/convex/storeFront/checkoutSession.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 8) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 20) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 22) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 8) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/packages/athena-webapp/convex/inventory/posSessions.ts
+++ b/packages/athena-webapp/convex/inventory/posSessions.ts
@@ -372,6 +372,7 @@ export const createSession = mutation({
     terminalId: v.id("posTerminal"),
     cashierId: v.optional(v.id("cashier")),
     registerNumber: v.optional(v.string()),
+    registerSessionId: v.optional(v.id("registerSession")),
   },
   returns: createSessionResultValidator,
   handler: async (ctx, args) => {

--- a/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
@@ -16,6 +16,7 @@ import {
   createPosTransaction,
   createPosTransactionItem,
   getPosSessionById,
+  getRegisterSessionById,
   getPosTransactionById,
   getProductSkuById,
   getStoreById,
@@ -69,6 +70,49 @@ export function buildCompleteTransactionResult(input: {
 
 function calculateTotalPaid(payments: PosPaymentInput[]) {
   return payments.reduce((sum, payment) => sum + payment.amount, 0);
+}
+
+function normalizeRegisterNumber(registerNumber?: string | null) {
+  const trimmedRegisterNumber = registerNumber?.trim();
+  return trimmedRegisterNumber ? trimmedRegisterNumber : undefined;
+}
+
+function registerSessionMatchesIdentity(
+  registerSession: {
+    registerNumber?: string;
+    terminalId?: Id<"posTerminal">;
+  },
+  identity: {
+    registerNumber?: string;
+    terminalId?: Id<"posTerminal">;
+  },
+) {
+  const normalizedRegisterNumber = normalizeRegisterNumber(identity.registerNumber);
+  const normalizedSessionRegisterNumber = normalizeRegisterNumber(
+    registerSession.registerNumber,
+  );
+
+  let hasSharedIdentity = false;
+
+  if (normalizedRegisterNumber && normalizedSessionRegisterNumber) {
+    hasSharedIdentity = true;
+    if (normalizedRegisterNumber !== normalizedSessionRegisterNumber) {
+      return false;
+    }
+  }
+
+  if (identity.terminalId && registerSession.terminalId) {
+    hasSharedIdentity = true;
+    if (identity.terminalId !== registerSession.terminalId) {
+      return false;
+    }
+  }
+
+  return hasSharedIdentity;
+}
+
+function isUsableRegisterSession(registerSession: { status: string }) {
+  return registerSession.status === "open" || registerSession.status === "active";
 }
 
 async function safeTraceWrite(
@@ -196,6 +240,45 @@ async function persistWorkflowTraceIdBestEffort(
       workflowTraceId: args.traceId,
     });
   });
+}
+
+async function resolveSessionRegisterSessionId(
+  ctx: MutationCtx,
+  args: {
+    session: NonNullable<Awaited<ReturnType<typeof getPosSessionById>>>;
+    providedRegisterSessionId?: Id<"registerSession">;
+  },
+) {
+  const resolvedRegisterSessionId =
+    args.session.registerSessionId ?? args.providedRegisterSessionId;
+
+  if (!resolvedRegisterSessionId) {
+    throw new Error("Open the cash drawer before completing this sale.");
+  }
+
+  if (
+    args.session.registerSessionId &&
+    args.providedRegisterSessionId &&
+    args.session.registerSessionId !== args.providedRegisterSessionId
+  ) {
+    throw new Error("Open the cash drawer before completing this sale.");
+  }
+
+  const registerSession = await getRegisterSessionById(ctx, resolvedRegisterSessionId);
+
+  if (
+    !registerSession ||
+    registerSession.storeId !== args.session.storeId ||
+    !isUsableRegisterSession(registerSession) ||
+    !registerSessionMatchesIdentity(registerSession, {
+      registerNumber: args.session.registerNumber,
+      terminalId: args.session.terminalId,
+    })
+  ) {
+    throw new Error("Open the cash drawer before completing this sale.");
+  }
+
+  return resolvedRegisterSessionId;
 }
 
 async function recordRegisterSessionSale(
@@ -571,6 +654,11 @@ export async function createTransactionFromSessionHandler(
     throw new Error("Cannot complete session with no items");
   }
 
+  const resolvedRegisterSessionId = await resolveSessionRegisterSessionId(ctx, {
+    session,
+    providedRegisterSessionId: args.registerSessionId,
+  });
+
   const skuQuantityMap = new Map<Id<"productSku">, number>();
   for (const item of items) {
     skuQuantityMap.set(
@@ -618,7 +706,7 @@ export async function createTransactionFromSessionHandler(
     transactionNumber,
     storeId: session.storeId,
     sessionId: args.sessionId,
-    registerSessionId: args.registerSessionId,
+    registerSessionId: resolvedRegisterSessionId,
     customerId: session.customerId,
     cashierId: session.cashierId,
     registerNumber: session.registerNumber,
@@ -643,7 +731,7 @@ export async function createTransactionFromSessionHandler(
     startedAt: traceStartedAt,
     transactionNumber,
     posTransactionId: transactionId,
-    registerSessionId: args.registerSessionId,
+    registerSessionId: resolvedRegisterSessionId,
     cashierId: session.cashierId,
     terminalId: session.terminalId,
     customerId: session.customerId,
@@ -660,16 +748,14 @@ export async function createTransactionFromSessionHandler(
     transactionId,
   });
 
-  if (args.registerSessionId) {
-    await recordRegisterSessionSale(ctx, {
-      changeGiven,
-      payments: args.payments,
-      registerSessionId: args.registerSessionId,
-      registerNumber: session.registerNumber,
-      storeId: session.storeId,
-      terminalId: session.terminalId,
-    });
-  }
+  await recordRegisterSessionSale(ctx, {
+    changeGiven,
+    payments: args.payments,
+    registerSessionId: resolvedRegisterSessionId,
+    registerNumber: session.registerNumber,
+    storeId: session.storeId,
+    terminalId: session.terminalId,
+  });
 
   const completionResult = buildCompleteTransactionResult({
     transactionId,
@@ -679,7 +765,7 @@ export async function createTransactionFromSessionHandler(
       organizationId: store?.organizationId,
       payments: args.payments,
       posTransactionId: transactionId,
-      registerSessionId: args.registerSessionId,
+      registerSessionId: resolvedRegisterSessionId,
       storeId: session.storeId,
       transactionNumber,
     }),
@@ -730,6 +816,7 @@ export async function createTransactionFromSessionHandler(
 
   await patchPosSession(ctx, args.sessionId, {
     transactionId,
+    registerSessionId: resolvedRegisterSessionId,
   });
 
   const finalizedTrace = await recordPosSaleTraceBestEffort(ctx, {

--- a/packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts
@@ -56,6 +56,7 @@ export type PosSessionTraceableSession = Pick<
   | "subtotal"
   | "tax"
   | "total"
+  | "registerSessionId"
   | "workflowTraceId"
 >;
 

--- a/packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts
@@ -40,6 +40,7 @@ export interface StartSessionArgs {
   terminalId: Id<"posTerminal">;
   cashierId?: Id<"cashier">;
   registerNumber?: string;
+  registerSessionId?: Id<"registerSession">;
 }
 
 export interface HoldSessionArgs {
@@ -169,27 +170,58 @@ export function createPosSessionCommandService(
       }
 
       if (existingSession) {
+        const registerSessionBinding = await resolveRegisterSessionBinding(
+          dependencies,
+          {
+            storeId: existingSession.storeId,
+            terminalId: existingSession.terminalId,
+            registerNumber: existingSession.registerNumber ?? registerNumber,
+            preferredRegisterSessionId:
+              existingSession.registerSessionId ?? args.registerSessionId,
+            failureMessage: "Open the cash drawer before starting a sale.",
+          },
+        );
+        if (registerSessionBinding.status !== "ok") {
+          return registerSessionBinding;
+        }
+
         const existingItems = await dependencies.repository.listSessionItems(
           existingSession._id,
         );
+        const sessionPatch: Partial<
+          Omit<Doc<"posSession">, "_id" | "_creationTime">
+        > = {};
+
+        if (
+          existingSession.registerSessionId !==
+          registerSessionBinding.data.registerSessionId
+        ) {
+          sessionPatch.registerSessionId =
+            registerSessionBinding.data.registerSessionId;
+          sessionPatch.updatedAt = now;
+        }
 
         if (existingItems.length > 0) {
-          await dependencies.repository.patchSession(existingSession._id, {
+          Object.assign(sessionPatch, {
             status: "held",
             heldAt: now,
             updatedAt: now,
             holdReason: "Auto-held when new session started",
           });
+        }
 
+        if (Object.keys(sessionPatch).length > 0) {
+          await dependencies.repository.patchSession(existingSession._id, sessionPatch);
+        }
+
+        const updatedSession = {
+          ...existingSession,
+          ...sessionPatch,
+        };
+        if (existingItems.length > 0) {
           await recordSessionLifecycleBestEffort(dependencies, {
             stage: "autoHeld",
-            session: {
-              ...existingSession,
-              status: "held",
-              heldAt: now,
-              updatedAt: now,
-              holdReason: "Auto-held when new session started",
-            },
+            session: updatedSession,
             occurredAt: now,
             holdReason: "Auto-held when new session started",
           });
@@ -199,6 +231,20 @@ export function createPosSessionCommandService(
           sessionId: existingSession._id,
           expiresAt: existingSession.expiresAt,
         });
+      }
+
+      const registerSessionBinding = await resolveRegisterSessionBinding(
+        dependencies,
+        {
+          storeId: args.storeId,
+          terminalId: args.terminalId,
+          registerNumber,
+          preferredRegisterSessionId: args.registerSessionId,
+          failureMessage: "Open the cash drawer before starting a sale.",
+        },
+      );
+      if (registerSessionBinding.status !== "ok") {
+        return registerSessionBinding;
       }
 
       const latestSessionNumber =
@@ -214,6 +260,7 @@ export function createPosSessionCommandService(
         cashierId: args.cashierId,
         terminalId: args.terminalId,
         registerNumber,
+        registerSessionId: registerSessionBinding.data.registerSessionId,
         status: "active",
         createdAt: now,
         updatedAt: now,
@@ -229,6 +276,7 @@ export function createPosSessionCommandService(
           cashierId: args.cashierId,
           terminalId: args.terminalId,
           registerNumber,
+          registerSessionId: registerSessionBinding.data.registerSessionId,
           status: "active",
           createdAt: now,
           updatedAt: now,
@@ -305,18 +353,34 @@ export function createPosSessionCommandService(
         );
       }
 
+      const registerSessionBinding = await resolveRegisterSessionBinding(
+        dependencies,
+        {
+          storeId: session.storeId,
+          terminalId: session.terminalId,
+          registerNumber: session.registerNumber,
+          preferredRegisterSessionId: session.registerSessionId,
+          failureMessage: "Open the cash drawer before resuming this sale.",
+        },
+      );
+      if (registerSessionBinding.status !== "ok") {
+        return registerSessionBinding;
+      }
+
       const expiresAt = dependencies.calculateExpiration(now);
       await dependencies.repository.patchSession(args.sessionId, {
         status: "active",
         resumedAt: now,
         updatedAt: now,
         expiresAt,
+        registerSessionId: registerSessionBinding.data.registerSessionId,
       });
 
       await recordSessionLifecycleBestEffort(dependencies, {
         stage: "resumed",
         session: {
           ...session,
+          registerSessionId: registerSessionBinding.data.registerSessionId,
           status: "active",
           resumedAt: now,
           updatedAt: now,
@@ -545,6 +609,82 @@ function buildNextSessionNumber(
     : 0;
   const nextSequence = Number.isFinite(lastSequence) ? lastSequence + 1 : 1;
   return `${prefix}-${String(nextSequence).padStart(3, "0")}`;
+}
+
+function normalizeRegisterNumber(registerNumber?: string | null) {
+  const trimmedRegisterNumber = registerNumber?.trim();
+  return trimmedRegisterNumber ? trimmedRegisterNumber : undefined;
+}
+
+function isActiveRegisterSession(
+  registerSession: Pick<Doc<"registerSession">, "status">,
+) {
+  return registerSession.status === "open" || registerSession.status === "active";
+}
+
+function registerSessionMatchesIdentity(
+  registerSession: Pick<Doc<"registerSession">, "registerNumber" | "terminalId">,
+  identity: {
+    terminalId?: Id<"posTerminal">;
+    registerNumber?: string;
+  },
+) {
+  const normalizedRegisterNumber = normalizeRegisterNumber(identity.registerNumber);
+  const normalizedSessionRegisterNumber = normalizeRegisterNumber(
+    registerSession.registerNumber,
+  );
+
+  let hasSharedIdentity = false;
+
+  if (normalizedRegisterNumber && normalizedSessionRegisterNumber) {
+    hasSharedIdentity = true;
+    if (normalizedRegisterNumber !== normalizedSessionRegisterNumber) {
+      return false;
+    }
+  }
+
+  if (identity.terminalId && registerSession.terminalId) {
+    hasSharedIdentity = true;
+    if (identity.terminalId !== registerSession.terminalId) {
+      return false;
+    }
+  }
+
+  return hasSharedIdentity;
+}
+
+async function resolveRegisterSessionBinding(
+  dependencies: SessionCommandDependencies,
+  args: {
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+    registerNumber?: string;
+    preferredRegisterSessionId?: Id<"registerSession">;
+    failureMessage: string;
+  },
+): Promise<PosSessionCommandOutcome<{ registerSessionId: Id<"registerSession"> }>> {
+  const registerSession = args.preferredRegisterSessionId
+    ? await dependencies.repository.getRegisterSessionById(
+        args.preferredRegisterSessionId,
+      )
+    : await dependencies.repository.getOpenRegisterSessionForIdentity({
+        storeId: args.storeId,
+        terminalId: args.terminalId,
+        registerNumber: args.registerNumber,
+      });
+
+  if (
+    !registerSession ||
+    registerSession.storeId !== args.storeId ||
+    !isActiveRegisterSession(registerSession) ||
+    !registerSessionMatchesIdentity(registerSession, args)
+  ) {
+    return failure("validationFailed", args.failureMessage);
+  }
+
+  return success({
+    registerSessionId: registerSession._id,
+  });
 }
 
 function isSessionExpired(session: Pick<Doc<"posSession">, "expiresAt" | "status">, now: number) {

--- a/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
+++ b/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
@@ -390,8 +390,9 @@ describe("completeTransaction trace ordering", () => {
   });
 
   it("uses the stored session drawer binding during session-based checkout", async () => {
+    const runMutation = vi.fn().mockResolvedValue(undefined);
     const ctx = {
-      runMutation: vi.fn().mockResolvedValue(undefined),
+      runMutation,
     } as never;
 
     vi.mocked(getStoreById).mockResolvedValue({
@@ -474,7 +475,7 @@ describe("completeTransaction trace ordering", () => {
         registerSessionId: "register-1",
       }),
     );
-    expect(ctx.runMutation).toHaveBeenCalledWith(
+    expect(runMutation).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         registerSessionId: "register-1",

--- a/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
+++ b/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
@@ -17,6 +17,7 @@ import {
   createPosTransaction,
   createPosTransactionItem,
   getPosSessionById,
+  getRegisterSessionById,
   getProductSkuById,
   getStoreById,
   listSessionItems,
@@ -37,6 +38,7 @@ vi.mock("../infrastructure/repositories/transactionRepository", () => ({
   createPosTransaction: vi.fn(),
   createPosTransactionItem: vi.fn(),
   getPosSessionById: vi.fn(),
+  getRegisterSessionById: vi.fn(),
   getPosTransactionById: vi.fn(),
   getProductSkuById: vi.fn(),
   getStoreById: vi.fn(),
@@ -291,6 +293,10 @@ describe("completeTransaction trace ordering", () => {
   });
 
   it("does not write a successful session-sale trace before the session is fully patched", async () => {
+    const ctx = {
+      runMutation: vi.fn().mockResolvedValue(undefined),
+    } as never;
+
     vi.mocked(getStoreById).mockResolvedValue({
       _id: "store-1",
       organizationId: "org-1",
@@ -301,11 +307,19 @@ describe("completeTransaction trace ordering", () => {
       customerId: undefined,
       cashierId: "cashier-1",
       registerNumber: "1",
+      registerSessionId: "register-1",
       subtotal: 10,
       tax: 0,
       total: 10,
       terminalId: "terminal-1",
       customerInfo: undefined,
+    } as never);
+    vi.mocked(getRegisterSessionById).mockResolvedValue({
+      _id: "register-1",
+      storeId: "store-1",
+      status: "open",
+      terminalId: "terminal-1",
+      registerNumber: "1",
     } as never);
     vi.mocked(listSessionItems).mockResolvedValue([
       {
@@ -354,7 +368,7 @@ describe("completeTransaction trace ordering", () => {
     });
 
     await expect(
-      createTransactionFromSessionHandler({} as never, {
+      createTransactionFromSessionHandler(ctx, {
         sessionId: "session-1" as Id<"posSession">,
         payments: [{ method: "cash", amount: 10, timestamp: 1 }],
       }),
@@ -373,6 +387,141 @@ describe("completeTransaction trace ordering", () => {
         workflowTraceId: expect.stringMatching(/^pos_sale:/),
       }),
     );
+  });
+
+  it("uses the stored session drawer binding during session-based checkout", async () => {
+    const ctx = {
+      runMutation: vi.fn().mockResolvedValue(undefined),
+    } as never;
+
+    vi.mocked(getStoreById).mockResolvedValue({
+      _id: "store-1",
+      organizationId: "org-1",
+    } as never);
+    vi.mocked(getPosSessionById).mockResolvedValue({
+      _id: "session-1",
+      storeId: "store-1",
+      customerId: undefined,
+      cashierId: "cashier-1",
+      registerNumber: "1",
+      registerSessionId: "register-1",
+      subtotal: 10,
+      tax: 0,
+      total: 10,
+      terminalId: "terminal-1",
+      customerInfo: undefined,
+    } as never);
+    vi.mocked(getRegisterSessionById).mockResolvedValue({
+      _id: "register-1",
+      storeId: "store-1",
+      status: "open",
+      terminalId: "terminal-1",
+      registerNumber: "1",
+    } as never);
+    vi.mocked(listSessionItems).mockResolvedValue([
+      {
+        _id: "session-item-1",
+        sessionId: "session-1",
+        storeId: "store-1",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        productSku: "SKU-1",
+        productName: "Sneaker",
+        price: 10,
+        quantity: 1,
+        image: undefined,
+      },
+    ] as never);
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-1",
+      images: [],
+      inventoryCount: 10,
+      productId: "product-1",
+      quantityAvailable: 10,
+      sku: "SKU-1",
+    } as never);
+    vi.mocked(createPosTransaction).mockResolvedValue("txn-1" as never);
+    vi.mocked(recordRetailSalePaymentAllocations).mockResolvedValue(true);
+    vi.mocked(createPosTransactionItem).mockResolvedValue(
+      "txn-item-1" as never,
+    );
+    vi.mocked(patchProductSku).mockResolvedValue(undefined as never);
+    vi.mocked(patchPosSession).mockResolvedValue(undefined as never);
+    vi.mocked(createWorkflowTraceWithCtx).mockResolvedValue("trace-1" as never);
+    vi.mocked(registerWorkflowTraceLookupWithCtx).mockResolvedValue(
+      "lookup-1" as never,
+    );
+    vi.mocked(appendWorkflowTraceEventWithCtx).mockResolvedValue(
+      "event-1" as never,
+    );
+    vi.mocked(patchPosTransaction).mockResolvedValue(undefined as never);
+
+    await expect(
+      createTransactionFromSessionHandler(ctx, {
+        sessionId: "session-1" as Id<"posSession">,
+        payments: [{ method: "cash", amount: 10, timestamp: 1 }],
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        transactionId: "txn-1",
+      }),
+    );
+
+    expect(createPosTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        registerSessionId: "register-1",
+      }),
+    );
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        registerSessionId: "register-1",
+      }),
+    );
+    expect(recordRetailSalePaymentAllocations).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        registerSessionId: "register-1",
+      }),
+    );
+  });
+
+  it("fails when a session sale is not bound to an open drawer", async () => {
+    vi.mocked(getPosSessionById).mockResolvedValue({
+      _id: "session-1",
+      storeId: "store-1",
+      customerId: undefined,
+      cashierId: "cashier-1",
+      registerNumber: "1",
+      subtotal: 10,
+      tax: 0,
+      total: 10,
+      terminalId: "terminal-1",
+      customerInfo: undefined,
+    } as never);
+    vi.mocked(listSessionItems).mockResolvedValue([
+      {
+        _id: "session-item-1",
+        sessionId: "session-1",
+        storeId: "store-1",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        productSku: "SKU-1",
+        productName: "Sneaker",
+        price: 10,
+        quantity: 1,
+        image: undefined,
+      },
+    ] as never);
+
+    await expect(
+      createTransactionFromSessionHandler({} as never, {
+        sessionId: "session-1" as Id<"posSession">,
+        payments: [{ method: "cash", amount: 10, timestamp: 1 }],
+      }),
+    ).rejects.toThrow("Open the cash drawer before completing this sale.");
   });
 
   it("does not fail direct sale completion when workflowTraceId persistence fails", async () => {

--- a/packages/athena-webapp/convex/pos/application/sessionCommands.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sessionCommands.test.ts
@@ -7,6 +7,7 @@ type SessionRecord = {
   terminalId: string;
   cashierId?: string;
   registerNumber?: string;
+  registerSessionId?: string;
   status: "active" | "held" | "completed" | "void" | "expired";
   workflowTraceId?: string;
   expiresAt: number;
@@ -14,6 +15,14 @@ type SessionRecord = {
   heldAt?: number;
   resumedAt?: number;
   holdReason?: string;
+};
+
+type RegisterSessionRecord = {
+  _id: string;
+  storeId: string;
+  status: "open" | "active" | "closing" | "closed";
+  terminalId?: string;
+  registerNumber?: string;
 };
 
 type SessionItemRecord = {
@@ -56,7 +65,17 @@ type TraceCall = {
 describe("createPosSessionCommandService", () => {
   it("creates a fresh active session when no matching active session exists", async () => {
     const commandService = await loadCommandService();
-    const repository = createFakeRepository();
+    const repository = createFakeRepository({
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+    });
     const traceCalls: TraceCall[] = [];
 
     const result = await commandService(
@@ -88,6 +107,7 @@ describe("createPosSessionCommandService", () => {
         terminalId: "terminal-1",
         cashierId: "cashier-1",
         registerNumber: "1",
+        registerSessionId: "drawer-1",
         expiresAt: 61_000,
         workflowTraceId: "pos_session:ses-001",
       }),
@@ -144,6 +164,15 @@ describe("createPosSessionCommandService", () => {
     const commandService = await loadCommandService();
     const traceCalls: TraceCall[] = [];
     const repository = createFakeRepository({
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
       sessions: [
         buildSession({
           _id: "session-4",
@@ -151,6 +180,7 @@ describe("createPosSessionCommandService", () => {
           storeId: "store-1",
           terminalId: "terminal-1",
           cashierId: "cashier-1",
+          registerSessionId: "drawer-1",
           status: "active",
           expiresAt: 12_000,
           updatedAt: 950,
@@ -197,6 +227,7 @@ describe("createPosSessionCommandService", () => {
         status: "held",
         heldAt: 1_000,
         holdReason: "Auto-held when new session started",
+        registerSessionId: "drawer-1",
       }),
     );
     expect(traceCalls).toEqual([
@@ -272,7 +303,17 @@ describe("createPosSessionCommandService", () => {
 
   it("keeps session start successful when lifecycle tracing fails", async () => {
     const commandService = await loadCommandService();
-    const repository = createFakeRepository();
+    const repository = createFakeRepository({
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+    });
 
     const result = await commandService(
       createDependencies({
@@ -298,6 +339,30 @@ describe("createPosSessionCommandService", () => {
     expect(repository.getSession("session-1")).not.toHaveProperty(
       "workflowTraceId",
     );
+  });
+
+  it("fails clearly when no open drawer can be resolved for a new retail session", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository();
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).startSession({
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      cashierId: "cashier-1",
+      registerNumber: "1",
+    });
+
+    expect(result).toEqual({
+      status: "validationFailed",
+      message: "Open the cash drawer before starting a sale.",
+    });
+    expect(repository.sessions).toHaveLength(0);
   });
 
   it("refuses to resume an expired held session", async () => {
@@ -662,13 +727,22 @@ function createDependencies(options: {
 function createFakeRepository(seed?: {
   sessions?: SessionRecord[];
   items?: SessionItemRecord[];
+  registerSessions?: RegisterSessionRecord[];
 }) {
   const repository = {
     sessions: [...(seed?.sessions ?? [])],
     items: [...(seed?.items ?? [])],
+    registerSessions: [...(seed?.registerSessions ?? [])],
     getSession(sessionId: string) {
       return (
         repository.sessions.find((session) => session._id === sessionId) ?? null
+      );
+    },
+    getRegisterSession(registerSessionId: string) {
+      return (
+        repository.registerSessions.find(
+          (session) => session._id === registerSessionId,
+        ) ?? null
       );
     },
     getItem(itemId: string) {
@@ -701,6 +775,40 @@ function createFakeRepository(seed?: {
     },
     async getSessionById(sessionId: string) {
       return repository.getSession(sessionId);
+    },
+    async getRegisterSessionById(registerSessionId: string) {
+      return repository.getRegisterSession(registerSessionId);
+    },
+    async getOpenRegisterSessionForIdentity(args: {
+      storeId: string;
+      terminalId?: string;
+      registerNumber?: string;
+    }) {
+      if (args.registerNumber) {
+        return (
+          [...repository.registerSessions]
+            .reverse()
+            .find(
+              (session) =>
+                session.storeId === args.storeId &&
+                session.registerNumber === args.registerNumber &&
+                session.status !== "closed",
+            ) ?? null
+        );
+      }
+
+      if (!args.terminalId) {
+        return null;
+      }
+
+      return (
+        [...repository.registerSessions]
+          .reverse()
+          .find(
+            (session) =>
+              session.terminalId === args.terminalId && session.status !== "closed",
+          ) ?? null
+      );
     },
     async listSessionItems(sessionId: string) {
       return repository.items.filter((item) => item.sessionId === sessionId);
@@ -763,6 +871,12 @@ function buildSession(input: SessionRecord): SessionRecord {
   return input;
 }
 
+function buildRegisterSession(
+  input: RegisterSessionRecord,
+): RegisterSessionRecord {
+  return input;
+}
+
 function buildItem(
   input: Omit<SessionItemRecord, "createdAt" | "updatedAt">,
 ): SessionItemRecord {
@@ -781,6 +895,7 @@ function createCommandService(
     terminalId: string;
     cashierId?: string;
     registerNumber?: string;
+    registerSessionId?: string;
   }) => Promise<unknown>;
   holdSession: (args: {
     sessionId: string;

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts
@@ -1,5 +1,6 @@
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
+import { internal } from "../../../_generated/api";
 
 const ACTIVE_SESSION_CANDIDATE_LIMIT = 100;
 const SESSION_ITEMS_PAGE_SIZE = 200;
@@ -17,6 +18,14 @@ export interface SessionCommandRepository {
   getSessionById(
     sessionId: Id<"posSession">,
   ): Promise<Doc<"posSession"> | null>;
+  getRegisterSessionById(
+    registerSessionId: Id<"registerSession">,
+  ): Promise<Doc<"registerSession"> | null>;
+  getOpenRegisterSessionForIdentity(args: {
+    storeId: Id<"store">;
+    terminalId?: Id<"posTerminal">;
+    registerNumber?: string;
+  }): Promise<Doc<"registerSession"> | null>;
   listSessionItems(
     sessionId: Id<"posSession">,
   ): Promise<Doc<"posSessionItem">[]>;
@@ -81,6 +90,19 @@ export function createSessionCommandRepository(
     },
     getSessionById(sessionId) {
       return ctx.db.get("posSession", sessionId);
+    },
+    getRegisterSessionById(registerSessionId) {
+      return ctx.db.get("registerSession", registerSessionId);
+    },
+    getOpenRegisterSessionForIdentity(args) {
+      return ctx.runQuery(
+        internal.operations.registerSessions.getOpenRegisterSession,
+        {
+          storeId: args.storeId,
+          terminalId: args.terminalId,
+          registerNumber: args.registerNumber,
+        },
+      );
     },
     listSessionItems(sessionId) {
       return collectSessionItemsFromPages((cursor) =>

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts
@@ -41,6 +41,13 @@ export async function getPosSessionById(
   return ctx.db.get("posSession", sessionId);
 }
 
+export async function getRegisterSessionById(
+  ctx: PosTransactionReadCtx,
+  registerSessionId: Id<"registerSession">,
+) {
+  return ctx.db.get("registerSession", registerSessionId);
+}
+
 export async function getCashierById(
   ctx: PosTransactionReadCtx,
   cashierId: Id<"cashier">,

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -216,6 +216,7 @@ const schema = defineSchema({
     .index("by_status", ["status"])
     .index("by_cashierId", ["cashierId"])
     .index("by_cashierId_and_status", ["cashierId", "status"])
+    .index("by_registerSessionId", ["registerSessionId"])
     .index("by_status_and_expiresAt", ["status", "expiresAt"])
     .index("by_storeId_and_status", ["storeId", "status"])
     .index("by_storeId_terminalId", ["storeId", "terminalId"])

--- a/packages/athena-webapp/convex/schemas/pos/posSession.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posSession.ts
@@ -5,6 +5,7 @@ export const posSessionSchema = v.object({
   storeId: v.id("store"),
   cashierId: v.optional(v.id("cashier")), // Cashier who created the session
   registerNumber: v.optional(v.string()),
+  registerSessionId: v.optional(v.id("registerSession")),
 
   // Session state
   status: v.string(), // "active", "held", "completed", "void"


### PR DESCRIPTION
## Summary
- persist `registerSessionId` on POS sessions and validate or repair the drawer binding when a session starts or resumes
- carry the stored drawer binding through session-based checkout so transactions, register-session sales, and payment allocations stay tied to the correct drawer
- extend session and checkout coverage for missing and stored drawer bindings, then refresh graphify artifacts after the final typing follow-up

## Why
- session-based POS checkout could still complete without a durable drawer binding, which left a gap between cashier activity and the cash-controls audit trail
- this keeps every retail POS session attached to an open drawer before checkout can succeed and makes that association durable across the whole sale flow

## Validation
- `bun run --filter '@athena/webapp' test -- convex/pos/application/sessionCommands.test.ts convex/pos/application/completeTransaction.test.ts`
- `bun run pr:athena`
- `git push -u origin codex/v26-329-pos-session-drawer-binding`

Linear: https://linear.app/v26-labs/issue/V26-329/bind-pos-sale-sessions-to-register-sessions-and-carry-the-drawer-id