### PR TITLE
[V26-339]: Normalize services form controls onto shared UI primitives

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3644 nodes · 3134 edges · 1388 communities detected
+- 3655 nodes · 3145 edges · 1388 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1862,68 +1862,68 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 109 - "Community 109"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 110 - "Community 110"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 111 - "Community 111"
+### Community 110 - "Community 110"
 Cohesion: 0.4
 Nodes (2): useBulkOperations(), validateOperationValue()
+
+### Community 111 - "Community 111"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 112 - "Community 112"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 113 - "Community 113"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 114 - "Community 114"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 115 - "Community 115"
+### Community 114 - "Community 114"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 116 - "Community 116"
+### Community 115 - "Community 115"
 Cohesion: 0.4
 Nodes (2): hasCustomerDetails(), useRegisterViewModel()
+
+### Community 116 - "Community 116"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 117 - "Community 117"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 118 - "Community 118"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 119 - "Community 119"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 120 - "Community 120"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 121 - "Community 121"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 122 - "Community 122"
+### Community 121 - "Community 121"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 122 - "Community 122"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 123 - "Community 123"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 124 - "Community 124"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 125 - "Community 125"
 Cohesion: 0.53
@@ -2034,88 +2034,88 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 152 - "Community 152"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleSubmit(), parseDateTimeLocal()
 
 ### Community 153 - "Community 153"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 154 - "Community 154"
-Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 155 - "Community 155"
 Cohesion: 0.4
-Nodes (1): MockImage
+Nodes (0):
 
 ### Community 156 - "Community 156"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
 ### Community 157 - "Community 157"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 158 - "Community 158"
-Cohesion: 0.6
-Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 159 - "Community 159"
-Cohesion: 0.5
-Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 160 - "Community 160"
 Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
 ### Community 161 - "Community 161"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
 
 ### Community 162 - "Community 162"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 163 - "Community 163"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 164 - "Community 164"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 165 - "Community 165"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 166 - "Community 166"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 167 - "Community 167"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 168 - "Community 168"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 169 - "Community 169"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 171 - "Community 171"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 170 - "Community 170"
+### Community 172 - "Community 172"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 171 - "Community 171"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 172 - "Community 172"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 173 - "Community 173"
 Cohesion: 0.5
@@ -2134,72 +2134,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 177 - "Community 177"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
-
-### Community 178 - "Community 178"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
-
-### Community 179 - "Community 179"
-Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
-
-### Community 180 - "Community 180"
-Cohesion: 0.67
-Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
-
-### Community 181 - "Community 181"
-Cohesion: 0.67
-Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
-
-### Community 182 - "Community 182"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 183 - "Community 183"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 184 - "Community 184"
+### Community 178 - "Community 178"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 179 - "Community 179"
+Cohesion: 0.67
+Nodes (2): toDisplayAmount(), toPesewas()
+
+### Community 180 - "Community 180"
 Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+
+### Community 181 - "Community 181"
+Cohesion: 0.67
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+
+### Community 182 - "Community 182"
+Cohesion: 0.67
+Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
+
+### Community 183 - "Community 183"
+Cohesion: 0.67
+Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
+
+### Community 184 - "Community 184"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 185 - "Community 185"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 186 - "Community 186"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 187 - "Community 187"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 188 - "Community 188"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 189 - "Community 189"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 190 - "Community 190"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 191 - "Community 191"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 192 - "Community 192"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 191 - "Community 191"
+### Community 193 - "Community 193"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 192 - "Community 192"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 193 - "Community 193"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 194 - "Community 194"
 Cohesion: 0.5
@@ -2218,28 +2218,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 198 - "Community 198"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 199 - "Community 199"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 200 - "Community 200"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 201 - "Community 201"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 202 - "Community 202"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 203 - "Community 203"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 204 - "Community 204"
 Cohesion: 0.5
@@ -2258,20 +2258,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 208 - "Community 208"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), parseDateTimeLocal()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 209 - "Community 209"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 210 - "Community 210"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 211 - "Community 211"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 211 - "Community 211"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 212 - "Community 212"
 Cohesion: 0.5
@@ -2282,36 +2282,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 214 - "Community 214"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 215 - "Community 215"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.67
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 221 - "Community 221"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 222 - "Community 222"
 Cohesion: 0.5
@@ -2334,51 +2334,51 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 227 - "Community 227"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 228 - "Community 228"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 233 - "Community 233"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 234 - "Community 234"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 235 - "Community 235"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 236 - "Community 236"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 237 - "Community 237"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 238 - "Community 238"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 239 - "Community 239"
@@ -2394,84 +2394,84 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 242 - "Community 242"
-Cohesion: 1.0
-Nodes (2): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestWithCtx()
-
-### Community 243 - "Community 243"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 243 - "Community 243"
+Cohesion: 1.0
+Nodes (2): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestWithCtx()
 
 ### Community 244 - "Community 244"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 245 - "Community 245"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 246 - "Community 246"
 Cohesion: 1.0
 Nodes (2): buildRegisterState(), getRegisterState()
 
-### Community 246 - "Community 246"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 247 - "Community 247"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 248 - "Community 248"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 249 - "Community 249"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 250 - "Community 250"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 251 - "Community 251"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 251 - "Community 251"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 252 - "Community 252"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 253 - "Community 253"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 254 - "Community 254"
 Cohesion: 1.0
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 255 - "Community 255"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 256 - "Community 256"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 257 - "Community 257"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 258 - "Community 258"
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 259 - "Community 259"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 260 - "Community 260"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 261 - "Community 261"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.67
@@ -2486,16 +2486,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 265 - "Community 265"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 266 - "Community 266"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 267 - "Community 267"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 268 - "Community 268"
 Cohesion: 0.67
@@ -2503,11 +2503,11 @@ Nodes (0):
 
 ### Community 269 - "Community 269"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 270 - "Community 270"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 271 - "Community 271"
 Cohesion: 0.67
@@ -2515,11 +2515,11 @@ Nodes (0):
 
 ### Community 272 - "Community 272"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 273 - "Community 273"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 274 - "Community 274"
 Cohesion: 0.67
@@ -2538,12 +2538,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 278 - "Community 278"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceLinkTarget(), WorkflowTraceLink()
-
-### Community 279 - "Community 279"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 279 - "Community 279"
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceLinkTarget(), WorkflowTraceLink()
 
 ### Community 280 - "Community 280"
 Cohesion: 0.67
@@ -2571,83 +2571,83 @@ Nodes (0):
 
 ### Community 286 - "Community 286"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 287 - "Community 287"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 288 - "Community 288"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 289 - "Community 289"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 290 - "Community 290"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 291 - "Community 291"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 292 - "Community 292"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TableSkeleton()
 
 ### Community 293 - "Community 293"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): TransactionsSkeleton()
 
 ### Community 294 - "Community 294"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): NotFound()
 
 ### Community 295 - "Community 295"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (0):
 
 ### Community 296 - "Community 296"
-Cohesion: 0.67
-Nodes (1): Badge()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 297 - "Community 297"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): AppContextMenu()
 
 ### Community 298 - "Community 298"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): Badge()
 
 ### Community 299 - "Community 299"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): LoadingButton()
 
 ### Community 300 - "Community 300"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): onChange()
 
 ### Community 301 - "Community 301"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): AlertModal()
 
 ### Community 302 - "Community 302"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): OverlayModal()
 
 ### Community 303 - "Community 303"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Skeleton()
 
 ### Community 304 - "Community 304"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 305 - "Community 305"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 306 - "Community 306"
 Cohesion: 0.67
@@ -2671,7 +2671,7 @@ Nodes (0):
 
 ### Community 311 - "Community 311"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 312 - "Community 312"
 Cohesion: 0.67
@@ -2679,7 +2679,7 @@ Nodes (0):
 
 ### Community 313 - "Community 313"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 314 - "Community 314"
 Cohesion: 0.67
@@ -2687,7 +2687,7 @@ Nodes (0):
 
 ### Community 315 - "Community 315"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 316 - "Community 316"
 Cohesion: 0.67
@@ -2695,75 +2695,75 @@ Nodes (0):
 
 ### Community 317 - "Community 317"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 318 - "Community 318"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 319 - "Community 319"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 320 - "Community 320"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): App()
 
 ### Community 321 - "Community 321"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 322 - "Community 322"
-Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 323 - "Community 323"
 Cohesion: 0.67
-Nodes (1): hashPassword()
+Nodes (0):
 
 ### Community 324 - "Community 324"
-Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 325 - "Community 325"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): hashPassword()
 
 ### Community 326 - "Community 326"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): createVersionChecker()
 
 ### Community 327 - "Community 327"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (1): manualChunks()
 
 ### Community 328 - "Community 328"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 329 - "Community 329"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 330 - "Community 330"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 331 - "Community 331"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 332 - "Community 332"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 333 - "Community 333"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 334 - "Community 334"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 335 - "Community 335"
 Cohesion: 0.67
@@ -2774,12 +2774,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 337 - "Community 337"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 338 - "Community 338"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 339 - "Community 339"
 Cohesion: 0.67
@@ -2790,8 +2790,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 341 - "Community 341"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 342 - "Community 342"
 Cohesion: 0.67
@@ -2862,52 +2862,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 359 - "Community 359"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 360 - "Community 360"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 361 - "Community 361"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 362 - "Community 362"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 363 - "Community 363"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 364 - "Community 364"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 365 - "Community 365"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 366 - "Community 366"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 367 - "Community 367"
 Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 368 - "Community 368"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 369 - "Community 369"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 370 - "Community 370"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 371 - "Community 371"
 Cohesion: 1.0
@@ -6978,1131 +6978,1125 @@ Cohesion: 1.0
 Nodes (0):
 
 ## Knowledge Gaps
-- **Thin community `Community 368`** (2 nodes): `getSource()`, `closeouts.test.ts`
+- **Thin community `Community 371`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 372`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 373`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 374`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 375`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 376`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 377`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 378`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `authenticateHandler()`, `cashier.ts`
+- **Thin community `Community 379`** (2 nodes): `authenticateHandler()`, `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 380`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 381`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 382`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 383`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 384`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 385`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 386`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 387`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 388`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 389`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `registerSessionTracing.test.ts`, `buildSession()`
+- **Thin community `Community 390`** (2 nodes): `registerSessionTracing.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
+- **Thin community `Community 391`** (2 nodes): `serviceIntake.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 392`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `register.ts`, `openDrawer()`
+- **Thin community `Community 393`** (2 nodes): `register.ts`, `openDrawer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 394`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 395`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 396`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 397`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 398`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 399`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 400`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 401`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `receiving.test.ts`, `getSource()`
+- **Thin community `Community 402`** (2 nodes): `receiving.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 403`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 404`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 405`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 406`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 407`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 408`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 409`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 410`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 411`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 412`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 413`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 414`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 415`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 416`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 417`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `posSale.ts`, `buildPosSaleTraceSeed()`
+- **Thin community `Community 418`** (2 nodes): `posSale.ts`, `buildPosSaleTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 419`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 420`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 421`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 422`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 423`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 424`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 425`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 426`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 427`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 428`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 429`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 430`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 431`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 432`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 433`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 434`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 435`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 436`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 437`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 438`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 439`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 440`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 441`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 442`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 443`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 444`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 445`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 446`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 447`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 448`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 449`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 450`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 451`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 452`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 453`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 454`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 455`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 456`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 457`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 458`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 459`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 460`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 461`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 462`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 463`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 464`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 465`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 466`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 467`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 468`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 469`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 470`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
+- **Thin community `Community 471`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 472`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 473`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 474`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 475`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 476`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `CashierView()`, `CashierView.tsx`
+- **Thin community `Community 477`** (2 nodes): `CashierView()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 478`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 479`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 480`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 481`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 482`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 483`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 484`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 485`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 486`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 487`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 488`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `RegisterDrawerGate.tsx`, `RegisterDrawerGate()`
+- **Thin community `Community 489`** (2 nodes): `RegisterDrawerGate.tsx`, `RegisterDrawerGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 490`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 491`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 492`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 493`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 494`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 495`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 496`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 497`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 498`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 499`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 500`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 501`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 502`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 503`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 504`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 505`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 506`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 507`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 508`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 509`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
+- **Thin community `Community 510`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 511`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 512`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 513`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 514`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 515`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 516`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 517`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 518`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 519`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 520`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 521`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 522`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 523`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 524`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 525`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 526`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
+- **Thin community `Community 527`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 528`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 529`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 530`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 531`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 532`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 533`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 534`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 535`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 536`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 537`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 538`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 539`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 540`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 541`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 542`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 543`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 544`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 545`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 546`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 547`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 548`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 549`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 550`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 551`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 552`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 553`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 554`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 555`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 556`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 557`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 558`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 559`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 560`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 561`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 562`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 563`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 564`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 565`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 566`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 567`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 568`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 569`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 570`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 571`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 572`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 573`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 574`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 575`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 576`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 577`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 578`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 579`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 580`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 581`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 582`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 583`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
+- **Thin community `Community 584`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 585`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 586`** (2 nodes): `hasOrgNotFoundPayload()`, `closeouts.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 587`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 588`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 589`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 590`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 591`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 592`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 593`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 594`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 595`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 596`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 597`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 598`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 599`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 600`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 601`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 602`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 603`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 604`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 605`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 606`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 607`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 608`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 609`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 610`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 611`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 612`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 613`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 614`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 615`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 616`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 617`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 618`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 619`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 620`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 621`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 622`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 623`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 624`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 625`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 626`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 627`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 628`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 629`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 630`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 631`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 632`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 633`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 634`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 635`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 636`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 637`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 638`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 639`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 640`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 641`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 642`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 643`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 644`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 645`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 646`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 647`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 648`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 649`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 650`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 651`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 652`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 653`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 654`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 655`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 656`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 657`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 658`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 659`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 660`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 661`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 662`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 663`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 664`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 665`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 666`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 667`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 668`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 669`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 670`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 671`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 672`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 673`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 674`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 675`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 676`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 677`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 678`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 679`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 680`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 681`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 682`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 683`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 684`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 685`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 686`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 687`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 688`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 689`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 690`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 691`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 692`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 693`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 694`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 695`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 696`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 697`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 698`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 699`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 700`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 701`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 702`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 703`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 704`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 705`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 706`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 707`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 708`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 709`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 710`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 711`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 712`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 713`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 714`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 715`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 716`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 717`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 718`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 719`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 720`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `api.d.ts`
+- **Thin community `Community 721`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `api.js`
+- **Thin community `Community 722`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 723`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `server.d.ts`
+- **Thin community `Community 724`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `server.js`
+- **Thin community `Community 725`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `app.ts`
+- **Thin community `Community 726`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `auth.config.js`
+- **Thin community `Community 727`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `auth.ts`
+- **Thin community `Community 728`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 729`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `countries.ts`
+- **Thin community `Community 730`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `email.ts`
+- **Thin community `Community 731`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `ghana.ts`
+- **Thin community `Community 732`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `payment.ts`
+- **Thin community `Community 733`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `crons.ts`
+- **Thin community `Community 734`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 735`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 736`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 737`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 738`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `env.ts`
+- **Thin community `Community 739`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `analytics.ts`
+- **Thin community `Community 740`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `auth.ts`
+- **Thin community `Community 741`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 742`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `categories.ts`
+- **Thin community `Community 743`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `colors.ts`
+- **Thin community `Community 744`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `index.ts`
+- **Thin community `Community 745`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `organizations.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `products.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `stores.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 746`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 747`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `bag.ts`
+- **Thin community `Community 748`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `guest.ts`
+- **Thin community `Community 749`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `index.ts`
+- **Thin community `Community 750`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `me.ts`
+- **Thin community `Community 751`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `offers.ts`
+- **Thin community `Community 752`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 753`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `paystack.ts`
+- **Thin community `Community 754`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `reviews.ts`
+- **Thin community `Community 755`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `rewards.ts`
+- **Thin community `Community 756`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 757`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `security.test.ts`
+- **Thin community `Community 758`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `storefront.ts`
+- **Thin community `Community 759`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `upsells.ts`
+- **Thin community `Community 760`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `user.ts`
+- **Thin community `Community 761`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 762`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `health.test.ts`
+- **Thin community `Community 763`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `http.ts`
+- **Thin community `Community 764`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 765`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `auth.ts`
+- **Thin community `Community 766`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 767`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 768`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `categories.ts`
+- **Thin community `Community 769`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `colors.ts`
+- **Thin community `Community 770`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 771`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 772`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 773`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 774`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 775`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 776`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `organizations.ts`
+- **Thin community `Community 777`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `pos.ts`
+- **Thin community `Community 778`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 779`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 780`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 781`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `productSku.ts`
+- **Thin community `Community 782`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 783`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 784`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 785`** (1 nodes): `posSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 786`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 787`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 788`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 789`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 790`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 791`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `client.test.ts`
+- **Thin community `Community 792`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `config.test.ts`
+- **Thin community `Community 793`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 794`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `types.ts`
+- **Thin community `Community 795`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 796`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 797`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 798`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `staffProfiles.test.ts`
+- **Thin community `Community 799`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 800`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `completeTransaction.test.ts`
+- **Thin community `Community 801`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `dto.ts`
+- **Thin community `Community 802`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 803`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `getTransactions.test.ts`
+- **Thin community `Community 804`** (1 nodes): `staffProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `openDrawer.test.ts`
+- **Thin community `Community 805`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 806`** (1 nodes): `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `types.ts`
+- **Thin community `Community 807`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `sessionCommandRepository.test.ts`
+- **Thin community `Community 808`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `catalog.ts`
+- **Thin community `Community 809`** (1 nodes): `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `customers.ts`
+- **Thin community `Community 810`** (1 nodes): `openDrawer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `register.ts`
+- **Thin community `Community 811`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `terminals.ts`
+- **Thin community `Community 812`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `transactions.ts`
+- **Thin community `Community 813`** (1 nodes): `sessionCommandRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `schema.ts`
+- **Thin community `Community 814`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 815`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 816`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 817`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 818`** (1 nodes): `transactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `cashier.ts`
+- **Thin community `Community 819`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `category.ts`
+- **Thin community `Community 820`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `color.ts`
+- **Thin community `Community 821`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 822`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 823`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `index.ts`
+- **Thin community `Community 824`** (1 nodes): `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 825`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `organization.ts`
+- **Thin community `Community 826`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 827`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `product.ts`
+- **Thin community `Community 828`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 829`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 830`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `store.ts`
+- **Thin community `Community 831`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 832`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `index.ts`
+- **Thin community `Community 833`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 834`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 835`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 836`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 837`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 838`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `index.ts`
+- **Thin community `Community 839`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 840`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 841`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 842`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 843`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 844`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 845`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 846`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 847`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `customer.ts`
+- **Thin community `Community 848`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 849`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 850`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 851`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 852`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `index.ts`
+- **Thin community `Community 853`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `posSession.ts`
+- **Thin community `Community 854`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 855`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 856`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 857`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 858`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `index.ts`
+- **Thin community `Community 859`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 860`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 861`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 862`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 863`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 864`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `index.ts`
+- **Thin community `Community 865`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 866`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 867`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 868`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 869`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `vendor.ts`
+- **Thin community `Community 870`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `analytics.ts`
+- **Thin community `Community 871`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `bag.ts`
+- **Thin community `Community 872`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 873`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 874`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 875`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `customer.ts`
+- **Thin community `Community 876`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `guest.ts`
+- **Thin community `Community 877`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `index.ts`
+- **Thin community `Community 878`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `offer.ts`
+- **Thin community `Community 879`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 880`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 881`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `review.ts`
+- **Thin community `Community 882`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `rewards.ts`
+- **Thin community `Community 883`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 884`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 885`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 886`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 887`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 888`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 889`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 890`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `bag.ts`
+- **Thin community `Community 891`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 892`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `customer.ts`
+- **Thin community `Community 893`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `guest.ts`
+- **Thin community `Community 894`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 895`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 896`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `payment.ts`
+- **Thin community `Community 897`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 898`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 899`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 900`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `users.ts`
+- **Thin community `Community 901`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 902`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `posSale.test.ts`
+- **Thin community `Community 903`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 904`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 905`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 906`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 907`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `index.ts`
+- **Thin community `Community 908`** (1 nodes): `posSale.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 909`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `auth.ts`
+- **Thin community `Community 910`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 911`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 912`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 913`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 914`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 915`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 916`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `constants.ts`
+- **Thin community `Community 917`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 918`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 919`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 920`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `types.ts`
+- **Thin community `Community 921`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 922`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 923`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 924`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 925`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 926`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 927`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 928`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 929`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `columns.tsx`
+- **Thin community `Community 930`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 931`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -8114,643 +8108,643 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 935`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 936`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 937`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `chart.tsx`
+- **Thin community `Community 938`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `columns.tsx`
+- **Thin community `Community 939`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 940`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 941`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `columns.tsx`
+- **Thin community `Community 942`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `constants.ts`
+- **Thin community `Community 943`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 944`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 945`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 946`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `data.ts`
+- **Thin community `Community 947`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `columns.tsx`
+- **Thin community `Community 948`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 949`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 950`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `columns.tsx`
+- **Thin community `Community 951`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 952`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 953`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 954`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 955`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 956`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 957`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 958`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `constants.ts`
+- **Thin community `Community 959`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 960`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 961`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 962`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `data.ts`
+- **Thin community `Community 963`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 964`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `InputOTP.test.tsx`
+- **Thin community `Community 965`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 966`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 967`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `columns.tsx`
+- **Thin community `Community 968`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 969`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 970`** (1 nodes): `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 971`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 972`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 973`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `columns.tsx`
+- **Thin community `Community 974`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `constants.ts`
+- **Thin community `Community 975`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 976`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 977`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 978`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 979`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 980`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 981`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `RegisterCloseoutView.test.tsx`
+- **Thin community `Community 982`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 983`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 984`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `index.tsx`
+- **Thin community `Community 985`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `columns.tsx`
+- **Thin community `Community 986`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 987`** (1 nodes): `RegisterCloseoutView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 988`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 989`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 990`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `OperationsQueueView.test.tsx`
+- **Thin community `Community 991`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
+- **Thin community `Community 992`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 993`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 994`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 995`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 996`** (1 nodes): `OperationsQueueView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 997`** (1 nodes): `StockAdjustmentWorkspace.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `constants.ts`
+- **Thin community `Community 998`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 999`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1000`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1001`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `data.ts`
+- **Thin community `Community 1002`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1003`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `constants.ts`
+- **Thin community `Community 1004`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1005`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1006`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1007`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1008`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `data.ts`
+- **Thin community `Community 1009`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1010`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `constants.ts`
+- **Thin community `Community 1011`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1012`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1013`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1014`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1015`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `data.ts`
+- **Thin community `Community 1016`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1017`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1018`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 1019`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 1020`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1021`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1022`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1023`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 1024`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1025`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1026`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1027`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1028`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1029`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1030`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1031`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1032`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1033`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1034`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `TransactionView.test.tsx`
+- **Thin community `Community 1035`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 1036`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1037`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `WorkflowTraceLink.test.tsx`
+- **Thin community `Community 1038`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `types.ts`
+- **Thin community `Community 1039`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `ProcurementView.test.tsx`
+- **Thin community `Community 1040`** (1 nodes): `TransactionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1041`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1042`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1043`** (1 nodes): `WorkflowTraceLink.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1044`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1045`** (1 nodes): `ProcurementView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 1046`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1047`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1048`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1049`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1050`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1051`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1052`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1053`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1054`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1055`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1056`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1057`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1058`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `data.ts`
+- **Thin community `Community 1059`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1060`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `PromoCodePreview.tsx`
+- **Thin community `Community 1061`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1062`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1063`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1064`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1065`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1066`** (1 nodes): `PromoCodePreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1067`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1068`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1069`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1070`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1071`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `constants.ts`
+- **Thin community `Community 1072`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1073`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1074`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1075`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `data.ts`
+- **Thin community `Community 1076`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `types.ts`
+- **Thin community `Community 1077`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1078`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1079`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1080`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1081`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `ServiceAppointmentsView.test.tsx`
+- **Thin community `Community 1082`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `ServiceCasesView.test.tsx`
+- **Thin community `Community 1083`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `ServiceCatalogView.test.tsx`
+- **Thin community `Community 1084`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `ServiceIntakeView.auth.test.tsx`
+- **Thin community `Community 1085`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `ServiceIntakeView.test.tsx`
+- **Thin community `Community 1086`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1087`** (1 nodes): `ServiceIntakeView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `index.tsx`
+- **Thin community `Community 1088`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1089`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1090`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1091`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `button.tsx`
+- **Thin community `Community 1092`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1093`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `card.tsx`
+- **Thin community `Community 1094`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1095`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1096`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `command.tsx`
+- **Thin community `Community 1097`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1098`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1099`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1100`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `form.tsx`
+- **Thin community `Community 1101`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1102`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1103`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `input.tsx`
+- **Thin community `Community 1104`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1105`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1106`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1107`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1108`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1109`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `select.tsx`
+- **Thin community `Community 1110`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1111`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1112`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1113`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `table.tsx`
+- **Thin community `Community 1114`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1115`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1116`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1117`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1118`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1119`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1120`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1121`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1122`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `constants.ts`
+- **Thin community `Community 1123`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1124`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1125`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1126`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `data.ts`
+- **Thin community `Community 1127`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1128`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1129`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1130`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 1131`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1132`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1133`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1134`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1135`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1136`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1137`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1138`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1139`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1140`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `index.ts`
+- **Thin community `Community 1141`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `config.ts`
+- **Thin community `Community 1142`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1143`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1144`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1145`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1146`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `aws.ts`
+- **Thin community `Community 1147`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `constants.ts`
+- **Thin community `Community 1148`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `countries.ts`
+- **Thin community `Community 1149`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1150`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1151`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `bootstrapRegister.test.ts`
+- **Thin community `Community 1152`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `dto.ts`
+- **Thin community `Community 1153`** (1 nodes): `bootstrapRegister.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `ports.ts`
+- **Thin community `Community 1154`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `constants.ts`
+- **Thin community `Community 1155`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1156`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1157`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `index.ts`
+- **Thin community `Community 1158`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1159`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `types.ts`
+- **Thin community `Community 1160`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1161`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1162`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1163`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1164`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `useRegisterViewModel.test.ts`
+- **Thin community `Community 1165`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1166`** (1 nodes): `useRegisterViewModel.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `category.ts`
+- **Thin community `Community 1167`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `product.ts`
+- **Thin community `Community 1168`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `store.ts`
+- **Thin community `Community 1169`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1170`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `user.ts`
+- **Thin community `Community 1171`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1172`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1173`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1174`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1175`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1176`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `index.tsx`
+- **Thin community `Community 1177`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1178`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1179`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1180`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1181`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1182`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1183`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1184`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `index.tsx`
+- **Thin community `Community 1185`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1186`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1187`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1188`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `home.tsx`
+- **Thin community `Community 1189`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1190`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1191`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1192`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `index.tsx`
+- **Thin community `Community 1193`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1194`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1195`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1196`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1197`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `index.tsx`
+- **Thin community `Community 1198`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1199`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1200`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1201`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1202`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1203`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1204`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 1205`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `index.tsx`
+- **Thin community `Community 1206`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1207`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1208`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1209`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1210`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `procurement.index.tsx`
+- **Thin community `Community 1211`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1212`** (1 nodes): `procurement.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `index.tsx`
+- **Thin community `Community 1213`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1214`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `new.tsx`
+- **Thin community `Community 1215`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `index.tsx`
+- **Thin community `Community 1216`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `new.tsx`
+- **Thin community `Community 1217`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1218`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1219`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `index.tsx`
+- **Thin community `Community 1220`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `new.tsx`
+- **Thin community `Community 1221`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `index.tsx`
+- **Thin community `Community 1222`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1223`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1224`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1225`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1226`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1227`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1228`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1229`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `index.tsx`
+- **Thin community `Community 1230`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1231`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1232`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1233`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1234`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1235`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1236`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1237`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1238`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1239`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1240`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1241`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1242`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1243`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1244`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1245`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1246`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1247`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1248`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `setup.ts`
+- **Thin community `Community 1249`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1250`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1251`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `types.ts`
+- **Thin community `Community 1252`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1253`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1254`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1255`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -18760,6 +18760,42 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
+      "_tgt": "serviceappointmentsview_test_choosedatetime",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
+      "source_location": "L58",
+      "target": "serviceappointmentsview_test_choosedatetime",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
+      "_tgt": "serviceappointmentsview_test_chooseselectoption",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
+      "source_location": "L49",
+      "target": "serviceappointmentsview_test_chooseselectoption",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "_tgt": "serviceappointmentsview_formatdatetimelocal",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L90",
+      "target": "serviceappointmentsview_formatdatetimelocal",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "_tgt": "serviceappointmentsview_handlesubmit",
       "confidence": "EXTRACTED",
@@ -18767,7 +18803,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L115",
+      "source_location": "L131",
       "target": "serviceappointmentsview_handlesubmit",
       "weight": 1
     },
@@ -18779,7 +18815,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L77",
+      "source_location": "L85",
       "target": "serviceappointmentsview_parsedatetimelocal",
       "weight": 1
     },
@@ -18791,8 +18827,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L448",
+      "source_location": "L472",
       "target": "serviceappointmentsview_withsavestate",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
+      "_tgt": "servicecasesview_test_chooseselectoption",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
+      "source_location": "L62",
+      "target": "servicecasesview_test_chooseselectoption",
       "weight": 1
     },
     {
@@ -18803,8 +18851,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L171",
+      "source_location": "L178",
       "target": "servicecasesview_handlecreatecase",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
+      "_tgt": "servicecatalogview_test_chooseselectoption",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L28",
+      "target": "servicecatalogview_test_chooseselectoption",
       "weight": 1
     },
     {
@@ -18815,7 +18875,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L142",
+      "source_location": "L149",
       "target": "servicecatalogview_handlechange",
       "weight": 1
     },
@@ -18827,7 +18887,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L152",
+      "source_location": "L159",
       "target": "servicecatalogview_handleedit",
       "weight": 1
     },
@@ -18839,7 +18899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L158",
+      "source_location": "L165",
       "target": "servicecatalogview_handlereset",
       "weight": 1
     },
@@ -18851,7 +18911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L164",
+      "source_location": "L171",
       "target": "servicecatalogview_handlesubmit",
       "weight": 1
     },
@@ -18863,7 +18923,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L75",
+      "source_location": "L82",
       "target": "servicecatalogview_itemtoformstate",
       "weight": 1
     },
@@ -18875,7 +18935,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L89",
+      "source_location": "L96",
       "target": "servicecatalogview_parseservicecatalogform",
       "weight": 1
     },
@@ -18887,7 +18947,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L60",
+      "source_location": "L67",
       "target": "servicecatalogview_validateservicecatalogform",
       "weight": 1
     },
@@ -18899,7 +18959,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L443",
+      "source_location": "L461",
       "target": "servicecatalogview_withsavestate",
       "weight": 1
     },
@@ -18911,8 +18971,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx",
-      "source_location": "L52",
+      "source_location": "L59",
       "target": "serviceintakeform_serviceintakeform",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
+      "_tgt": "serviceintakeview_test_chooseselectoption",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx",
+      "source_location": "L40",
+      "target": "serviceintakeview_test_chooseselectoption",
       "weight": 1
     },
     {
@@ -19661,14 +19733,50 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
-      "_tgt": "date_time_picker_datetimepicker",
+      "_tgt": "date_time_picker_handleclear",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
-      "source_location": "L21",
-      "target": "date_time_picker_datetimepicker",
+      "source_location": "L99",
+      "target": "date_time_picker_handleclear",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
+      "_tgt": "date_time_picker_handledateselect",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
+      "source_location": "L53",
+      "target": "date_time_picker_handledateselect",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
+      "_tgt": "date_time_picker_handletimeblur",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
+      "source_location": "L75",
+      "target": "date_time_picker_handletimeblur",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
+      "_tgt": "date_time_picker_handletimechange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
+      "source_location": "L63",
+      "target": "date_time_picker_handletimechange",
       "weight": 1
     },
     {
@@ -23893,6 +24001,30 @@
       "source_file": "packages/athena-webapp/vite.config.ts",
       "source_location": "L19",
       "target": "vite_config_manualchunks",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_vitest_setup_ts",
+      "_tgt": "vitest_setup_pointercapturestub",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_vitest_setup_ts",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L23",
+      "target": "vitest_setup_pointercapturestub",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_vitest_setup_ts",
+      "_tgt": "vitest_setup_pointerreleasestub",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_vitest_setup_ts",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L24",
+      "target": "vitest_setup_pointerreleasestub",
       "weight": 1
     },
     {
@@ -35207,7 +35339,7 @@
       "relation": "calls",
       "source": "serviceappointmentsview_parsedatetimelocal",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L130",
+      "source_location": "L146",
       "target": "serviceappointmentsview_handlesubmit",
       "weight": 1
     },
@@ -35279,7 +35411,7 @@
       "relation": "calls",
       "source": "servicecatalogview_itemtoformstate",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L154",
+      "source_location": "L161",
       "target": "servicecatalogview_handleedit",
       "weight": 1
     },
@@ -35291,7 +35423,7 @@
       "relation": "calls",
       "source": "servicecatalogview_handlereset",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L183",
+      "source_location": "L190",
       "target": "servicecatalogview_handlesubmit",
       "weight": 1
     },
@@ -35303,7 +35435,7 @@
       "relation": "calls",
       "source": "servicecatalogview_parseservicecatalogform",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L172",
+      "source_location": "L179",
       "target": "servicecatalogview_handlesubmit",
       "weight": 1
     },
@@ -35315,7 +35447,7 @@
       "relation": "calls",
       "source": "servicecatalogview_validateservicecatalogform",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L165",
+      "source_location": "L172",
       "target": "servicecatalogview_handlesubmit",
       "weight": 1
     },
@@ -38688,6 +38820,51 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
+      "label": "Orders.tsx",
+      "norm_label": "orders.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
+      "label": "ReturnExchangeView.test.tsx",
+      "norm_label": "returnexchangeview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1003,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1004,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1005,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -38695,7 +38872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -38704,7 +38881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -38713,7 +38890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -38722,57 +38899,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1005,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1006,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1007,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1008,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -38832,6 +38964,51 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1012,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1013,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1014,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1015,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
       "norm_label": "invitecolumns.tsx",
@@ -38839,7 +39016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -38848,7 +39025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -38857,7 +39034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -38866,57 +39043,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1015,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1016,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1017,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
-      "label": "membersColumns.tsx",
-      "norm_label": "memberscolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1018,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
-      "label": "organization-switcher.test.tsx",
-      "norm_label": "organization-switcher.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-switcher.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
-      "label": "CartItems.tsx",
-      "norm_label": "cartitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
       "source_location": "L1"
     },
     {
@@ -38976,6 +39108,51 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1022,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
+      "label": "membersColumns.tsx",
+      "norm_label": "memberscolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1023,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
+      "label": "organization-switcher.test.tsx",
+      "norm_label": "organization-switcher.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-switcher.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1024,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
+      "label": "CartItems.tsx",
+      "norm_label": "cartitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1025,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
       "norm_label": "cashierauthdialog.tsx",
@@ -38983,7 +39160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -38992,7 +39169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -39001,7 +39178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -39010,57 +39187,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
       "norm_label": "searchresultssection.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1025,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
-      "label": "SessionManager.test.tsx",
-      "norm_label": "sessionmanager.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1026,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
-      "label": "SessionManager.tsx",
-      "norm_label": "sessionmanager.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1027,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
-      "label": "TotalsDisplay.test.tsx",
-      "norm_label": "totalsdisplay.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1028,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
-      "label": "ExpenseReportView.tsx",
-      "norm_label": "expensereportview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
-      "label": "expenseReportColumns.tsx",
-      "norm_label": "expensereportcolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
       "source_location": "L1"
     },
     {
@@ -39120,6 +39252,51 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
+      "label": "SessionManager.test.tsx",
+      "norm_label": "sessionmanager.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
+      "label": "SessionManager.tsx",
+      "norm_label": "sessionmanager.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1032,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
+      "label": "TotalsDisplay.test.tsx",
+      "norm_label": "totalsdisplay.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1033,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
+      "label": "ExpenseReportView.tsx",
+      "norm_label": "expensereportview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1034,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
+      "label": "expenseReportColumns.tsx",
+      "norm_label": "expensereportcolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1035,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
       "norm_label": "posregisterview.test.tsx",
@@ -39127,7 +39304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -39136,7 +39313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -39145,7 +39322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -39154,57 +39331,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
       "norm_label": "heldsessionslist.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1035,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
-      "label": "TransactionView.test.tsx",
-      "norm_label": "transactionview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1036,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
-      "label": "TransactionView.tsx",
-      "norm_label": "transactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1037,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
-      "label": "TransactionsView.test.tsx",
-      "norm_label": "transactionsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1038,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_workflowtracelink_test_tsx",
-      "label": "WorkflowTraceLink.test.tsx",
-      "norm_label": "workflowtracelink.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/WorkflowTraceLink.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
       "source_location": "L1"
     },
     {
@@ -39264,6 +39396,51 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
+      "label": "TransactionView.test.tsx",
+      "norm_label": "transactionview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "label": "TransactionView.tsx",
+      "norm_label": "transactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1042,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
+      "label": "TransactionsView.test.tsx",
+      "norm_label": "transactionsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1043,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_workflowtracelink_test_tsx",
+      "label": "WorkflowTraceLink.test.tsx",
+      "norm_label": "workflowtracelink.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/WorkflowTraceLink.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1044,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1045,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
       "norm_label": "procurementview.test.tsx",
@@ -39271,7 +39448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
@@ -39280,7 +39457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -39289,7 +39466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -39298,57 +39475,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
       "norm_label": "detailsview.tsx",
       "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1045,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
-      "label": "ProductDetailView.tsx",
-      "norm_label": "productdetailview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1046,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
-      "label": "ProductStatus.tsx",
-      "norm_label": "productstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1047,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
-      "label": "CategoryListView.tsx",
-      "norm_label": "categorylistview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1048,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
-      "label": "ProductSubcategoryToggleGroup.tsx",
-      "norm_label": "productsubcategorytogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
       "source_location": "L1"
     },
     {
@@ -39408,6 +39540,51 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
+      "label": "ProductDetailView.tsx",
+      "norm_label": "productdetailview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
+      "label": "ProductStatus.tsx",
+      "norm_label": "productstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1052,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
+      "label": "CategoryListView.tsx",
+      "norm_label": "categorylistview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1053,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
+      "label": "ProductSubcategoryToggleGroup.tsx",
+      "norm_label": "productsubcategorytogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1054,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1055,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
       "norm_label": "storeproducts.tsx",
@@ -39415,7 +39592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -39424,7 +39601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -39433,7 +39610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -39442,57 +39619,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
       "norm_label": "data-table-column-header.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1055,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1056,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1057,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1058,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -39552,6 +39684,51 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1062,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1063,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1064,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1065,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
       "norm_label": "productcolumns.tsx",
@@ -39559,7 +39736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -39568,7 +39745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -39577,7 +39754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -39586,57 +39763,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
       "norm_label": "captured-emails-columns.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1065,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1066,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1067,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1068,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -39696,6 +39828,51 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1072,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1073,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1074,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1075,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -39703,7 +39880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -39712,7 +39889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -39721,7 +39898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -39730,57 +39907,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1075,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1076,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1077,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1078,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
-      "label": "welcome-offer-card.tsx",
-      "norm_label": "welcome-offer-card.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
-      "label": "RatingStars.tsx",
-      "norm_label": "ratingstars.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
       "source_location": "L1"
     },
     {
@@ -39840,6 +39972,51 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1082,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1083,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
+      "label": "welcome-offer-card.tsx",
+      "norm_label": "welcome-offer-card.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1084,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
+      "label": "RatingStars.tsx",
+      "norm_label": "ratingstars.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1085,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
       "norm_label": "reviewcard.tsx",
@@ -39847,7 +40024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -39856,34 +40033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
-      "label": "ServiceAppointmentsView.test.tsx",
-      "norm_label": "serviceappointmentsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1083,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
-      "label": "ServiceCasesView.test.tsx",
-      "norm_label": "servicecasesview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1084,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
-      "label": "ServiceCatalogView.test.tsx",
-      "norm_label": "servicecatalogview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1085,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -39892,16 +40042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
-      "label": "ServiceIntakeView.test.tsx",
-      "norm_label": "serviceintakeview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -39910,7 +40051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -39919,7 +40060,61 @@
       "source_location": "L1"
     },
     {
-      "community": 1089,
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 1090,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
@@ -39928,61 +40123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 109,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1090,
+      "community": 1091,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -39991,7 +40132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -40000,7 +40141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -40009,7 +40150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -40018,7 +40159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -40027,7 +40168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -40036,7 +40177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -40045,7 +40186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -40054,21 +40195,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
       "norm_label": "context-menu.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1"
     },
     {
@@ -40254,150 +40386,6 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 1100,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
-      "label": "dropdown-menu.tsx",
-      "norm_label": "dropdown-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1101,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_form_tsx",
-      "label": "form.tsx",
-      "norm_label": "form.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1102,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_icons_tsx",
-      "label": "icons.tsx",
-      "norm_label": "icons.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/icons.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1103,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
-      "label": "input-otp.tsx",
-      "norm_label": "input-otp.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1104,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1105,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
-      "label": "action-modal.tsx",
-      "norm_label": "action-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1106,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_popover_tsx",
-      "label": "popover.tsx",
-      "norm_label": "popover.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1107,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
-      "label": "primitives.test.tsx",
-      "norm_label": "primitives.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1108,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
-      "label": "radio-group.tsx",
-      "norm_label": "radio-group.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
       "label": "useBulkOperations.ts",
       "norm_label": "usebulkoperations.ts",
@@ -40405,7 +40393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 111,
+      "community": 110,
       "file_type": "code",
       "id": "usebulkoperations_applyoperation",
       "label": "applyOperation()",
@@ -40414,7 +40402,7 @@
       "source_location": "L56"
     },
     {
-      "community": 111,
+      "community": 110,
       "file_type": "code",
       "id": "usebulkoperations_calculatepricewithfee",
       "label": "calculatePriceWithFee()",
@@ -40423,7 +40411,7 @@
       "source_location": "L87"
     },
     {
-      "community": 111,
+      "community": 110,
       "file_type": "code",
       "id": "usebulkoperations_computepreview",
       "label": "computePreview()",
@@ -40432,7 +40420,7 @@
       "source_location": "L101"
     },
     {
-      "community": 111,
+      "community": 110,
       "file_type": "code",
       "id": "usebulkoperations_usebulkoperations",
       "label": "useBulkOperations()",
@@ -40441,7 +40429,7 @@
       "source_location": "L158"
     },
     {
-      "community": 111,
+      "community": 110,
       "file_type": "code",
       "id": "usebulkoperations_validateoperationvalue",
       "label": "validateOperationValue()",
@@ -40450,97 +40438,97 @@
       "source_location": "L139"
     },
     {
-      "community": 1110,
+      "community": 1100,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_select_tsx",
-      "label": "select.tsx",
-      "norm_label": "select.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/select.tsx",
+      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1101,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_separator_tsx",
-      "label": "separator.tsx",
-      "norm_label": "separator.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
+      "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
+      "label": "dropdown-menu.tsx",
+      "norm_label": "dropdown-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1102,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
-      "label": "sheet.tsx",
-      "norm_label": "sheet.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
+      "id": "packages_athena_webapp_src_components_ui_form_tsx",
+      "label": "form.tsx",
+      "norm_label": "form.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1103,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
-      "label": "switch.tsx",
-      "norm_label": "switch.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
+      "id": "packages_athena_webapp_src_components_ui_icons_tsx",
+      "label": "icons.tsx",
+      "norm_label": "icons.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/icons.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1104,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_table_tsx",
-      "label": "table.tsx",
-      "norm_label": "table.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
+      "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
+      "label": "input-otp.tsx",
+      "norm_label": "input-otp.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1105,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
-      "label": "tabs.tsx",
-      "norm_label": "tabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
+      "id": "packages_athena_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1106,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
-      "label": "textarea.tsx",
-      "norm_label": "textarea.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
+      "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
+      "label": "action-modal.tsx",
+      "norm_label": "action-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1107,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
+      "id": "packages_athena_webapp_src_components_ui_popover_tsx",
+      "label": "popover.tsx",
+      "norm_label": "popover.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1108,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
-      "label": "toggle.tsx",
-      "norm_label": "toggle.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
+      "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
+      "label": "primitives.test.tsx",
+      "norm_label": "primitives.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1119,
+      "community": 1109,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
+      "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
+      "label": "radio-group.tsx",
+      "norm_label": "radio-group.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
       "source_location": "L1"
     },
     {
-      "community": 112,
+      "community": 111,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -40549,7 +40537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 112,
+      "community": 111,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -40558,7 +40546,7 @@
       "source_location": "L33"
     },
     {
-      "community": 112,
+      "community": 111,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -40567,7 +40555,7 @@
       "source_location": "L23"
     },
     {
-      "community": 112,
+      "community": 111,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -40576,7 +40564,7 @@
       "source_location": "L48"
     },
     {
-      "community": 112,
+      "community": 111,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -40585,7 +40573,7 @@
       "source_location": "L85"
     },
     {
-      "community": 112,
+      "community": 111,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -40594,97 +40582,97 @@
       "source_location": "L7"
     },
     {
-      "community": 1120,
+      "community": 1110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_upload_button_tsx",
-      "label": "upload-button.tsx",
-      "norm_label": "upload-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
+      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1111,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
-      "label": "BagView.tsx",
-      "norm_label": "bagview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
+      "id": "packages_athena_webapp_src_components_ui_select_tsx",
+      "label": "select.tsx",
+      "norm_label": "select.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/select.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1112,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
+      "id": "packages_athena_webapp_src_components_ui_separator_tsx",
+      "label": "separator.tsx",
+      "norm_label": "separator.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1113,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
+      "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
+      "label": "sheet.tsx",
+      "norm_label": "sheet.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1114,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
+      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
+      "label": "switch.tsx",
+      "norm_label": "switch.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1115,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
+      "id": "packages_athena_webapp_src_components_ui_table_tsx",
+      "label": "table.tsx",
+      "norm_label": "table.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
+      "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
+      "label": "tabs.tsx",
+      "norm_label": "tabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1117,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
+      "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
+      "label": "textarea.tsx",
+      "norm_label": "textarea.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1118,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
-      "label": "bag-columns.tsx",
-      "norm_label": "bag-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
+      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1129,
+      "community": 1119,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
-      "label": "bags-table.tsx",
-      "norm_label": "bags-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
+      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
+      "label": "toggle.tsx",
+      "norm_label": "toggle.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1"
     },
     {
-      "community": 113,
+      "community": 112,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -40693,7 +40681,7 @@
       "source_location": "L173"
     },
     {
-      "community": 113,
+      "community": 112,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -40702,7 +40690,7 @@
       "source_location": "L71"
     },
     {
-      "community": 113,
+      "community": 112,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -40711,7 +40699,7 @@
       "source_location": "L251"
     },
     {
-      "community": 113,
+      "community": 112,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -40720,7 +40708,7 @@
       "source_location": "L36"
     },
     {
-      "community": 113,
+      "community": 112,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -40729,7 +40717,7 @@
       "source_location": "L277"
     },
     {
-      "community": 113,
+      "community": 112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -40738,97 +40726,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1130,
+      "community": 1120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
+      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_upload_button_tsx",
+      "label": "upload-button.tsx",
+      "norm_label": "upload-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1122,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
+      "label": "BagView.tsx",
+      "norm_label": "bagview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1123,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1124,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1125,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1126,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1127,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1135,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1128,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
-      "label": "LinkedAccounts.tsx",
-      "norm_label": "linkedaccounts.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1129,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
-      "label": "TimelineEventCard.test.tsx",
-      "norm_label": "timelineeventcard.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
+      "label": "bag-columns.tsx",
+      "norm_label": "bag-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1138,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
-      "label": "UserCheckoutSession.tsx",
-      "norm_label": "usercheckoutsession.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
-      "label": "UserInsightsSection.tsx",
-      "norm_label": "userinsightssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 114,
+      "community": 113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
       "label": "payments.ts",
@@ -40837,7 +40825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 114,
+      "community": 113,
       "file_type": "code",
       "id": "payments_calculateposchange",
       "label": "calculatePosChange()",
@@ -40846,7 +40834,7 @@
       "source_location": "L3"
     },
     {
-      "community": 114,
+      "community": 113,
       "file_type": "code",
       "id": "payments_calculateposremainingdue",
       "label": "calculatePosRemainingDue()",
@@ -40855,7 +40843,7 @@
       "source_location": "L20"
     },
     {
-      "community": 114,
+      "community": 113,
       "file_type": "code",
       "id": "payments_calculatepostotalpaid",
       "label": "calculatePosTotalPaid()",
@@ -40864,7 +40852,7 @@
       "source_location": "L14"
     },
     {
-      "community": 114,
+      "community": 113,
       "file_type": "code",
       "id": "payments_ispospaymentsufficient",
       "label": "isPosPaymentSufficient()",
@@ -40873,7 +40861,7 @@
       "source_location": "L7"
     },
     {
-      "community": 114,
+      "community": 113,
       "file_type": "code",
       "id": "payments_roundposamount",
       "label": "roundPosAmount()",
@@ -40882,97 +40870,97 @@
       "source_location": "L27"
     },
     {
-      "community": 1140,
+      "community": 1130,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
-      "label": "UserBehaviorInsights.tsx",
-      "norm_label": "userbehaviorinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
+      "label": "bags-table.tsx",
+      "norm_label": "bags-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1131,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/src/config.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1133,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
-      "label": "ThemeContext.tsx",
-      "norm_label": "themecontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1134,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1135,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
-      "label": "useAuth.test.tsx",
-      "norm_label": "useauth.test.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useAuth.test.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1136,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1137,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_aws_ts",
-      "label": "aws.ts",
-      "norm_label": "aws.ts",
-      "source_file": "packages/athena-webapp/src/lib/aws.ts",
+      "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
+      "label": "LinkedAccounts.tsx",
+      "norm_label": "linkedaccounts.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1138,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/constants.ts",
+      "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
+      "label": "TimelineEventCard.test.tsx",
+      "norm_label": "timelineeventcard.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1149,
+      "community": 1139,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/src/lib/countries.ts",
+      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
+      "label": "UserCheckoutSession.tsx",
+      "norm_label": "usercheckoutsession.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
       "source_location": "L1"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -40981,7 +40969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -40990,7 +40978,7 @@
       "source_location": "L27"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -40999,7 +40987,7 @@
       "source_location": "L36"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -41008,7 +40996,7 @@
       "source_location": "L11"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -41017,7 +41005,7 @@
       "source_location": "L5"
     },
     {
-      "community": 115,
+      "community": 114,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -41026,97 +41014,97 @@
       "source_location": "L48"
     },
     {
-      "community": 1150,
+      "community": 1140,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
+      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
+      "label": "UserInsightsSection.tsx",
+      "norm_label": "userinsightssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1141,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
-      "label": "ghanaRegions.ts",
-      "norm_label": "ghanaregions.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
+      "label": "UserBehaviorInsights.tsx",
+      "norm_label": "userbehaviorinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1142,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
-      "label": "bootstrapRegister.test.ts",
-      "norm_label": "bootstrapregister.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1153,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
-      "label": "dto.ts",
-      "norm_label": "dto.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1154,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
-      "label": "ports.ts",
-      "norm_label": "ports.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1155,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1156,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
-      "label": "displayAmounts.test.ts",
-      "norm_label": "displayamounts.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1157,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
-      "label": "cart.test.ts",
-      "norm_label": "cart.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/index.ts",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
       "source_location": "L1"
     },
     {
-      "community": 1159,
+      "community": 1143,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
-      "label": "session.test.ts",
-      "norm_label": "session.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.test.ts",
+      "id": "packages_athena_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/src/config.ts",
       "source_location": "L1"
     },
     {
-      "community": 116,
+      "community": 1144,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
+      "label": "ThemeContext.tsx",
+      "norm_label": "themecontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1145,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1146,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
+      "label": "useAuth.test.tsx",
+      "norm_label": "useauth.test.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useAuth.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1147,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1148,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_aws_ts",
+      "label": "aws.ts",
+      "norm_label": "aws.ts",
+      "source_file": "packages/athena-webapp/src/lib/aws.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1149,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
       "label": "useRegisterViewModel.ts",
@@ -41125,7 +41113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "useregisterviewmodel_createpaymentid",
       "label": "createPaymentId()",
@@ -41134,7 +41122,7 @@
       "source_location": "L86"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "useregisterviewmodel_hascustomerdetails",
       "label": "hasCustomerDetails()",
@@ -41143,7 +41131,7 @@
       "source_location": "L60"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "useregisterviewmodel_mapsessioncustomer",
       "label": "mapSessionCustomer()",
@@ -41152,7 +41140,7 @@
       "source_location": "L73"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "useregisterviewmodel_trimoptional",
       "label": "trimOptional()",
@@ -41161,7 +41149,7 @@
       "source_location": "L93"
     },
     {
-      "community": 116,
+      "community": 115,
       "file_type": "code",
       "id": "useregisterviewmodel_useregisterviewmodel",
       "label": "useRegisterViewModel()",
@@ -41170,97 +41158,97 @@
       "source_location": "L98"
     },
     {
-      "community": 1160,
+      "community": 1150,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
+      "id": "packages_athena_webapp_src_lib_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/src/lib/countries.ts",
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1151,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
-      "label": "registerGateway.test.ts",
-      "norm_label": "registergateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
+      "id": "packages_athena_webapp_src_lib_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1152,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
-      "label": "sessionGateway.test.ts",
-      "norm_label": "sessiongateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts",
+      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
+      "label": "ghanaRegions.ts",
+      "norm_label": "ghanaregions.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1153,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
-      "label": "loggerGateway.ts",
-      "norm_label": "loggergateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
+      "label": "bootstrapRegister.test.ts",
+      "norm_label": "bootstrapregister.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1154,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
-      "label": "registerUiState.ts",
-      "norm_label": "registeruistate.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
+      "label": "dto.ts",
+      "norm_label": "dto.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1155,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
-      "label": "useRegisterViewModel.test.ts",
-      "norm_label": "useregisterviewmodel.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
+      "label": "ports.ts",
+      "norm_label": "ports.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1156,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
-      "label": "productUtils.test.ts",
-      "norm_label": "productutils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
+      "id": "packages_athena_webapp_src_lib_pos_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1157,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
+      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
+      "label": "displayAmounts.test.ts",
+      "norm_label": "displayamounts.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1158,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
+      "label": "cart.test.ts",
+      "norm_label": "cart.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1169,
+      "community": 1159,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/index.ts",
       "source_location": "L1"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -41269,7 +41257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -41278,7 +41266,7 @@
       "source_location": "L171"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -41287,7 +41275,7 @@
       "source_location": "L302"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -41296,7 +41284,7 @@
       "source_location": "L319"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -41305,7 +41293,7 @@
       "source_location": "L312"
     },
     {
-      "community": 117,
+      "community": 116,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -41314,97 +41302,97 @@
       "source_location": "L293"
     },
     {
-      "community": 1170,
+      "community": 1160,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
+      "label": "session.test.ts",
+      "norm_label": "session.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1161,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1162,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
-      "label": "storeConfig.test.ts",
-      "norm_label": "storeconfig.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
+      "label": "registerGateway.test.ts",
+      "norm_label": "registergateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1163,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
-      "label": "createWorkflowTraceId.test.ts",
-      "norm_label": "createworkflowtraceid.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
+      "label": "sessionGateway.test.ts",
+      "norm_label": "sessiongateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1164,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
+      "label": "loggerGateway.ts",
+      "norm_label": "loggergateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1165,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routetree_gen_ts",
-      "label": "routeTree.gen.ts",
-      "norm_label": "routetree.gen.ts",
-      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
+      "label": "registerUiState.ts",
+      "norm_label": "registeruistate.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts",
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1166,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_root_tsx",
-      "label": "__root.tsx",
-      "norm_label": "__root.tsx",
-      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
+      "label": "useRegisterViewModel.test.ts",
+      "norm_label": "useregisterviewmodel.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1167,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
+      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
+      "label": "productUtils.test.ts",
+      "norm_label": "productutils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1168,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
+      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
       "source_location": "L1"
     },
     {
-      "community": 1179,
+      "community": 1169,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
+      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
       "source_location": "L1"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
@@ -41413,7 +41401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -41422,7 +41410,7 @@
       "source_location": "L12"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "traceid_workflowtraceloadingstate",
       "label": "WorkflowTraceLoadingState()",
@@ -41431,7 +41419,7 @@
       "source_location": "L21"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -41440,7 +41428,7 @@
       "source_location": "L101"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -41449,7 +41437,7 @@
       "source_location": "L35"
     },
     {
-      "community": 118,
+      "community": 117,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -41458,97 +41446,97 @@
       "source_location": "L66"
     },
     {
-      "community": 1180,
+      "community": 1170,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
-      "label": "$storeUrlSlug.tsx",
-      "norm_label": "$storeurlslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
+      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1171,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
-      "label": "analytics.tsx",
-      "norm_label": "analytics.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
+      "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1172,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
-      "label": "assets.index.tsx",
-      "norm_label": "assets.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
+      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1173,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
-      "label": "bags.$bagId.tsx",
-      "norm_label": "bags.$bagid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
+      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
+      "label": "storeConfig.test.ts",
+      "norm_label": "storeconfig.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1174,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
-      "label": "bags.index.tsx",
-      "norm_label": "bags.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
+      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
+      "label": "createWorkflowTraceId.test.ts",
+      "norm_label": "createworkflowtraceid.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1175,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
+      "id": "packages_athena_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1176,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routetree_gen_ts",
+      "label": "routeTree.gen.ts",
+      "norm_label": "routetree.gen.ts",
+      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1177,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_root_tsx",
+      "label": "__root.tsx",
+      "norm_label": "__root.tsx",
+      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1178,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1179,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
-      "label": "checkout-sessions.index.tsx",
-      "norm_label": "checkout-sessions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1187,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
-      "label": "configuration.index.tsx",
-      "norm_label": "configuration.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
-      "label": "dashboard.index.tsx",
-      "norm_label": "dashboard.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
-      "label": "home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -41557,7 +41545,7 @@
       "source_location": "L156"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -41566,7 +41554,7 @@
       "source_location": "L198"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -41575,7 +41563,7 @@
       "source_location": "L105"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -41584,7 +41572,7 @@
       "source_location": "L24"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -41593,7 +41581,7 @@
       "source_location": "L71"
     },
     {
-      "community": 119,
+      "community": 118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -41602,7 +41590,160 @@
       "source_location": "L1"
     },
     {
+      "community": 1180,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
+      "label": "$storeUrlSlug.tsx",
+      "norm_label": "$storeurlslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1182,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
+      "label": "analytics.tsx",
+      "norm_label": "analytics.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1183,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
+      "label": "assets.index.tsx",
+      "norm_label": "assets.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1184,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
+      "label": "bags.$bagId.tsx",
+      "norm_label": "bags.$bagid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1185,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
+      "label": "bags.index.tsx",
+      "norm_label": "bags.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1186,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1187,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
+      "label": "checkout-sessions.index.tsx",
+      "norm_label": "checkout-sessions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1188,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
+      "label": "configuration.index.tsx",
+      "norm_label": "configuration.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1189,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
+      "label": "dashboard.index.tsx",
+      "norm_label": "dashboard.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L232"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L28"
+    },
+    {
       "community": 1190,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
+      "label": "home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -41611,7 +41752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -41620,7 +41761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -41629,7 +41770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
@@ -41638,7 +41779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -41647,7 +41788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -41656,7 +41797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -41665,7 +41806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -41674,21 +41815,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
-      "label": "open.index.tsx",
-      "norm_label": "open.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1"
     },
     {
@@ -41865,150 +41997,6 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L232"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "storesettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 1200,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
-      "label": "out-for-delivery.index.tsx",
-      "norm_label": "out-for-delivery.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1201,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
-      "label": "ready.index.tsx",
-      "norm_label": "ready.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1202,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
-      "label": "refunded.index.tsx",
-      "norm_label": "refunded.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1203,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
-      "label": "$reportId.tsx",
-      "norm_label": "$reportid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1204,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
-      "label": "expense-reports.index.tsx",
-      "norm_label": "expense-reports.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1205,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
-      "label": "expense.index.tsx",
-      "norm_label": "expense.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1206,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1207,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
-      "label": "register.index.tsx",
-      "norm_label": "register.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
-      "label": "settings.index.tsx",
-      "norm_label": "settings.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
-      "label": "$transactionId.tsx",
-      "norm_label": "$transactionid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
       "norm_label": "storybook-shell.tsx",
@@ -42016,7 +42004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -42025,7 +42013,7 @@
       "source_location": "L83"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -42034,7 +42022,7 @@
       "source_location": "L62"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -42043,7 +42031,7 @@
       "source_location": "L95"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -42052,7 +42040,7 @@
       "source_location": "L41"
     },
     {
-      "community": 121,
+      "community": 120,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -42061,97 +42049,97 @@
       "source_location": "L12"
     },
     {
-      "community": 1210,
+      "community": 1200,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
-      "label": "transactions.index.tsx",
-      "norm_label": "transactions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
+      "label": "open.index.tsx",
+      "norm_label": "open.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1201,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
-      "label": "procurement.index.tsx",
-      "norm_label": "procurement.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
+      "label": "out-for-delivery.index.tsx",
+      "norm_label": "out-for-delivery.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1202,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
-      "label": "edit.tsx",
-      "norm_label": "edit.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
+      "label": "ready.index.tsx",
+      "norm_label": "ready.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1203,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
+      "label": "refunded.index.tsx",
+      "norm_label": "refunded.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1204,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
+      "label": "$reportId.tsx",
+      "norm_label": "$reportid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1205,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
+      "label": "expense-reports.index.tsx",
+      "norm_label": "expense-reports.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1206,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
+      "label": "expense.index.tsx",
+      "norm_label": "expense.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1207,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1208,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
+      "label": "register.index.tsx",
+      "norm_label": "register.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1209,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
+      "label": "settings.index.tsx",
+      "norm_label": "settings.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1216,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1217,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1218,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
-      "label": "unresolved.tsx",
-      "norm_label": "unresolved.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
-      "label": "$promoCodeSlug.tsx",
-      "norm_label": "$promocodeslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -42160,7 +42148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -42169,7 +42157,7 @@
       "source_location": "L4"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -42178,7 +42166,7 @@
       "source_location": "L49"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -42187,7 +42175,7 @@
       "source_location": "L34"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -42196,7 +42184,7 @@
       "source_location": "L74"
     },
     {
-      "community": 122,
+      "community": 121,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -42205,97 +42193,97 @@
       "source_location": "L6"
     },
     {
-      "community": 1220,
+      "community": 1210,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
+      "label": "$transactionId.tsx",
+      "norm_label": "$transactionid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1211,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
+      "label": "transactions.index.tsx",
+      "norm_label": "transactions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1212,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
+      "label": "procurement.index.tsx",
+      "norm_label": "procurement.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1213,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
+      "label": "edit.tsx",
+      "norm_label": "edit.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1214,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1215,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1216,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1217,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1218,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
-      "label": "new.index.tsx",
-      "norm_label": "new.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1219,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
-      "label": "active-cases.index.tsx",
-      "norm_label": "active-cases.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/active-cases.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
+      "label": "unresolved.tsx",
+      "norm_label": "unresolved.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1225,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
-      "label": "appointments.index.tsx",
-      "norm_label": "appointments.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/appointments.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1226,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
-      "label": "catalog-management.index.tsx",
-      "norm_label": "catalog-management.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1227,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
-      "label": "intake.index.tsx",
-      "norm_label": "intake.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1228,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
-      "label": "$traceId.test.tsx",
-      "norm_label": "$traceid.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
-      "label": "users.$userId.tsx",
-      "norm_label": "users.$userid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -42304,7 +42292,7 @@
       "source_location": "L173"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -42313,7 +42301,7 @@
       "source_location": "L102"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -42322,7 +42310,7 @@
       "source_location": "L201"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -42331,7 +42319,7 @@
       "source_location": "L150"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -42340,7 +42328,7 @@
       "source_location": "L155"
     },
     {
-      "community": 123,
+      "community": 122,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -42349,97 +42337,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1230,
+      "community": 1220,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
+      "label": "$promoCodeSlug.tsx",
+      "norm_label": "$promocodeslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1222,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_test_tsx",
-      "label": "_authed.test.tsx",
-      "norm_label": "_authed.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1223,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
-      "label": "join-team.index.tsx",
-      "norm_label": "join-team.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1224,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
-      "label": "_layout.index.test.tsx",
-      "norm_label": "_layout.index.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
+      "label": "new.index.tsx",
+      "norm_label": "new.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1225,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
-      "label": "_layout.test.tsx",
-      "norm_label": "_layout.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
+      "label": "active-cases.index.tsx",
+      "norm_label": "active-cases.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/active-cases.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1226,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
-      "label": "StoresSettingsAccordion.tsx",
-      "norm_label": "storessettingsaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
+      "label": "appointments.index.tsx",
+      "norm_label": "appointments.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/appointments.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1227,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stores_expensestore_ts",
-      "label": "expenseStore.ts",
-      "norm_label": "expensestore.ts",
-      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
+      "label": "catalog-management.index.tsx",
+      "norm_label": "catalog-management.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1228,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
+      "label": "intake.index.tsx",
+      "norm_label": "intake.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 1229,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
-      "label": "foundations-content.test.tsx",
-      "norm_label": "foundations-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
+      "label": "$traceId.test.tsx",
+      "norm_label": "$traceid.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
-      "label": "Introduction.stories.tsx",
-      "norm_label": "introduction.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -42448,7 +42436,7 @@
       "source_location": "L9"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -42457,7 +42445,7 @@
       "source_location": "L73"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -42466,7 +42454,7 @@
       "source_location": "L54"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -42475,7 +42463,7 @@
       "source_location": "L98"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -42484,7 +42472,7 @@
       "source_location": "L33"
     },
     {
-      "community": 124,
+      "community": 123,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
@@ -42493,7 +42481,160 @@
       "source_location": "L1"
     },
     {
+      "community": 1230,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
+      "label": "users.$userId.tsx",
+      "norm_label": "users.$userid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1231,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1232,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_test_tsx",
+      "label": "_authed.test.tsx",
+      "norm_label": "_authed.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1233,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
+      "label": "join-team.index.tsx",
+      "norm_label": "join-team.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1234,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
+      "label": "_layout.index.test.tsx",
+      "norm_label": "_layout.index.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1235,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
+      "label": "_layout.test.tsx",
+      "norm_label": "_layout.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1236,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
+      "label": "StoresSettingsAccordion.tsx",
+      "norm_label": "storessettingsaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1237,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stores_expensestore_ts",
+      "label": "expenseStore.ts",
+      "norm_label": "expensestore.ts",
+      "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1238,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1239,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
+      "label": "foundations-content.test.tsx",
+      "norm_label": "foundations-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
       "community": 1240,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
+      "label": "Introduction.stories.tsx",
+      "norm_label": "introduction.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1241,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -42502,7 +42643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -42511,7 +42652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -42520,7 +42661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -42529,7 +42670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -42538,7 +42679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -42547,7 +42688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -42556,7 +42697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -42565,21 +42706,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
       "norm_label": "reference-fixtures.test.tsx",
       "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_test_setup_ts",
-      "label": "setup.ts",
-      "norm_label": "setup.ts",
-      "source_file": "packages/athena-webapp/src/test/setup.ts",
       "source_location": "L1"
     },
     {
@@ -42639,6 +42771,15 @@
     {
       "community": 1250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_test_setup_ts",
+      "label": "setup.ts",
+      "norm_label": "setup.ts",
+      "source_file": "packages/athena-webapp/src/test/setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1251,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
       "norm_label": "useprint.test.ts",
@@ -42646,7 +42787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -42655,7 +42796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -42664,21 +42805,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
       "norm_label": "vitest.config.ts",
       "source_file": "packages/athena-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1254,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
       "source_location": "L1"
     },
     {
@@ -45582,6 +45714,96 @@
     {
       "community": 152,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "label": "ServiceAppointmentsView.tsx",
+      "norm_label": "serviceappointmentsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "serviceappointmentsview_formatdatetimelocal",
+      "label": "formatDateTimeLocal()",
+      "norm_label": "formatdatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "serviceappointmentsview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "serviceappointmentsview_parsedatetimelocal",
+      "label": "parseDateTimeLocal()",
+      "norm_label": "parsedatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "serviceappointmentsview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L472"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "date_time_picker_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
+      "source_location": "L99"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "date_time_picker_handledateselect",
+      "label": "handleDateSelect()",
+      "norm_label": "handledateselect()",
+      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "date_time_picker_handletimeblur",
+      "label": "handleTimeBlur()",
+      "norm_label": "handletimeblur()",
+      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "date_time_picker_handletimechange",
+      "label": "handleTimeChange()",
+      "norm_label": "handletimechange()",
+      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
+      "label": "date-time-picker.tsx",
+      "norm_label": "date-time-picker.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
       "norm_label": "basicmodalexample()",
@@ -45589,7 +45811,7 @@
       "source_location": "L7"
     },
     {
-      "community": 152,
+      "community": 154,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -45598,7 +45820,7 @@
       "source_location": "L69"
     },
     {
-      "community": 152,
+      "community": 154,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -45607,7 +45829,7 @@
       "source_location": "L44"
     },
     {
-      "community": 152,
+      "community": 154,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -45616,7 +45838,7 @@
       "source_location": "L103"
     },
     {
-      "community": 152,
+      "community": 154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -45625,7 +45847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
@@ -45634,7 +45856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 155,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -45643,7 +45865,7 @@
       "source_location": "L16"
     },
     {
-      "community": 153,
+      "community": 155,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -45652,7 +45874,7 @@
       "source_location": "L23"
     },
     {
-      "community": 153,
+      "community": 155,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -45661,7 +45883,7 @@
       "source_location": "L9"
     },
     {
-      "community": 153,
+      "community": 155,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -45670,7 +45892,7 @@
       "source_location": "L30"
     },
     {
-      "community": 154,
+      "community": 156,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -45679,7 +45901,7 @@
       "source_location": "L18"
     },
     {
-      "community": 154,
+      "community": 156,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -45688,7 +45910,7 @@
       "source_location": "L23"
     },
     {
-      "community": 154,
+      "community": 156,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -45697,7 +45919,7 @@
       "source_location": "L65"
     },
     {
-      "community": 154,
+      "community": 156,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -45706,7 +45928,7 @@
       "source_location": "L45"
     },
     {
-      "community": 154,
+      "community": 156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -45715,7 +45937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 157,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -45724,7 +45946,7 @@
       "source_location": "L78"
     },
     {
-      "community": 155,
+      "community": 157,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -45733,7 +45955,7 @@
       "source_location": "L74"
     },
     {
-      "community": 155,
+      "community": 157,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -45742,7 +45964,7 @@
       "source_location": "L103"
     },
     {
-      "community": 155,
+      "community": 157,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -45751,7 +45973,7 @@
       "source_location": "L109"
     },
     {
-      "community": 155,
+      "community": 157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -45760,7 +45982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 158,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -45769,7 +45991,7 @@
       "source_location": "L75"
     },
     {
-      "community": 156,
+      "community": 158,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -45778,7 +46000,7 @@
       "source_location": "L26"
     },
     {
-      "community": 156,
+      "community": 158,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -45787,7 +46009,7 @@
       "source_location": "L38"
     },
     {
-      "community": 156,
+      "community": 158,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -45796,7 +46018,7 @@
       "source_location": "L4"
     },
     {
-      "community": 156,
+      "community": 158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -45805,7 +46027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -45814,7 +46036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 159,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -45823,7 +46045,7 @@
       "source_location": "L86"
     },
     {
-      "community": 157,
+      "community": 159,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -45832,7 +46054,7 @@
       "source_location": "L59"
     },
     {
-      "community": 157,
+      "community": 159,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -45841,103 +46063,13 @@
       "source_location": "L42"
     },
     {
-      "community": 157,
+      "community": 159,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
       "norm_label": "mapthrownerror()",
       "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
       "source_location": "L76"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "cart_calculateposcarttotals",
-      "label": "calculatePosCartTotals()",
-      "norm_label": "calculateposcarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "cart_calculatepositemtotal",
-      "label": "calculatePosItemTotal()",
-      "norm_label": "calculatepositemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "cart_getposeffectiveprice",
-      "label": "getPosEffectivePrice()",
-      "norm_label": "getposeffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "cart_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
-      "label": "cart.ts",
-      "norm_label": "cart.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "cataloggateway_mapproductbyidresult",
-      "label": "mapProductByIdResult()",
-      "norm_label": "mapproductbyidresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexbarcodelookup",
-      "label": "useConvexBarcodeLookup()",
-      "norm_label": "useconvexbarcodelookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductidlookup",
-      "label": "useConvexProductIdLookup()",
-      "norm_label": "useconvexproductidlookup()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "cataloggateway_useconvexproductsearch",
-      "label": "useConvexProductSearch()",
-      "norm_label": "useconvexproductsearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
-      "label": "catalogGateway.ts",
-      "norm_label": "cataloggateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
-      "source_location": "L1"
     },
     {
       "community": 16,
@@ -46104,6 +46236,96 @@
     {
       "community": 160,
       "file_type": "code",
+      "id": "cart_calculateposcarttotals",
+      "label": "calculatePosCartTotals()",
+      "norm_label": "calculateposcarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "cart_calculatepositemtotal",
+      "label": "calculatePosItemTotal()",
+      "norm_label": "calculatepositemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "cart_getposeffectiveprice",
+      "label": "getPosEffectivePrice()",
+      "norm_label": "getposeffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "cart_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
+      "label": "cart.ts",
+      "norm_label": "cart.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cataloggateway_mapproductbyidresult",
+      "label": "mapProductByIdResult()",
+      "norm_label": "mapproductbyidresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexbarcodelookup",
+      "label": "useConvexBarcodeLookup()",
+      "norm_label": "useconvexbarcodelookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductidlookup",
+      "label": "useConvexProductIdLookup()",
+      "norm_label": "useconvexproductidlookup()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cataloggateway_useconvexproductsearch",
+      "label": "useConvexProductSearch()",
+      "norm_label": "useconvexproductsearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_cataloggateway_ts",
+      "label": "catalogGateway.ts",
+      "norm_label": "cataloggateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
       "norm_label": "registergateway.ts",
@@ -46111,7 +46333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 160,
+      "community": 162,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -46120,7 +46342,7 @@
       "source_location": "L12"
     },
     {
-      "community": 160,
+      "community": 162,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -46129,7 +46351,7 @@
       "source_location": "L27"
     },
     {
-      "community": 160,
+      "community": 162,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -46138,7 +46360,7 @@
       "source_location": "L33"
     },
     {
-      "community": 160,
+      "community": 162,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -46147,7 +46369,7 @@
       "source_location": "L55"
     },
     {
-      "community": 161,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -46156,7 +46378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 163,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -46165,7 +46387,7 @@
       "source_location": "L42"
     },
     {
-      "community": 161,
+      "community": 163,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -46174,7 +46396,7 @@
       "source_location": "L29"
     },
     {
-      "community": 161,
+      "community": 163,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -46183,7 +46405,7 @@
       "source_location": "L49"
     },
     {
-      "community": 161,
+      "community": 163,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -46192,7 +46414,7 @@
       "source_location": "L14"
     },
     {
-      "community": 162,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -46201,7 +46423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 164,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -46210,7 +46432,7 @@
       "source_location": "L184"
     },
     {
-      "community": 162,
+      "community": 164,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -46219,7 +46441,7 @@
       "source_location": "L200"
     },
     {
-      "community": 162,
+      "community": 164,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -46228,7 +46450,7 @@
       "source_location": "L244"
     },
     {
-      "community": 162,
+      "community": 164,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -46237,7 +46459,7 @@
       "source_location": "L206"
     },
     {
-      "community": 163,
+      "community": 165,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -46246,7 +46468,7 @@
       "source_location": "L93"
     },
     {
-      "community": 163,
+      "community": 165,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -46255,7 +46477,7 @@
       "source_location": "L75"
     },
     {
-      "community": 163,
+      "community": 165,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -46264,7 +46486,7 @@
       "source_location": "L4"
     },
     {
-      "community": 163,
+      "community": 165,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -46273,7 +46495,7 @@
       "source_location": "L47"
     },
     {
-      "community": 163,
+      "community": 165,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -46282,7 +46504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 166,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -46291,7 +46513,7 @@
       "source_location": "L11"
     },
     {
-      "community": 164,
+      "community": 166,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -46300,7 +46522,7 @@
       "source_location": "L25"
     },
     {
-      "community": 164,
+      "community": 166,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -46309,7 +46531,7 @@
       "source_location": "L9"
     },
     {
-      "community": 164,
+      "community": 166,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -46318,7 +46540,7 @@
       "source_location": "L39"
     },
     {
-      "community": 164,
+      "community": 166,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -46327,7 +46549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 167,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -46336,7 +46558,7 @@
       "source_location": "L4"
     },
     {
-      "community": 165,
+      "community": 167,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -46345,7 +46567,7 @@
       "source_location": "L24"
     },
     {
-      "community": 165,
+      "community": 167,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -46354,7 +46576,7 @@
       "source_location": "L6"
     },
     {
-      "community": 165,
+      "community": 167,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -46363,7 +46585,7 @@
       "source_location": "L42"
     },
     {
-      "community": 165,
+      "community": 167,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -46372,7 +46594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 168,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -46381,7 +46603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 168,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -46390,7 +46612,7 @@
       "source_location": "L28"
     },
     {
-      "community": 166,
+      "community": 168,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -46399,7 +46621,7 @@
       "source_location": "L5"
     },
     {
-      "community": 166,
+      "community": 168,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -46408,7 +46630,7 @@
       "source_location": "L7"
     },
     {
-      "community": 166,
+      "community": 168,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -46417,7 +46639,7 @@
       "source_location": "L46"
     },
     {
-      "community": 167,
+      "community": 169,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -46426,7 +46648,7 @@
       "source_location": "L147"
     },
     {
-      "community": 167,
+      "community": 169,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -46435,7 +46657,7 @@
       "source_location": "L185"
     },
     {
-      "community": 167,
+      "community": 169,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -46444,7 +46666,7 @@
       "source_location": "L115"
     },
     {
-      "community": 167,
+      "community": 169,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -46453,103 +46675,13 @@
       "source_location": "L31"
     },
     {
-      "community": 167,
+      "community": 169,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
       "norm_label": "homepage.tsx",
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "inventorylevelbadge_lowstockbadge",
-      "label": "LowStockBadge()",
-      "norm_label": "lowstockbadge()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "inventorylevelbadge_sellingfastbadge",
-      "label": "SellingFastBadge()",
-      "norm_label": "sellingfastbadge()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "inventorylevelbadge_sellingfastsignal",
-      "label": "SellingFastSignal()",
-      "norm_label": "sellingfastsignal()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "inventorylevelbadge_soldoutbadge",
-      "label": "SoldOutBadge()",
-      "norm_label": "soldoutbadge()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
-      "label": "InventoryLevelBadge.tsx",
-      "norm_label": "inventorylevelbadge.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
-      "label": "storefrontFailureObservability.ts",
-      "norm_label": "storefrontfailureobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "storefrontfailureobservability_createstorefrontfailureevent",
-      "label": "createStorefrontFailureEvent()",
-      "norm_label": "createstorefrontfailureevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L136"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "storefrontfailureobservability_emitstorefrontfailure",
-      "label": "emitStorefrontFailure()",
-      "norm_label": "emitstorefrontfailure()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L154"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
-      "label": "inferStorefrontJourneyFromRoute()",
-      "norm_label": "inferstorefrontjourneyfromroute()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "storefrontfailureobservability_normalizestorefronterror",
-      "label": "normalizeStorefrontError()",
-      "norm_label": "normalizestorefronterror()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L47"
     },
     {
       "community": 17,
@@ -46707,6 +46839,96 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "inventorylevelbadge_lowstockbadge",
+      "label": "LowStockBadge()",
+      "norm_label": "lowstockbadge()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "inventorylevelbadge_sellingfastbadge",
+      "label": "SellingFastBadge()",
+      "norm_label": "sellingfastbadge()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "inventorylevelbadge_sellingfastsignal",
+      "label": "SellingFastSignal()",
+      "norm_label": "sellingfastsignal()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "inventorylevelbadge_soldoutbadge",
+      "label": "SoldOutBadge()",
+      "norm_label": "soldoutbadge()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
+      "label": "InventoryLevelBadge.tsx",
+      "norm_label": "inventorylevelbadge.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
+      "label": "storefrontFailureObservability.ts",
+      "norm_label": "storefrontfailureobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "storefrontfailureobservability_createstorefrontfailureevent",
+      "label": "createStorefrontFailureEvent()",
+      "norm_label": "createstorefrontfailureevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L136"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "storefrontfailureobservability_emitstorefrontfailure",
+      "label": "emitStorefrontFailure()",
+      "norm_label": "emitstorefrontfailure()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
+      "label": "inferStorefrontJourneyFromRoute()",
+      "norm_label": "inferstorefrontjourneyfromroute()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "storefrontfailureobservability_normalizestorefronterror",
+      "label": "normalizeStorefrontError()",
+      "norm_label": "normalizestorefronterror()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
       "norm_label": "collectharnessrepovalidationselection()",
@@ -46714,7 +46936,7 @@
       "source_location": "L44"
     },
     {
-      "community": 170,
+      "community": 172,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -46723,7 +46945,7 @@
       "source_location": "L36"
     },
     {
-      "community": 170,
+      "community": 172,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -46732,7 +46954,7 @@
       "source_location": "L26"
     },
     {
-      "community": 170,
+      "community": 172,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -46741,7 +46963,7 @@
       "source_location": "L30"
     },
     {
-      "community": 170,
+      "community": 172,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
@@ -46750,7 +46972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
       "label": "registerSessionTraceLifecycle.test.ts",
@@ -46759,7 +46981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 173,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -46768,7 +46990,7 @@
       "source_location": "L63"
     },
     {
-      "community": 171,
+      "community": 173,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -46777,7 +46999,7 @@
       "source_location": "L79"
     },
     {
-      "community": 171,
+      "community": 173,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_gethandler",
       "label": "getHandler()",
@@ -46786,7 +47008,7 @@
       "source_location": "L206"
     },
     {
-      "community": 172,
+      "community": 174,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -46795,7 +47017,7 @@
       "source_location": "L109"
     },
     {
-      "community": 172,
+      "community": 174,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -46804,7 +47026,7 @@
       "source_location": "L84"
     },
     {
-      "community": 172,
+      "community": 174,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -46813,7 +47035,7 @@
       "source_location": "L95"
     },
     {
-      "community": 172,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
       "label": "checkout.ts",
@@ -46822,7 +47044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 175,
       "file_type": "code",
       "id": "expensesessions_buildnextexpensesessionnumber",
       "label": "buildNextExpenseSessionNumber()",
@@ -46831,7 +47053,7 @@
       "source_location": "L33"
     },
     {
-      "community": 173,
+      "community": 175,
       "file_type": "code",
       "id": "expensesessions_listexpensesessionsbystatusbefore",
       "label": "listExpenseSessionsByStatusBefore()",
@@ -46840,7 +47062,7 @@
       "source_location": "L66"
     },
     {
-      "community": 173,
+      "community": 175,
       "file_type": "code",
       "id": "expensesessions_loadexpensesessionitems",
       "label": "loadExpenseSessionItems()",
@@ -46849,7 +47071,7 @@
       "source_location": "L41"
     },
     {
-      "community": 173,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
       "label": "expenseSessions.ts",
@@ -46858,7 +47080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 176,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -46867,7 +47089,7 @@
       "source_location": "L21"
     },
     {
-      "community": 174,
+      "community": 176,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -46876,7 +47098,7 @@
       "source_location": "L35"
     },
     {
-      "community": 174,
+      "community": 176,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -46885,7 +47107,7 @@
       "source_location": "L45"
     },
     {
-      "community": 174,
+      "community": 176,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -46894,7 +47116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -46903,7 +47125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 177,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -46912,7 +47134,7 @@
       "source_location": "L21"
     },
     {
-      "community": 175,
+      "community": 177,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -46921,7 +47143,7 @@
       "source_location": "L35"
     },
     {
-      "community": 175,
+      "community": 177,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -46930,7 +47152,7 @@
       "source_location": "L45"
     },
     {
-      "community": 176,
+      "community": 178,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -46939,7 +47161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 178,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -46948,7 +47170,7 @@
       "source_location": "L181"
     },
     {
-      "community": 176,
+      "community": 178,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -46957,7 +47179,7 @@
       "source_location": "L77"
     },
     {
-      "community": 176,
+      "community": 178,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -46966,7 +47188,7 @@
       "source_location": "L197"
     },
     {
-      "community": 177,
+      "community": 179,
       "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
@@ -46975,7 +47197,7 @@
       "source_location": "L5"
     },
     {
-      "community": 177,
+      "community": 179,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -46984,7 +47206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 179,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -46993,84 +47215,12 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 179,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
       "norm_label": "currency.ts",
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "collections_getcachedtokenrecord",
-      "label": "getCachedTokenRecord()",
-      "norm_label": "getcachedtokenrecord()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "collections_resolveaccesstokenforstore",
-      "label": "resolveAccessTokenForStore()",
-      "norm_label": "resolveaccesstokenforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "collections_resolveconfigforstore",
-      "label": "resolveConfigForStore()",
-      "norm_label": "resolveconfigforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_collections_ts",
-      "label": "collections.ts",
-      "norm_label": "collections.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "normalize_maskmtnpartyid",
-      "label": "maskMtnPartyId()",
-      "norm_label": "maskmtnpartyid()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "normalize_normalizecollectionstransaction",
-      "label": "normalizeCollectionsTransaction()",
-      "norm_label": "normalizecollectionstransaction()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "normalize_parsecollectionsnotificationrequest",
-      "label": "parseCollectionsNotificationRequest()",
-      "norm_label": "parsecollectionsnotificationrequest()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_normalize_ts",
-      "label": "normalize.ts",
-      "norm_label": "normalize.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L1"
     },
     {
@@ -47229,6 +47379,78 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "collections_getcachedtokenrecord",
+      "label": "getCachedTokenRecord()",
+      "norm_label": "getcachedtokenrecord()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "collections_resolveaccesstokenforstore",
+      "label": "resolveAccessTokenForStore()",
+      "norm_label": "resolveaccesstokenforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "collections_resolveconfigforstore",
+      "label": "resolveConfigForStore()",
+      "norm_label": "resolveconfigforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_collections_ts",
+      "label": "collections.ts",
+      "norm_label": "collections.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "normalize_maskmtnpartyid",
+      "label": "maskMtnPartyId()",
+      "norm_label": "maskmtnpartyid()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "normalize_normalizecollectionstransaction",
+      "label": "normalizeCollectionsTransaction()",
+      "norm_label": "normalizecollectionstransaction()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "normalize_parsecollectionsnotificationrequest",
+      "label": "parseCollectionsNotificationRequest()",
+      "norm_label": "parsecollectionsnotificationrequest()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_normalize_ts",
+      "label": "normalize.ts",
+      "norm_label": "normalize.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 182,
+      "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
       "norm_label": "buildoperationalevent()",
@@ -47236,7 +47458,7 @@
       "source_location": "L28"
     },
     {
-      "community": 180,
+      "community": 182,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -47245,7 +47467,7 @@
       "source_location": "L42"
     },
     {
-      "community": 180,
+      "community": 182,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -47254,7 +47476,7 @@
       "source_location": "L73"
     },
     {
-      "community": 180,
+      "community": 182,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -47263,7 +47485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -47272,7 +47494,7 @@
       "source_location": "L8"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -47281,7 +47503,7 @@
       "source_location": "L32"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -47290,7 +47512,7 @@
       "source_location": "L64"
     },
     {
-      "community": 181,
+      "community": 183,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -47299,7 +47521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -47308,7 +47530,7 @@
       "source_location": "L18"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -47317,7 +47539,7 @@
       "source_location": "L25"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -47326,7 +47548,7 @@
       "source_location": "L11"
     },
     {
-      "community": 182,
+      "community": 184,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -47335,7 +47557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -47344,7 +47566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -47353,7 +47575,7 @@
       "source_location": "L26"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -47362,7 +47584,7 @@
       "source_location": "L43"
     },
     {
-      "community": 183,
+      "community": 185,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -47371,7 +47593,7 @@
       "source_location": "L107"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -47380,7 +47602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -47389,7 +47611,7 @@
       "source_location": "L36"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -47398,7 +47620,7 @@
       "source_location": "L23"
     },
     {
-      "community": 184,
+      "community": 186,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -47407,7 +47629,7 @@
       "source_location": "L18"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
       "label": "terminals.ts",
@@ -47416,7 +47638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "terminals_deleteterminal",
       "label": "deleteTerminal()",
@@ -47425,7 +47647,7 @@
       "source_location": "L89"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "terminals_registerterminal",
       "label": "registerTerminal()",
@@ -47434,7 +47656,7 @@
       "source_location": "L13"
     },
     {
-      "community": 185,
+      "community": 187,
       "file_type": "code",
       "id": "terminals_updateterminal",
       "label": "updateTerminal()",
@@ -47443,7 +47665,7 @@
       "source_location": "L54"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -47452,7 +47674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -47461,7 +47683,7 @@
       "source_location": "L122"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -47470,7 +47692,7 @@
       "source_location": "L34"
     },
     {
-      "community": 186,
+      "community": 188,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -47479,7 +47701,7 @@
       "source_location": "L72"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -47488,7 +47710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -47497,7 +47719,7 @@
       "source_location": "L162"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -47506,85 +47728,13 @@
       "source_location": "L56"
     },
     {
-      "community": 187,
+      "community": 189,
       "file_type": "code",
       "id": "sessioncommandrepository_findsessionitembyskuinpages",
       "label": "findSessionItemBySkuInPages()",
       "norm_label": "findsessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L180"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "adjustments_test_createapprovaldecisionmutationctx",
-      "label": "createApprovalDecisionMutationCtx()",
-      "norm_label": "createapprovaldecisionmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "adjustments_test_createsubmissionmutationctx",
-      "label": "createSubmissionMutationCtx()",
-      "norm_label": "createsubmissionmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L175"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "adjustments_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
-      "label": "adjustments.test.ts",
-      "norm_label": "adjustments.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
-      "label": "replenishment.test.ts",
-      "norm_label": "replenishment.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "replenishment_test_createreplenishmentqueryctx",
-      "label": "createReplenishmentQueryCtx()",
-      "norm_label": "createreplenishmentqueryctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "replenishment_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "replenishment_test_toasynciterable",
-      "label": "toAsyncIterable()",
-      "norm_label": "toasynciterable()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
-      "source_location": "L13"
     },
     {
       "community": 19,
@@ -47742,6 +47892,78 @@
     {
       "community": 190,
       "file_type": "code",
+      "id": "adjustments_test_createapprovaldecisionmutationctx",
+      "label": "createApprovalDecisionMutationCtx()",
+      "norm_label": "createapprovaldecisionmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "adjustments_test_createsubmissionmutationctx",
+      "label": "createSubmissionMutationCtx()",
+      "norm_label": "createsubmissionmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L175"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "adjustments_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
+      "label": "adjustments.test.ts",
+      "norm_label": "adjustments.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
+      "label": "replenishment.test.ts",
+      "norm_label": "replenishment.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "replenishment_test_createreplenishmentqueryctx",
+      "label": "createReplenishmentQueryCtx()",
+      "norm_label": "createreplenishmentqueryctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "replenishment_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "replenishment_test_toasynciterable",
+      "label": "toAsyncIterable()",
+      "norm_label": "toasynciterable()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
       "norm_label": "expectindex()",
@@ -47749,7 +47971,7 @@
       "source_location": "L19"
     },
     {
-      "community": 190,
+      "community": 192,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -47758,7 +47980,7 @@
       "source_location": "L26"
     },
     {
-      "community": 190,
+      "community": 192,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -47767,7 +47989,7 @@
       "source_location": "L12"
     },
     {
-      "community": 190,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -47776,7 +47998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 193,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -47785,7 +48007,7 @@
       "source_location": "L21"
     },
     {
-      "community": 191,
+      "community": 193,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -47794,7 +48016,7 @@
       "source_location": "L63"
     },
     {
-      "community": 191,
+      "community": 193,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -47803,7 +48025,7 @@
       "source_location": "L71"
     },
     {
-      "community": 191,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -47812,7 +48034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -47821,7 +48043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 194,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -47830,7 +48052,7 @@
       "source_location": "L13"
     },
     {
-      "community": 192,
+      "community": 194,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -47839,7 +48061,7 @@
       "source_location": "L31"
     },
     {
-      "community": 192,
+      "community": 194,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -47848,7 +48070,7 @@
       "source_location": "L9"
     },
     {
-      "community": 193,
+      "community": 195,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -47857,7 +48079,7 @@
       "source_location": "L228"
     },
     {
-      "community": 193,
+      "community": 195,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -47866,7 +48088,7 @@
       "source_location": "L45"
     },
     {
-      "community": 193,
+      "community": 195,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -47875,7 +48097,7 @@
       "source_location": "L26"
     },
     {
-      "community": 193,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -47884,7 +48106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -47893,7 +48115,7 @@
       "source_location": "L55"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -47902,7 +48124,7 @@
       "source_location": "L32"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -47911,7 +48133,7 @@
       "source_location": "L210"
     },
     {
-      "community": 194,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -47920,7 +48142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -47929,7 +48151,7 @@
       "source_location": "L51"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -47938,7 +48160,7 @@
       "source_location": "L26"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -47947,7 +48169,7 @@
       "source_location": "L290"
     },
     {
-      "community": 195,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -47956,7 +48178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -47965,7 +48187,7 @@
       "source_location": "L48"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -47974,7 +48196,7 @@
       "source_location": "L88"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -47983,7 +48205,7 @@
       "source_location": "L14"
     },
     {
-      "community": 196,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -47992,7 +48214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -48001,7 +48223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -48010,7 +48232,7 @@
       "source_location": "L15"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -48019,85 +48241,13 @@
       "source_location": "L28"
     },
     {
-      "community": 197,
+      "community": 199,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
       "norm_label": "summarycard()",
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L19"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "utils_countgroupedanalytics",
-      "label": "countGroupedAnalytics()",
-      "norm_label": "countgroupedanalytics()",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "utils_groupanalytics",
-      "label": "groupAnalytics()",
-      "norm_label": "groupanalytics()",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "utils_groupproductviewsbyday",
-      "label": "groupProductViewsByDay()",
-      "norm_label": "groupproductviewsbyday()",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L86"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
-      "label": "MaintenanceMessageEditor.tsx",
-      "norm_label": "maintenancemessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L1"
     },
     {
       "community": 2,
@@ -48552,6 +48702,78 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "utils_countgroupedanalytics",
+      "label": "countGroupedAnalytics()",
+      "norm_label": "countgroupedanalytics()",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "utils_groupanalytics",
+      "label": "groupAnalytics()",
+      "norm_label": "groupanalytics()",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "utils_groupproductviewsbyday",
+      "label": "groupProductViewsByDay()",
+      "norm_label": "groupproductviewsbyday()",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L86"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L52"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
+      "label": "MaintenanceMessageEditor.tsx",
+      "norm_label": "maintenancemessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
       "norm_label": "shoplook.tsx",
@@ -48559,7 +48781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 200,
+      "community": 202,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -48568,7 +48790,7 @@
       "source_location": "L67"
     },
     {
-      "community": 200,
+      "community": 202,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -48577,7 +48799,7 @@
       "source_location": "L90"
     },
     {
-      "community": 200,
+      "community": 202,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -48586,7 +48808,7 @@
       "source_location": "L73"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -48595,7 +48817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -48604,7 +48826,7 @@
       "source_location": "L103"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -48613,7 +48835,7 @@
       "source_location": "L95"
     },
     {
-      "community": 201,
+      "community": 203,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -48622,7 +48844,7 @@
       "source_location": "L81"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -48631,7 +48853,7 @@
       "source_location": "L91"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -48640,7 +48862,7 @@
       "source_location": "L68"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -48649,7 +48871,7 @@
       "source_location": "L22"
     },
     {
-      "community": 202,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -48658,7 +48880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "ordersummary_handlecompletetransaction",
       "label": "handleCompleteTransaction()",
@@ -48667,7 +48889,7 @@
       "source_location": "L131"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "ordersummary_handleprintreceipt",
       "label": "handlePrintReceipt()",
@@ -48676,7 +48898,7 @@
       "source_location": "L154"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "ordersummary_handlestartnewtransaction",
       "label": "handleStartNewTransaction()",
@@ -48685,7 +48907,7 @@
       "source_location": "L148"
     },
     {
-      "community": 203,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -48694,7 +48916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -48703,7 +48925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -48712,7 +48934,7 @@
       "source_location": "L247"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -48721,7 +48943,7 @@
       "source_location": "L284"
     },
     {
-      "community": 204,
+      "community": 206,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -48730,7 +48952,7 @@
       "source_location": "L166"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "label": "ProcurementView.tsx",
@@ -48739,7 +48961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "procurementview_formatoptionaldate",
       "label": "formatOptionalDate()",
@@ -48748,7 +48970,7 @@
       "source_location": "L78"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "procurementview_getfilteremptystatecopy",
       "label": "getFilterEmptyStateCopy()",
@@ -48757,7 +48979,7 @@
       "source_location": "L118"
     },
     {
-      "community": 205,
+      "community": 207,
       "file_type": "code",
       "id": "procurementview_getrecommendationstatuscopy",
       "label": "getRecommendationStatusCopy()",
@@ -48766,7 +48988,7 @@
       "source_location": "L89"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -48775,7 +48997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -48784,7 +49006,7 @@
       "source_location": "L63"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -48793,7 +49015,7 @@
       "source_location": "L54"
     },
     {
-      "community": 206,
+      "community": 208,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -48802,7 +49024,7 @@
       "source_location": "L11"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -48811,7 +49033,7 @@
       "source_location": "L16"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -48820,7 +49042,7 @@
       "source_location": "L35"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -48829,84 +49051,12 @@
       "source_location": "L6"
     },
     {
-      "community": 207,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
       "norm_label": "complimentaryproductsview.tsx",
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
-      "label": "ServiceAppointmentsView.tsx",
-      "norm_label": "serviceappointmentsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "serviceappointmentsview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L115"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "serviceappointmentsview_parsedatetimelocal",
-      "label": "parseDateTimeLocal()",
-      "norm_label": "parsedatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
-      "id": "serviceappointmentsview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L448"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "engagementmetrics_formatlastactivity",
-      "label": "formatLastActivity()",
-      "norm_label": "formatlastactivity()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "engagementmetrics_getdeviceicon",
-      "label": "getDeviceIcon()",
-      "norm_label": "getdeviceicon()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "engagementmetrics_getdevicelabel",
-      "label": "getDeviceLabel()",
-      "norm_label": "getdevicelabel()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
-      "label": "EngagementMetrics.tsx",
-      "norm_label": "engagementmetrics.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L1"
     },
     {
@@ -49065,6 +49215,42 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "engagementmetrics_formatlastactivity",
+      "label": "formatLastActivity()",
+      "norm_label": "formatlastactivity()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "engagementmetrics_getdeviceicon",
+      "label": "getDeviceIcon()",
+      "norm_label": "getdeviceicon()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "engagementmetrics_getdevicelabel",
+      "label": "getDeviceLabel()",
+      "norm_label": "getdevicelabel()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L93"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
+      "label": "EngagementMetrics.tsx",
+      "norm_label": "engagementmetrics.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
       "norm_label": "riskindicators.tsx",
@@ -49072,7 +49258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -49081,7 +49267,7 @@
       "source_location": "L15"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -49090,7 +49276,7 @@
       "source_location": "L28"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -49099,7 +49285,7 @@
       "source_location": "L54"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -49108,7 +49294,7 @@
       "source_location": "L66"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -49117,7 +49303,7 @@
       "source_location": "L121"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -49126,7 +49312,7 @@
       "source_location": "L74"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -49135,7 +49321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -49144,7 +49330,7 @@
       "source_location": "L51"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -49153,7 +49339,7 @@
       "source_location": "L92"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -49162,7 +49348,7 @@
       "source_location": "L16"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -49171,7 +49357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -49180,7 +49366,7 @@
       "source_location": "L16"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -49189,7 +49375,7 @@
       "source_location": "L6"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -49198,7 +49384,7 @@
       "source_location": "L46"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -49207,7 +49393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -49216,7 +49402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -49225,7 +49411,7 @@
       "source_location": "L83"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -49234,7 +49420,7 @@
       "source_location": "L100"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -49243,7 +49429,7 @@
       "source_location": "L79"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -49252,7 +49438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -49261,7 +49447,7 @@
       "source_location": "L25"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -49270,7 +49456,7 @@
       "source_location": "L52"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -49279,7 +49465,7 @@
       "source_location": "L78"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -49288,7 +49474,7 @@
       "source_location": "L4"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -49297,7 +49483,7 @@
       "source_location": "L20"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -49306,7 +49492,7 @@
       "source_location": "L42"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -49315,7 +49501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -49324,7 +49510,7 @@
       "source_location": "L101"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -49333,7 +49519,7 @@
       "source_location": "L68"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -49342,7 +49528,7 @@
       "source_location": "L42"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -49351,7 +49537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -49360,7 +49546,7 @@
       "source_location": "L13"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -49369,7 +49555,7 @@
       "source_location": "L46"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -49378,49 +49564,13 @@
       "source_location": "L21"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
       "norm_label": "offers.ts",
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "stores_getallstores",
-      "label": "getAllStores()",
-      "norm_label": "getallstores()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "stores_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "stores_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L20"
     },
     {
       "community": 22,
@@ -49569,6 +49719,42 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "stores_getallstores",
+      "label": "getAllStores()",
+      "norm_label": "getallstores()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "stores_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "stores_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -49576,7 +49762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -49585,7 +49771,7 @@
       "source_location": "L11"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -49594,7 +49780,7 @@
       "source_location": "L9"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -49603,7 +49789,7 @@
       "source_location": "L25"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -49612,7 +49798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -49621,7 +49807,7 @@
       "source_location": "L50"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -49630,7 +49816,7 @@
       "source_location": "L92"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -49639,7 +49825,7 @@
       "source_location": "L74"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -49648,7 +49834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -49657,7 +49843,7 @@
       "source_location": "L62"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -49666,7 +49852,7 @@
       "source_location": "L109"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -49675,7 +49861,7 @@
       "source_location": "L177"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -49684,7 +49870,7 @@
       "source_location": "L18"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -49693,7 +49879,7 @@
       "source_location": "L52"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -49702,7 +49888,7 @@
       "source_location": "L68"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -49711,7 +49897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -49720,7 +49906,7 @@
       "source_location": "L68"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -49729,7 +49915,7 @@
       "source_location": "L26"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -49738,7 +49924,7 @@
       "source_location": "L7"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -49747,7 +49933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -49756,7 +49942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -49765,7 +49951,7 @@
       "source_location": "L43"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -49774,7 +49960,7 @@
       "source_location": "L13"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -49783,7 +49969,7 @@
       "source_location": "L88"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -49792,7 +49978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -49801,7 +49987,7 @@
       "source_location": "L111"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -49810,7 +49996,7 @@
       "source_location": "L66"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -49819,7 +50005,7 @@
       "source_location": "L127"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -49828,7 +50014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -49837,7 +50023,7 @@
       "source_location": "L115"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -49846,7 +50032,7 @@
       "source_location": "L105"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -49855,7 +50041,7 @@
       "source_location": "L110"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -49864,7 +50050,7 @@
       "source_location": "L121"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -49873,7 +50059,7 @@
       "source_location": "L26"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -49882,48 +50068,12 @@
       "source_location": "L71"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "bootstrap_bootstrapcheckout",
-      "label": "bootstrapCheckout()",
-      "norm_label": "bootstrapcheckout()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "bootstrap_createbootstraptoken",
-      "label": "createBootstrapToken()",
-      "norm_label": "createbootstraptoken()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "bootstrap_createmarker",
-      "label": "createMarker()",
-      "norm_label": "createmarker()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
-      "label": "bootstrap.ts",
-      "norm_label": "bootstrap.ts",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L1"
     },
     {
@@ -50073,6 +50223,42 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "bootstrap_bootstrapcheckout",
+      "label": "bootstrapCheckout()",
+      "norm_label": "bootstrapcheckout()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "bootstrap_createbootstraptoken",
+      "label": "createBootstrapToken()",
+      "norm_label": "createbootstraptoken()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "bootstrap_createmarker",
+      "label": "createMarker()",
+      "norm_label": "createmarker()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
+      "label": "bootstrap.ts",
+      "norm_label": "bootstrap.ts",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
       "norm_label": "createinmemoryredis()",
@@ -50080,7 +50266,7 @@
       "source_location": "L33"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -50089,7 +50275,7 @@
       "source_location": "L6"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -50098,7 +50284,7 @@
       "source_location": "L25"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -50107,7 +50293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -50116,7 +50302,7 @@
       "source_location": "L17"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -50125,7 +50311,7 @@
       "source_location": "L11"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -50134,7 +50320,7 @@
       "source_location": "L24"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -50143,7 +50329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -50152,7 +50338,7 @@
       "source_location": "L20"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -50161,7 +50347,7 @@
       "source_location": "L65"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -50170,7 +50356,7 @@
       "source_location": "L14"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -50179,7 +50365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -50188,7 +50374,7 @@
       "source_location": "L126"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -50197,7 +50383,7 @@
       "source_location": "L130"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -50206,7 +50392,7 @@
       "source_location": "L689"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -50215,7 +50401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -50224,7 +50410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -50233,7 +50419,7 @@
       "source_location": "L8"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -50242,7 +50428,7 @@
       "source_location": "L79"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -50251,7 +50437,7 @@
       "source_location": "L61"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -50260,7 +50446,7 @@
       "source_location": "L49"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -50269,7 +50455,7 @@
       "source_location": "L17"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -50278,7 +50464,7 @@
       "source_location": "L11"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -50287,7 +50473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -50296,7 +50482,7 @@
       "source_location": "L26"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -50305,7 +50491,7 @@
       "source_location": "L72"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -50314,7 +50500,7 @@
       "source_location": "L36"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -50323,7 +50509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -50332,7 +50518,7 @@
       "source_location": "L95"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -50341,7 +50527,7 @@
       "source_location": "L93"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -50350,7 +50536,7 @@
       "source_location": "L94"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -50359,7 +50545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -50368,7 +50554,7 @@
       "source_location": "L98"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -50377,39 +50563,12 @@
       "source_location": "L33"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
       "norm_label": "discountcode.tsx",
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "discountreminder_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "discountreminder_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
-      "label": "DiscountReminder.tsx",
-      "norm_label": "discountreminder.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L1"
     },
     {
@@ -50550,6 +50709,33 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "discountreminder_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "discountreminder_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
+      "label": "DiscountReminder.tsx",
+      "norm_label": "discountreminder.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
       "norm_label": "utils.ts",
@@ -50557,7 +50743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -50566,7 +50752,7 @@
       "source_location": "L5"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -50575,7 +50761,7 @@
       "source_location": "L12"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -50584,7 +50770,7 @@
       "source_location": "L43"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -50593,7 +50779,7 @@
       "source_location": "L11"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -50602,7 +50788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
       "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
@@ -50611,7 +50797,7 @@
       "source_location": "L75"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestwithctx",
       "label": "decideApprovalRequestWithCtx()",
@@ -50620,7 +50806,7 @@
       "source_location": "L25"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "label": "approvalRequests.ts",
@@ -50629,7 +50815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
       "label": "staffProfiles.ts",
@@ -50638,7 +50824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "staffprofiles_buildfullname",
       "label": "buildFullName()",
@@ -50647,7 +50833,7 @@
       "source_location": "L12"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "staffprofiles_buildroleassignmentdrafts",
       "label": "buildRoleAssignmentDrafts()",
@@ -50656,7 +50842,7 @@
       "source_location": "L17"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -50665,7 +50851,7 @@
       "source_location": "L7"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -50674,7 +50860,7 @@
       "source_location": "L109"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -50683,7 +50869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -50692,7 +50878,7 @@
       "source_location": "L17"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -50701,7 +50887,7 @@
       "source_location": "L37"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -50710,7 +50896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -50719,7 +50905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -50728,7 +50914,7 @@
       "source_location": "L18"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -50737,7 +50923,7 @@
       "source_location": "L9"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -50746,7 +50932,7 @@
       "source_location": "L8"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -50755,7 +50941,7 @@
       "source_location": "L9"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -50764,7 +50950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -50773,7 +50959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -50782,40 +50968,13 @@
       "source_location": "L7"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
       "norm_label": "selectresumablesession()",
       "source_file": "packages/athena-webapp/convex/pos/domain/sessionRules.ts",
       "source_location": "L29"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
-      "label": "paymentAllocationService.ts",
-      "norm_label": "paymentallocationservice.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "paymentallocationservice_recordretailsalepaymentallocations",
-      "label": "recordRetailSalePaymentAllocations()",
-      "norm_label": "recordretailsalepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "paymentallocationservice_recordretailvoidpaymentallocations",
-      "label": "recordRetailVoidPaymentAllocations()",
-      "norm_label": "recordretailvoidpaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
-      "source_location": "L45"
     },
     {
       "community": 25,
@@ -50955,6 +51114,33 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
+      "label": "paymentAllocationService.ts",
+      "norm_label": "paymentallocationservice.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "paymentallocationservice_recordretailsalepaymentallocations",
+      "label": "recordRetailSalePaymentAllocations()",
+      "norm_label": "recordretailsalepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "paymentallocationservice_recordretailvoidpaymentallocations",
+      "label": "recordRetailVoidPaymentAllocations()",
+      "norm_label": "recordretailvoidpaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
       "norm_label": "registersessionrepository.ts",
@@ -50962,7 +51148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -50971,7 +51157,7 @@
       "source_location": "L33"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -50980,7 +51166,7 @@
       "source_location": "L13"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -50989,7 +51175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -50998,7 +51184,7 @@
       "source_location": "L13"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -51007,7 +51193,7 @@
       "source_location": "L17"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -51016,7 +51202,7 @@
       "source_location": "L16"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -51025,7 +51211,7 @@
       "source_location": "L42"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -51034,7 +51220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -51043,7 +51229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -51052,7 +51238,7 @@
       "source_location": "L23"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -51061,7 +51247,7 @@
       "source_location": "L16"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -51070,7 +51256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -51079,7 +51265,7 @@
       "source_location": "L12"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -51088,7 +51274,7 @@
       "source_location": "L7"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -51097,7 +51283,7 @@
       "source_location": "L7"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -51106,7 +51292,7 @@
       "source_location": "L14"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -51115,7 +51301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -51124,7 +51310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -51133,7 +51319,7 @@
       "source_location": "L45"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -51142,7 +51328,7 @@
       "source_location": "L37"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -51151,7 +51337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -51160,7 +51346,7 @@
       "source_location": "L10"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -51169,7 +51355,7 @@
       "source_location": "L44"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -51178,7 +51364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -51187,40 +51373,13 @@
       "source_location": "L86"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
       "norm_label": "createtestctx()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
       "source_location": "L102"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_workflowtrace_ts",
-      "label": "workflowTrace.ts",
-      "norm_label": "workflowtrace.ts",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "workflowtrace_createworkflowtraceid",
-      "label": "createWorkflowTraceId()",
-      "norm_label": "createworkflowtraceid()",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "workflowtrace_normalizeworkflowtracelookupvalue",
-      "label": "normalizeWorkflowTraceLookupValue()",
-      "norm_label": "normalizeworkflowtracelookupvalue()",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L25"
     },
     {
       "community": 26,
@@ -51360,6 +51519,33 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_workflowtrace_ts",
+      "label": "workflowTrace.ts",
+      "norm_label": "workflowtrace.ts",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "workflowtrace_createworkflowtraceid",
+      "label": "createWorkflowTraceId()",
+      "norm_label": "createworkflowtraceid()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "workflowtrace_normalizeworkflowtracelookupvalue",
+      "label": "normalizeWorkflowTraceLookupValue()",
+      "norm_label": "normalizeworkflowtracelookupvalue()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
       "norm_label": "view.tsx",
@@ -51367,7 +51553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -51376,7 +51562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -51385,7 +51571,7 @@
       "source_location": "L4"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -51394,7 +51580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -51403,7 +51589,7 @@
       "source_location": "L18"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -51412,7 +51598,7 @@
       "source_location": "L5"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -51421,7 +51607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -51430,7 +51616,7 @@
       "source_location": "L19"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -51439,7 +51625,7 @@
       "source_location": "L11"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -51448,7 +51634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -51457,7 +51643,7 @@
       "source_location": "L21"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -51466,7 +51652,7 @@
       "source_location": "L8"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -51475,7 +51661,7 @@
       "source_location": "L21"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -51484,7 +51670,7 @@
       "source_location": "L13"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -51493,7 +51679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -51502,7 +51688,7 @@
       "source_location": "L100"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -51511,7 +51697,7 @@
       "source_location": "L10"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -51520,7 +51706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -51529,7 +51715,7 @@
       "source_location": "L100"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -51538,7 +51724,7 @@
       "source_location": "L10"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -51547,7 +51733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -51556,7 +51742,7 @@
       "source_location": "L15"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -51565,7 +51751,7 @@
       "source_location": "L39"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -51574,7 +51760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -51583,7 +51769,7 @@
       "source_location": "L43"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -51592,39 +51778,12 @@
       "source_location": "L51"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
       "norm_label": "inputotp.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "fadein_fadein",
-      "label": "FadeIn()",
-      "norm_label": "fadein()",
-      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_fadein_tsx",
-      "label": "FadeIn.tsx",
-      "norm_label": "fadein.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/FadeIn.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
-      "label": "FadeIn.tsx",
-      "norm_label": "fadein.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L1"
     },
     {
@@ -51756,6 +51915,33 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "fadein_fadein",
+      "label": "FadeIn()",
+      "norm_label": "fadein()",
+      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_fadein_tsx",
+      "label": "FadeIn.tsx",
+      "norm_label": "fadein.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/FadeIn.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
+      "label": "FadeIn.tsx",
+      "norm_label": "fadein.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
       "norm_label": "handleremovebestseller()",
@@ -51763,7 +51949,7 @@
       "source_location": "L53"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -51772,7 +51958,7 @@
       "source_location": "L65"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -51781,7 +51967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -51790,7 +51976,7 @@
       "source_location": "L47"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -51799,7 +51985,7 @@
       "source_location": "L53"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -51808,7 +51994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -51817,7 +52003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -51826,7 +52012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
@@ -51835,7 +52021,7 @@
       "source_location": "L9"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "operationsqueueview_handledecideapprovalrequest",
       "label": "handleDecideApprovalRequest()",
@@ -51844,7 +52030,7 @@
       "source_location": "L294"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "operationsqueueview_handlesubmitstockbatch",
       "label": "handleSubmitStockBatch()",
@@ -51853,7 +52039,7 @@
       "source_location": "L284"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -51862,7 +52048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -51871,7 +52057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -51880,7 +52066,7 @@
       "source_location": "L67"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -51889,7 +52075,7 @@
       "source_location": "L9"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
@@ -51898,7 +52084,7 @@
       "source_location": "L100"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -51907,7 +52093,7 @@
       "source_location": "L95"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -51916,7 +52102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -51925,7 +52111,7 @@
       "source_location": "L36"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -51934,7 +52120,7 @@
       "source_location": "L32"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -51943,7 +52129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -51952,7 +52138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -51961,7 +52147,7 @@
       "source_location": "L20"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -51970,7 +52156,7 @@
       "source_location": "L26"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_workflowtracelink_tsx",
       "label": "WorkflowTraceLink.tsx",
@@ -51979,7 +52165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "workflowtracelink_getworkflowtracelinktarget",
       "label": "getWorkflowTraceLinkTarget()",
@@ -51988,40 +52174,13 @@
       "source_location": "L25"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "workflowtracelink_workflowtracelink",
       "label": "WorkflowTraceLink()",
       "norm_label": "workflowtracelink()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/WorkflowTraceLink.tsx",
       "source_location": "L36"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
-      "label": "ProductsListView.tsx",
-      "norm_label": "productslistview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "productslistview_handleclearcache",
-      "label": "handleClearCache()",
-      "norm_label": "handleclearcache()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "productslistview_productactionstogglegroup",
-      "label": "ProductActionsToggleGroup()",
-      "norm_label": "productactionstogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
-      "source_location": "L20"
     },
     {
       "community": 28,
@@ -52152,6 +52311,33 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
+      "label": "ProductsListView.tsx",
+      "norm_label": "productslistview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "productslistview_handleclearcache",
+      "label": "handleClearCache()",
+      "norm_label": "handleclearcache()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "productslistview_productactionstogglegroup",
+      "label": "ProductActionsToggleGroup()",
+      "norm_label": "productactionstogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
       "norm_label": "productstablecontext.tsx",
@@ -52159,7 +52345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -52168,7 +52354,7 @@
       "source_location": "L16"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -52177,7 +52363,7 @@
       "source_location": "L60"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -52186,7 +52372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -52195,7 +52381,7 @@
       "source_location": "L45"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -52204,7 +52390,7 @@
       "source_location": "L19"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -52213,7 +52399,7 @@
       "source_location": "L128"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -52222,7 +52408,7 @@
       "source_location": "L40"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -52231,7 +52417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -52240,7 +52426,7 @@
       "source_location": "L24"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -52249,7 +52435,7 @@
       "source_location": "L20"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -52258,7 +52444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -52267,7 +52453,7 @@
       "source_location": "L25"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -52276,7 +52462,7 @@
       "source_location": "L17"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -52285,7 +52471,34 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
+      "label": "ServiceAppointmentsView.test.tsx",
+      "norm_label": "serviceappointmentsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "serviceappointmentsview_test_choosedatetime",
+      "label": "chooseDateTime()",
+      "norm_label": "choosedatetime()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "serviceappointmentsview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -52294,7 +52507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -52303,7 +52516,7 @@
       "source_location": "L214"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -52312,7 +52525,7 @@
       "source_location": "L69"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -52321,7 +52534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -52330,7 +52543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -52339,7 +52552,7 @@
       "source_location": "L3"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -52348,7 +52561,7 @@
       "source_location": "L9"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -52357,66 +52570,12 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "app_skeleton_appskeleton",
-      "label": "AppSkeleton()",
-      "norm_label": "appskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
-      "label": "app-skeleton.tsx",
-      "norm_label": "app-skeleton.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/loading/app-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
-      "label": "app-skeleton.tsx",
-      "norm_label": "app-skeleton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "dashboard_skeleton_dashboardskeleton",
-      "label": "DashboardSkeleton()",
-      "norm_label": "dashboardskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
-      "label": "dashboard-skeleton.tsx",
-      "norm_label": "dashboard-skeleton.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/loading/dashboard-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
-      "label": "dashboard-skeleton.tsx",
-      "norm_label": "dashboard-skeleton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1"
     },
     {
@@ -52539,6 +52698,60 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "app_skeleton_appskeleton",
+      "label": "AppSkeleton()",
+      "norm_label": "appskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
+      "label": "app-skeleton.tsx",
+      "norm_label": "app-skeleton.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/loading/app-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
+      "label": "app-skeleton.tsx",
+      "norm_label": "app-skeleton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "dashboard_skeleton_dashboardskeleton",
+      "label": "DashboardSkeleton()",
+      "norm_label": "dashboardskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
+      "label": "dashboard-skeleton.tsx",
+      "norm_label": "dashboard-skeleton.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/loading/dashboard-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
+      "label": "dashboard-skeleton.tsx",
+      "norm_label": "dashboard-skeleton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 292,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
       "norm_label": "table-skeleton.tsx",
@@ -52546,7 +52759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 292,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -52555,7 +52768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 292,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -52564,7 +52777,7 @@
       "source_location": "L3"
     },
     {
-      "community": 291,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -52573,7 +52786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 293,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -52582,7 +52795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 293,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -52591,7 +52804,7 @@
       "source_location": "L3"
     },
     {
-      "community": 292,
+      "community": 294,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -52600,7 +52813,7 @@
       "source_location": "L4"
     },
     {
-      "community": 292,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -52609,7 +52822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 294,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -52618,7 +52831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -52627,7 +52840,7 @@
       "source_location": "L104"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -52636,7 +52849,7 @@
       "source_location": "L36"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -52645,7 +52858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
       "label": "WorkflowTraceRouteLink.tsx",
@@ -52654,7 +52867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
       "label": "getWorkflowTraceRouteTarget()",
@@ -52663,7 +52876,7 @@
       "source_location": "L23"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "workflowtraceroutelink_workflowtraceroutelink",
       "label": "WorkflowTraceRouteLink()",
@@ -52672,7 +52885,7 @@
       "source_location": "L41"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -52681,7 +52894,7 @@
       "source_location": "L20"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -52690,7 +52903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -52699,7 +52912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -52708,7 +52921,7 @@
       "source_location": "L30"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -52717,7 +52930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -52726,7 +52939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -52735,7 +52948,7 @@
       "source_location": "L9"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -52744,66 +52957,12 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
       "norm_label": "loading-button.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "modal_onchange",
-      "label": "onChange()",
-      "norm_label": "onchange()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modal_tsx",
-      "label": "modal.tsx",
-      "norm_label": "modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
-      "label": "modal.tsx",
-      "norm_label": "modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "alert_modal_alertmodal",
-      "label": "AlertModal()",
-      "norm_label": "alertmodal()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
-      "label": "alert-modal.tsx",
-      "norm_label": "alert-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/alert-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
-      "label": "alert-modal.tsx",
-      "norm_label": "alert-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -53205,6 +53364,60 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "modal_onchange",
+      "label": "onChange()",
+      "norm_label": "onchange()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modal_tsx",
+      "label": "modal.tsx",
+      "norm_label": "modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
+      "label": "modal.tsx",
+      "norm_label": "modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "alert_modal_alertmodal",
+      "label": "AlertModal()",
+      "norm_label": "alertmodal()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
+      "label": "alert-modal.tsx",
+      "norm_label": "alert-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/alert-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
+      "label": "alert-modal.tsx",
+      "norm_label": "alert-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
       "norm_label": "overlaymodal()",
@@ -53212,7 +53425,7 @@
       "source_location": "L12"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -53221,7 +53434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -53230,7 +53443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -53239,7 +53452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -53248,7 +53461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -53257,7 +53470,7 @@
       "source_location": "L3"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -53266,7 +53479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -53275,7 +53488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -53284,7 +53497,7 @@
       "source_location": "L6"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -53293,7 +53506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -53302,7 +53515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -53311,7 +53524,7 @@
       "source_location": "L3"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -53320,7 +53533,7 @@
       "source_location": "L44"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -53329,7 +53542,7 @@
       "source_location": "L19"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -53338,7 +53551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -53347,7 +53560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -53356,7 +53569,7 @@
       "source_location": "L159"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -53365,7 +53578,7 @@
       "source_location": "L195"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -53374,7 +53587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -53383,7 +53596,7 @@
       "source_location": "L22"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -53392,7 +53605,7 @@
       "source_location": "L45"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -53401,7 +53614,7 @@
       "source_location": "L24"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -53410,67 +53623,13 @@
       "source_location": "L38"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
       "norm_label": "onlineordercontext.tsx",
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
-      "label": "PermissionsContext.tsx",
-      "norm_label": "permissionscontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "permissionscontext_permissionsprovider",
-      "label": "PermissionsProvider()",
-      "norm_label": "permissionsprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "permissionscontext_usepermissionscontext",
-      "label": "usePermissionsContext()",
-      "norm_label": "usepermissionscontext()",
-      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
-      "source_location": "L51"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
-      "label": "ProductContext.tsx",
-      "norm_label": "productcontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "productcontext_productprovider",
-      "label": "ProductProvider()",
-      "norm_label": "productprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "productcontext_useproduct",
-      "label": "useProduct()",
-      "norm_label": "useproduct()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L282"
     },
     {
       "community": 31,
@@ -53592,6 +53751,60 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
+      "label": "PermissionsContext.tsx",
+      "norm_label": "permissionscontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "permissionscontext_permissionsprovider",
+      "label": "PermissionsProvider()",
+      "norm_label": "permissionsprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "permissionscontext_usepermissionscontext",
+      "label": "usePermissionsContext()",
+      "norm_label": "usepermissionscontext()",
+      "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
+      "source_location": "L51"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
+      "label": "ProductContext.tsx",
+      "norm_label": "productcontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "productcontext_productprovider",
+      "label": "ProductProvider()",
+      "norm_label": "productprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "productcontext_useproduct",
+      "label": "useProduct()",
+      "norm_label": "useproduct()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L282"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
       "norm_label": "usercontext.tsx",
@@ -53599,7 +53812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -53608,7 +53821,7 @@
       "source_location": "L12"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -53617,7 +53830,7 @@
       "source_location": "L37"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -53626,7 +53839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -53635,7 +53848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -53644,7 +53857,7 @@
       "source_location": "L4"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -53653,7 +53866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -53662,7 +53875,7 @@
       "source_location": "L9"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -53671,7 +53884,7 @@
       "source_location": "L50"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -53680,7 +53893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -53689,7 +53902,7 @@
       "source_location": "L6"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -53698,7 +53911,7 @@
       "source_location": "L31"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -53707,7 +53920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -53716,7 +53929,7 @@
       "source_location": "L5"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -53725,7 +53938,7 @@
       "source_location": "L31"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
@@ -53734,7 +53947,7 @@
       "source_location": "L7"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -53743,7 +53956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -53752,7 +53965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -53761,7 +53974,7 @@
       "source_location": "L3"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -53770,7 +53983,7 @@
       "source_location": "L10"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -53779,7 +53992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -53788,7 +54001,7 @@
       "source_location": "L17"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -53797,67 +54010,13 @@
       "source_location": "L58"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
       "norm_label": "commandgateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/commandGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "main_app",
-      "label": "App()",
-      "norm_label": "app()",
-      "source_file": "packages/storefront-webapp/src/main.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_main_tsx",
-      "label": "main.tsx",
-      "norm_label": "main.tsx",
-      "source_file": "packages/athena-webapp/src/main.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_main_tsx",
-      "label": "main.tsx",
-      "norm_label": "main.tsx",
-      "source_file": "packages/storefront-webapp/src/main.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
-      "label": "routeTree.browser-boundary.test.ts",
-      "norm_label": "routetree.browser-boundary.test.ts",
-      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "routetree_browser_boundary_test_collectsourcefiles",
-      "label": "collectSourceFiles()",
-      "norm_label": "collectsourcefiles()",
-      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "routetree_browser_boundary_test_findillegalconveximports",
-      "label": "findIllegalConvexImports()",
-      "norm_label": "findillegalconveximports()",
-      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
-      "source_location": "L46"
     },
     {
       "community": 32,
@@ -53970,6 +54129,60 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "main_app",
+      "label": "App()",
+      "norm_label": "app()",
+      "source_file": "packages/storefront-webapp/src/main.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_main_tsx",
+      "label": "main.tsx",
+      "norm_label": "main.tsx",
+      "source_file": "packages/athena-webapp/src/main.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_main_tsx",
+      "label": "main.tsx",
+      "norm_label": "main.tsx",
+      "source_file": "packages/storefront-webapp/src/main.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
+      "label": "routeTree.browser-boundary.test.ts",
+      "norm_label": "routetree.browser-boundary.test.ts",
+      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "routetree_browser_boundary_test_collectsourcefiles",
+      "label": "collectSourceFiles()",
+      "norm_label": "collectsourcefiles()",
+      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "routetree_browser_boundary_test_findillegalconveximports",
+      "label": "findIllegalConvexImports()",
+      "norm_label": "findillegalconveximports()",
+      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
       "norm_label": "authedcomponent()",
@@ -53977,7 +54190,7 @@
       "source_location": "L18"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -53986,7 +54199,7 @@
       "source_location": "L28"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -53995,7 +54208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -54004,7 +54217,7 @@
       "source_location": "L127"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -54013,7 +54226,7 @@
       "source_location": "L106"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -54022,7 +54235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -54031,7 +54244,7 @@
       "source_location": "L66"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -54040,7 +54253,7 @@
       "source_location": "L20"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -54049,7 +54262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -54058,7 +54271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -54067,7 +54280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -54076,7 +54289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -54085,7 +54298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -54094,7 +54307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -54103,7 +54316,7 @@
       "source_location": "L16"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -54112,7 +54325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -54121,7 +54334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -54130,7 +54343,34 @@
       "source_location": "L19"
     },
     {
-      "community": 326,
+      "community": 328,
+      "file_type": "code",
+      "id": "packages_athena_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 328,
+      "file_type": "code",
+      "id": "vitest_setup_pointercapturestub",
+      "label": "pointerCaptureStub()",
+      "norm_label": "pointercapturestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 328,
+      "file_type": "code",
+      "id": "vitest_setup_pointerreleasestub",
+      "label": "pointerReleaseStub()",
+      "norm_label": "pointerreleasestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 329,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -54139,7 +54379,7 @@
       "source_location": "L32"
     },
     {
-      "community": 326,
+      "community": 329,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -54148,94 +54388,13 @@
       "source_location": "L3"
     },
     {
-      "community": 326,
+      "community": 329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 327,
-      "file_type": "code",
-      "id": "color_getallcolors",
-      "label": "getAllColors()",
-      "norm_label": "getallcolors()",
-      "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 327,
-      "file_type": "code",
-      "id": "color_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 327,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_color_ts",
-      "label": "color.ts",
-      "norm_label": "color.ts",
-      "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "organization_getallorganizations",
-      "label": "getAllOrganizations()",
-      "norm_label": "getallorganizations()",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "organization_getorganization",
-      "label": "getOrganization()",
-      "norm_label": "getorganization()",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "upsells_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "upsells_getlastviewedproduct",
-      "label": "getLastViewedProduct()",
-      "norm_label": "getlastviewedproduct()",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L5"
     },
     {
       "community": 33,
@@ -54339,6 +54498,87 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "color_getallcolors",
+      "label": "getAllColors()",
+      "norm_label": "getallcolors()",
+      "source_file": "packages/storefront-webapp/src/api/color.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "color_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/color.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_color_ts",
+      "label": "color.ts",
+      "norm_label": "color.ts",
+      "source_file": "packages/storefront-webapp/src/api/color.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "organization_getallorganizations",
+      "label": "getAllOrganizations()",
+      "norm_label": "getallorganizations()",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "organization_getorganization",
+      "label": "getOrganization()",
+      "norm_label": "getorganization()",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "upsells_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
+      "id": "upsells_getlastviewedproduct",
+      "label": "getLastViewedProduct()",
+      "norm_label": "getlastviewedproduct()",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 333,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
       "norm_label": "useroffers.ts",
@@ -54346,7 +54586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 333,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -54355,7 +54595,7 @@
       "source_location": "L18"
     },
     {
-      "community": 330,
+      "community": 333,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -54364,7 +54604,7 @@
       "source_location": "L23"
     },
     {
-      "community": 331,
+      "community": 334,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -54373,7 +54613,7 @@
       "source_location": "L22"
     },
     {
-      "community": 331,
+      "community": 334,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -54382,7 +54622,7 @@
       "source_location": "L55"
     },
     {
-      "community": 331,
+      "community": 334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -54391,7 +54631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 335,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -54400,7 +54640,7 @@
       "source_location": "L77"
     },
     {
-      "community": 332,
+      "community": 335,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -54409,7 +54649,7 @@
       "source_location": "L11"
     },
     {
-      "community": 332,
+      "community": 335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -54418,7 +54658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 336,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -54427,7 +54667,7 @@
       "source_location": "L11"
     },
     {
-      "community": 333,
+      "community": 336,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -54436,7 +54676,7 @@
       "source_location": "L22"
     },
     {
-      "community": 333,
+      "community": 336,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -54445,7 +54685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 337,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -54454,7 +54694,7 @@
       "source_location": "L110"
     },
     {
-      "community": 334,
+      "community": 337,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -54463,7 +54703,7 @@
       "source_location": "L89"
     },
     {
-      "community": 334,
+      "community": 337,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -54472,7 +54712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 338,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -54481,7 +54721,7 @@
       "source_location": "L4"
     },
     {
-      "community": 335,
+      "community": 338,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -54490,7 +54730,7 @@
       "source_location": "L24"
     },
     {
-      "community": 335,
+      "community": 338,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -54499,7 +54739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 339,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -54508,7 +54748,7 @@
       "source_location": "L131"
     },
     {
-      "community": 336,
+      "community": 339,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -54517,94 +54757,13 @@
       "source_location": "L12"
     },
     {
-      "community": 336,
+      "community": 339,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
       "norm_label": "footer.tsx",
       "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 337,
-      "file_type": "code",
-      "id": "featuredproductssection_featuredproductssection",
-      "label": "FeaturedProductsSection()",
-      "norm_label": "featuredproductssection()",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 337,
-      "file_type": "code",
-      "id": "featuredproductssection_featuredsection",
-      "label": "FeaturedSection()",
-      "norm_label": "featuredsection()",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 337,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
-      "label": "FeaturedProductsSection.tsx",
-      "norm_label": "featuredproductssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
-      "label": "PromoAlert.tsx",
-      "norm_label": "promoalert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "promoalert_getpromoalertcopy",
-      "label": "getPromoAlertCopy()",
-      "norm_label": "getpromoalertcopy()",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "promoalert_promoalert",
-      "label": "PromoAlert()",
-      "norm_label": "promoalert()",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L59"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
-      "label": "RewardsAlert.tsx",
-      "norm_label": "rewardsalert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "rewardsalert_handleshopnow",
-      "label": "handleShopNow()",
-      "norm_label": "handleshopnow()",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "rewardsalert_onrewardsalertclose",
-      "label": "onRewardsAlertClose()",
-      "norm_label": "onrewardsalertclose()",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L20"
     },
     {
       "community": 34,
@@ -54708,6 +54867,87 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "featuredproductssection_featuredproductssection",
+      "label": "FeaturedProductsSection()",
+      "norm_label": "featuredproductssection()",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "featuredproductssection_featuredsection",
+      "label": "FeaturedSection()",
+      "norm_label": "featuredsection()",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
+      "label": "FeaturedProductsSection.tsx",
+      "norm_label": "featuredproductssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
+      "label": "PromoAlert.tsx",
+      "norm_label": "promoalert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "promoalert_getpromoalertcopy",
+      "label": "getPromoAlertCopy()",
+      "norm_label": "getpromoalertcopy()",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "promoalert_promoalert",
+      "label": "PromoAlert()",
+      "norm_label": "promoalert()",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
+      "label": "RewardsAlert.tsx",
+      "norm_label": "rewardsalert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
+      "id": "rewardsalert_handleshopnow",
+      "label": "handleShopNow()",
+      "norm_label": "handleshopnow()",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
+      "id": "rewardsalert_onrewardsalertclose",
+      "label": "onRewardsAlertClose()",
+      "norm_label": "onrewardsalertclose()",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 343,
+      "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
       "norm_label": "navigationbar()",
@@ -54715,7 +54955,7 @@
       "source_location": "L30"
     },
     {
-      "community": 340,
+      "community": 343,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -54724,7 +54964,7 @@
       "source_location": "L95"
     },
     {
-      "community": 340,
+      "community": 343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -54733,7 +54973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 344,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -54742,7 +54982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 344,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -54751,7 +54991,7 @@
       "source_location": "L61"
     },
     {
-      "community": 341,
+      "community": 344,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -54760,7 +55000,7 @@
       "source_location": "L65"
     },
     {
-      "community": 342,
+      "community": 345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -54769,7 +55009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 345,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -54778,7 +55018,7 @@
       "source_location": "L150"
     },
     {
-      "community": 342,
+      "community": 345,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -54787,7 +55027,7 @@
       "source_location": "L157"
     },
     {
-      "community": 343,
+      "community": 346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -54796,7 +55036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 346,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -54805,7 +55045,7 @@
       "source_location": "L63"
     },
     {
-      "community": 343,
+      "community": 346,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -54814,7 +55054,7 @@
       "source_location": "L48"
     },
     {
-      "community": 344,
+      "community": 347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -54823,7 +55063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 347,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -54832,7 +55072,7 @@
       "source_location": "L63"
     },
     {
-      "community": 344,
+      "community": 347,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -54841,7 +55081,7 @@
       "source_location": "L76"
     },
     {
-      "community": 345,
+      "community": 348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -54850,7 +55090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 348,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -54859,7 +55099,7 @@
       "source_location": "L51"
     },
     {
-      "community": 345,
+      "community": 348,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -54868,7 +55108,7 @@
       "source_location": "L36"
     },
     {
-      "community": 346,
+      "community": 349,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -54877,7 +55117,7 @@
       "source_location": "L16"
     },
     {
-      "community": 346,
+      "community": 349,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -54886,94 +55126,13 @@
       "source_location": "L39"
     },
     {
-      "community": 346,
+      "community": 349,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
       "norm_label": "navigationbarprovider.tsx",
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 347,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
-      "label": "StoreContext.tsx",
-      "norm_label": "storecontext.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 347,
-      "file_type": "code",
-      "id": "storecontext_storeprovider",
-      "label": "StoreProvider()",
-      "norm_label": "storeprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 347,
-      "file_type": "code",
-      "id": "storecontext_usestorecontext",
-      "label": "useStoreContext()",
-      "norm_label": "usestorecontext()",
-      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
-      "label": "StorefrontObservabilityProvider.tsx",
-      "norm_label": "storefrontobservabilityprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "label": "StorefrontObservabilityProvider()",
-      "norm_label": "storefrontobservabilityprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "label": "useStorefrontObservability()",
-      "norm_label": "usestorefrontobservability()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
-      "label": "useProductDiscount.ts",
-      "norm_label": "useproductdiscount.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscount",
-      "label": "useProductDiscount()",
-      "norm_label": "useproductdiscount()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscounts",
-      "label": "useProductDiscounts()",
-      "norm_label": "useproductdiscounts()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L25"
     },
     {
       "community": 35,
@@ -55077,6 +55236,87 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
+      "label": "StoreContext.tsx",
+      "norm_label": "storecontext.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "storecontext_storeprovider",
+      "label": "StoreProvider()",
+      "norm_label": "storeprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "storecontext_usestorecontext",
+      "label": "useStoreContext()",
+      "norm_label": "usestorecontext()",
+      "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
+      "label": "StorefrontObservabilityProvider.tsx",
+      "norm_label": "storefrontobservabilityprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
+      "label": "StorefrontObservabilityProvider()",
+      "norm_label": "storefrontobservabilityprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_usestorefrontobservability",
+      "label": "useStorefrontObservability()",
+      "norm_label": "usestorefrontobservability()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
+      "label": "useProductDiscount.ts",
+      "norm_label": "useproductdiscount.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscount",
+      "label": "useProductDiscount()",
+      "norm_label": "useproductdiscount()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscounts",
+      "label": "useProductDiscounts()",
+      "norm_label": "useproductdiscounts()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 353,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
       "norm_label": "useshoppingbag.ts",
@@ -55084,7 +55324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 350,
+      "community": 353,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -55093,7 +55333,7 @@
       "source_location": "L556"
     },
     {
-      "community": 350,
+      "community": 353,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -55102,7 +55342,7 @@
       "source_location": "L52"
     },
     {
-      "community": 351,
+      "community": 354,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -55111,7 +55351,7 @@
       "source_location": "L429"
     },
     {
-      "community": 351,
+      "community": 354,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -55120,7 +55360,7 @@
       "source_location": "L102"
     },
     {
-      "community": 351,
+      "community": 354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -55129,7 +55369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -55138,7 +55378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 355,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -55147,7 +55387,7 @@
       "source_location": "L250"
     },
     {
-      "community": 352,
+      "community": 355,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -55156,7 +55396,7 @@
       "source_location": "L46"
     },
     {
-      "community": 353,
+      "community": 356,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -55165,7 +55405,7 @@
       "source_location": "L17"
     },
     {
-      "community": 353,
+      "community": 356,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -55174,7 +55414,7 @@
       "source_location": "L63"
     },
     {
-      "community": 353,
+      "community": 356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -55183,7 +55423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 357,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -55192,7 +55432,7 @@
       "source_location": "L47"
     },
     {
-      "community": 354,
+      "community": 357,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -55201,7 +55441,7 @@
       "source_location": "L141"
     },
     {
-      "community": 354,
+      "community": 357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
@@ -55210,7 +55450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
@@ -55219,7 +55459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 358,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -55228,7 +55468,7 @@
       "source_location": "L21"
     },
     {
-      "community": 355,
+      "community": 358,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -55237,7 +55477,7 @@
       "source_location": "L107"
     },
     {
-      "community": 356,
+      "community": 359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -55246,7 +55486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 359,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -55255,94 +55495,13 @@
       "source_location": "L161"
     },
     {
-      "community": 356,
+      "community": 359,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
       "norm_label": "signupbeforeload()",
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L66"
-    },
-    {
-      "community": 357,
-      "file_type": "code",
-      "id": "env_optionalnumberenv",
-      "label": "optionalNumberEnv()",
-      "norm_label": "optionalnumberenv()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 357,
-      "file_type": "code",
-      "id": "env_requireenv",
-      "label": "requireEnv()",
-      "norm_label": "requireenv()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 357,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
-      "label": "env.ts",
-      "norm_label": "env.ts",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "graphify_wiki_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "graphify_wiki_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "scripts_graphify_wiki_test_ts",
-      "label": "graphify-wiki.test.ts",
-      "norm_label": "graphify-wiki.test.ts",
-      "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "harness_audit_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "harness_audit_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "scripts_harness_audit_test_ts",
-      "label": "harness-audit.test.ts",
-      "norm_label": "harness-audit.test.ts",
-      "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 36,
@@ -55446,6 +55605,87 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "env_optionalnumberenv",
+      "label": "optionalNumberEnv()",
+      "norm_label": "optionalnumberenv()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "env_requireenv",
+      "label": "requireEnv()",
+      "norm_label": "requireenv()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
+      "label": "env.ts",
+      "norm_label": "env.ts",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "graphify_wiki_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "graphify_wiki_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "scripts_graphify_wiki_test_ts",
+      "label": "graphify-wiki.test.ts",
+      "norm_label": "graphify-wiki.test.ts",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
+      "id": "harness_audit_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
+      "id": "harness_audit_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
+      "id": "scripts_harness_audit_test_ts",
+      "label": "harness-audit.test.ts",
+      "norm_label": "harness-audit.test.ts",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 363,
+      "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -55453,7 +55693,7 @@
       "source_location": "L21"
     },
     {
-      "community": 360,
+      "community": 363,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -55462,7 +55702,7 @@
       "source_location": "L15"
     },
     {
-      "community": 360,
+      "community": 363,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -55471,7 +55711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 364,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -55480,7 +55720,7 @@
       "source_location": "L48"
     },
     {
-      "community": 361,
+      "community": 364,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -55489,7 +55729,7 @@
       "source_location": "L42"
     },
     {
-      "community": 361,
+      "community": 364,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -55498,7 +55738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 365,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -55507,7 +55747,7 @@
       "source_location": "L16"
     },
     {
-      "community": 362,
+      "community": 365,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -55516,7 +55756,7 @@
       "source_location": "L10"
     },
     {
-      "community": 362,
+      "community": 365,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -55525,7 +55765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 366,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -55534,7 +55774,7 @@
       "source_location": "L19"
     },
     {
-      "community": 363,
+      "community": 366,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -55543,7 +55783,7 @@
       "source_location": "L13"
     },
     {
-      "community": 363,
+      "community": 366,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -55552,7 +55792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 367,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -55561,7 +55801,7 @@
       "source_location": "L16"
     },
     {
-      "community": 364,
+      "community": 367,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -55570,7 +55810,7 @@
       "source_location": "L10"
     },
     {
-      "community": 364,
+      "community": 367,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -55579,7 +55819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 368,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -55588,7 +55828,7 @@
       "source_location": "L20"
     },
     {
-      "community": 365,
+      "community": 368,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -55597,7 +55837,7 @@
       "source_location": "L14"
     },
     {
-      "community": 365,
+      "community": 368,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
@@ -55606,7 +55846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 369,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -55615,7 +55855,7 @@
       "source_location": "L26"
     },
     {
-      "community": 366,
+      "community": 369,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -55624,75 +55864,12 @@
       "source_location": "L18"
     },
     {
-      "community": 366,
+      "community": 369,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
       "norm_label": "pre-commit-generated-artifacts.test.ts",
       "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 367,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
-      "label": "runPreCommitGeneratedArtifacts()",
-      "norm_label": "runprecommitgeneratedartifacts()",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 367,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
-      "label": "stageTrackedGraphifyArtifacts()",
-      "norm_label": "stagetrackedgraphifyartifacts()",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 367,
-      "file_type": "code",
-      "id": "scripts_pre_commit_generated_artifacts_ts",
-      "label": "pre-commit-generated-artifacts.ts",
-      "norm_label": "pre-commit-generated-artifacts.ts",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "closeouts_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
-      "label": "closeouts.test.ts",
-      "norm_label": "closeouts.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "deposits_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
-      "label": "deposits.test.ts",
-      "norm_label": "deposits.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
       "source_location": "L1"
     },
     {
@@ -55797,6 +55974,69 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
+      "label": "runPreCommitGeneratedArtifacts()",
+      "norm_label": "runprecommitgeneratedartifacts()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
+      "label": "stageTrackedGraphifyArtifacts()",
+      "norm_label": "stagetrackedgraphifyartifacts()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_ts",
+      "label": "pre-commit-generated-artifacts.ts",
+      "norm_label": "pre-commit-generated-artifacts.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "closeouts_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
+      "label": "closeouts.test.ts",
+      "norm_label": "closeouts.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
+      "id": "deposits_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
+      "label": "deposits.test.ts",
+      "norm_label": "deposits.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 373,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
       "norm_label": "paymentallocationattribution.test.ts",
@@ -55804,7 +56044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 373,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -55813,7 +56053,7 @@
       "source_location": "L12"
     },
     {
-      "community": 371,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -55822,7 +56062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 374,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -55831,7 +56071,7 @@
       "source_location": "L8"
     },
     {
-      "community": 372,
+      "community": 375,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -55840,7 +56080,7 @@
       "source_location": "L10"
     },
     {
-      "community": 372,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -55849,7 +56089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -55858,7 +56098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 376,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -55867,7 +56107,7 @@
       "source_location": "L18"
     },
     {
-      "community": 374,
+      "community": 377,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -55876,7 +56116,7 @@
       "source_location": "L10"
     },
     {
-      "community": 374,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -55885,7 +56125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -55894,7 +56134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 378,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -55903,7 +56143,7 @@
       "source_location": "L6"
     },
     {
-      "community": 376,
+      "community": 379,
       "file_type": "code",
       "id": "cashier_authenticatehandler",
       "label": "authenticateHandler()",
@@ -55912,67 +56152,13 @@
       "source_location": "L239"
     },
     {
-      "community": 376,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_cashier_ts",
       "label": "cashier.ts",
       "norm_label": "cashier.ts",
       "source_file": "packages/athena-webapp/convex/inventory/cashier.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 377,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
-      "label": "posQueryCleanup.test.ts",
-      "norm_label": "posquerycleanup.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 377,
-      "file_type": "code",
-      "id": "posquerycleanup_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
-      "label": "sessionQueryIndexes.test.ts",
-      "norm_label": "sessionqueryindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "sessionqueryindexes_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "stores_tov2onlyconfig",
-      "label": "toV2OnlyConfig()",
-      "norm_label": "tov2onlyconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L27"
     },
     {
       "community": 38,
@@ -56076,6 +56262,60 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
+      "label": "posQueryCleanup.test.ts",
+      "norm_label": "posquerycleanup.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "posquerycleanup_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
+      "label": "sessionQueryIndexes.test.ts",
+      "norm_label": "sessionqueryindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "sessionqueryindexes_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
+      "id": "stores_tov2onlyconfig",
+      "label": "toV2OnlyConfig()",
+      "norm_label": "tov2onlyconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 383,
+      "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
       "norm_label": "callllmprovider()",
@@ -56083,7 +56323,7 @@
       "source_location": "L4"
     },
     {
-      "community": 380,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -56092,7 +56332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 384,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -56101,7 +56341,7 @@
       "source_location": "L3"
     },
     {
-      "community": 381,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -56110,7 +56350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 385,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -56119,7 +56359,7 @@
       "source_location": "L3"
     },
     {
-      "community": 382,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -56128,7 +56368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 386,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -56137,7 +56377,7 @@
       "source_location": "L6"
     },
     {
-      "community": 383,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -56146,7 +56386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 387,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -56155,7 +56395,7 @@
       "source_location": "L3"
     },
     {
-      "community": 384,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -56164,7 +56404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 388,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -56173,7 +56413,7 @@
       "source_location": "L18"
     },
     {
-      "community": 385,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -56182,7 +56422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 389,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -56191,66 +56431,12 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
       "norm_label": "eventbuilders.ts",
       "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 387,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
-      "label": "registerSessionTracing.test.ts",
-      "norm_label": "registersessiontracing.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 387,
-      "file_type": "code",
-      "id": "registersessiontracing_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
-      "label": "serviceIntake.test.ts",
-      "norm_label": "serviceintake.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "serviceintake_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "emailotp_formatvalidtime",
-      "label": "formatValidTime()",
-      "norm_label": "formatvalidtime()",
-      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_otp_emailotp_ts",
-      "label": "EmailOTP.ts",
-      "norm_label": "emailotp.ts",
-      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
       "source_location": "L1"
     },
     {
@@ -56346,6 +56532,60 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
+      "label": "registerSessionTracing.test.ts",
+      "norm_label": "registersessiontracing.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "registersessiontracing_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
+      "label": "serviceIntake.test.ts",
+      "norm_label": "serviceintake.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "serviceintake_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 392,
+      "file_type": "code",
+      "id": "emailotp_formatvalidtime",
+      "label": "formatValidTime()",
+      "norm_label": "formatvalidtime()",
+      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 392,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_otp_emailotp_ts",
+      "label": "EmailOTP.ts",
+      "norm_label": "emailotp.ts",
+      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 393,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -56353,7 +56593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 393,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -56362,7 +56602,7 @@
       "source_location": "L8"
     },
     {
-      "community": 391,
+      "community": 394,
       "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
@@ -56371,7 +56611,7 @@
       "source_location": "L31"
     },
     {
-      "community": 391,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
@@ -56380,7 +56620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 395,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -56389,7 +56629,7 @@
       "source_location": "L6"
     },
     {
-      "community": 392,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -56398,7 +56638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -56407,7 +56647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 396,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -56416,7 +56656,7 @@
       "source_location": "L88"
     },
     {
-      "community": 394,
+      "community": 397,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -56425,7 +56665,7 @@
       "source_location": "L8"
     },
     {
-      "community": 394,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -56434,7 +56674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 398,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -56443,7 +56683,7 @@
       "source_location": "L4"
     },
     {
-      "community": 395,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -56452,7 +56692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 399,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -56461,67 +56701,13 @@
       "source_location": "L15"
     },
     {
-      "community": 396,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
       "norm_label": "access.test.ts",
       "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 397,
-      "file_type": "code",
-      "id": "access_requirestorefulladminaccess",
-      "label": "requireStoreFullAdminAccess()",
-      "norm_label": "requirestorefulladminaccess()",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 397,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_access_ts",
-      "label": "access.ts",
-      "norm_label": "access.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
-      "label": "purchaseOrders.test.ts",
-      "norm_label": "purchaseorders.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "purchaseorders_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
-      "label": "receiving.test.ts",
-      "norm_label": "receiving.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "receiving_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
-      "source_location": "L13"
     },
     {
       "community": 4,
@@ -56868,6 +57054,60 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "access_requirestorefulladminaccess",
+      "label": "requireStoreFullAdminAccess()",
+      "norm_label": "requirestorefulladminaccess()",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_access_ts",
+      "label": "access.ts",
+      "norm_label": "access.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
+      "label": "purchaseOrders.test.ts",
+      "norm_label": "purchaseorders.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "purchaseorders_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
+      "label": "receiving.test.ts",
+      "norm_label": "receiving.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "receiving_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
       "norm_label": "vendors.test.ts",
@@ -56875,7 +57115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 400,
+      "community": 403,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -56884,7 +57124,7 @@
       "source_location": "L5"
     },
     {
-      "community": 401,
+      "community": 404,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -56893,7 +57133,7 @@
       "source_location": "L15"
     },
     {
-      "community": 401,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -56902,7 +57142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 405,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -56911,7 +57151,7 @@
       "source_location": "L8"
     },
     {
-      "community": 402,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -56920,7 +57160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 406,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -56929,7 +57169,7 @@
       "source_location": "L17"
     },
     {
-      "community": 403,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -56938,7 +57178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 407,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -56947,7 +57187,7 @@
       "source_location": "L6"
     },
     {
-      "community": 404,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -56956,7 +57196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 408,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -56965,7 +57205,7 @@
       "source_location": "L5"
     },
     {
-      "community": 405,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -56974,7 +57214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 409,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -56983,67 +57223,13 @@
       "source_location": "L25"
     },
     {
-      "community": 406,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
       "norm_label": "onlineorderitem.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 407,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 407,
-      "file_type": "code",
-      "id": "reviews_getstorefrontactorbyid",
-      "label": "getStoreFrontActorById()",
-      "norm_label": "getstorefrontactorbyid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "rewards_formatpointslabel",
-      "label": "formatPointsLabel()",
-      "norm_label": "formatpointslabel()",
-      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "savedbag_listsavedbagitems",
-      "label": "listSavedBagItems()",
-      "norm_label": "listsavedbagitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
-      "source_location": "L14"
     },
     {
       "community": 41,
@@ -57138,6 +57324,60 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "reviews_getstorefrontactorbyid",
+      "label": "getStoreFrontActorById()",
+      "norm_label": "getstorefrontactorbyid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "rewards_formatpointslabel",
+      "label": "formatPointsLabel()",
+      "norm_label": "formatpointslabel()",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 412,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 412,
+      "file_type": "code",
+      "id": "savedbag_listsavedbagitems",
+      "label": "listSavedBagItems()",
+      "norm_label": "listsavedbagitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 413,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
       "norm_label": "storefrontobservabilityreport.test.ts",
@@ -57145,7 +57385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 413,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -57154,7 +57394,7 @@
       "source_location": "L8"
     },
     {
-      "community": 411,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -57163,7 +57403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 414,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -57172,7 +57412,7 @@
       "source_location": "L3"
     },
     {
-      "community": 412,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -57181,7 +57421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 415,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -57190,7 +57430,7 @@
       "source_location": "L5"
     },
     {
-      "community": 413,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -57199,7 +57439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 416,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -57208,7 +57448,7 @@
       "source_location": "L16"
     },
     {
-      "community": 414,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -57217,7 +57457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 417,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -57226,7 +57466,7 @@
       "source_location": "L30"
     },
     {
-      "community": 415,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possale_ts",
       "label": "posSale.ts",
@@ -57235,7 +57475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 418,
       "file_type": "code",
       "id": "possale_buildpossaletraceseed",
       "label": "buildPosSaleTraceSeed()",
@@ -57244,7 +57484,7 @@
       "source_location": "L43"
     },
     {
-      "community": 416,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
@@ -57253,67 +57493,13 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 419,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
       "norm_label": "buildpossessiontraceseed()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
       "source_location": "L43"
-    },
-    {
-      "community": 417,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
-      "label": "presentation.ts",
-      "norm_label": "presentation.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 417,
-      "file_type": "code",
-      "id": "presentation_buildworkflowtraceviewmodel",
-      "label": "buildWorkflowTraceViewModel()",
-      "norm_label": "buildworkflowtraceviewmodel()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
-      "label": "schemaIndexes.test.ts",
-      "norm_label": "schemaindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "schemaindexes_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_serviceintake_ts",
-      "label": "serviceIntake.ts",
-      "norm_label": "serviceintake.ts",
-      "source_file": "packages/athena-webapp/shared/serviceIntake.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "serviceintake_validateserviceintakeinput",
-      "label": "validateServiceIntakeInput()",
-      "norm_label": "validateserviceintakeinput()",
-      "source_file": "packages/athena-webapp/shared/serviceIntake.ts",
-      "source_location": "L1"
     },
     {
       "community": 42,
@@ -57408,6 +57594,60 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
+      "label": "presentation.ts",
+      "norm_label": "presentation.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "presentation_buildworkflowtraceviewmodel",
+      "label": "buildWorkflowTraceViewModel()",
+      "norm_label": "buildworkflowtraceviewmodel()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
+      "label": "schemaIndexes.test.ts",
+      "norm_label": "schemaindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "schemaindexes_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_serviceintake_ts",
+      "label": "serviceIntake.ts",
+      "norm_label": "serviceintake.ts",
+      "source_file": "packages/athena-webapp/shared/serviceIntake.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
+      "id": "serviceintake_validateserviceintakeinput",
+      "label": "validateServiceIntakeInput()",
+      "norm_label": "validateserviceintakeinput()",
+      "source_file": "packages/athena-webapp/shared/serviceIntake.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 423,
+      "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
@@ -57415,7 +57655,7 @@
       "source_location": "L7"
     },
     {
-      "community": 420,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -57424,7 +57664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 424,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -57433,7 +57673,7 @@
       "source_location": "L12"
     },
     {
-      "community": 421,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -57442,7 +57682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -57451,7 +57691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 425,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -57460,7 +57700,7 @@
       "source_location": "L11"
     },
     {
-      "community": 423,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -57469,7 +57709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 426,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -57478,7 +57718,7 @@
       "source_location": "L11"
     },
     {
-      "community": 424,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -57487,7 +57727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 427,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -57496,7 +57736,7 @@
       "source_location": "L3"
     },
     {
-      "community": 425,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -57505,7 +57745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 428,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -57514,7 +57754,7 @@
       "source_location": "L12"
     },
     {
-      "community": 426,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -57523,67 +57763,13 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 429,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
       "norm_label": "storedropdown()",
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L42"
-    },
-    {
-      "community": 427,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeview_tsx",
-      "label": "StoreView.tsx",
-      "norm_label": "storeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 427,
-      "file_type": "code",
-      "id": "storeview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
-      "label": "StoresDropdown.tsx",
-      "norm_label": "storesdropdown.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "storesdropdown_storesdropdown",
-      "label": "StoresDropdown()",
-      "norm_label": "storesdropdown()",
-      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "barcodeqrviewer_handleprint",
-      "label": "handlePrint()",
-      "norm_label": "handleprint()",
-      "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
-      "label": "BarcodeQRViewer.tsx",
-      "norm_label": "barcodeqrviewer.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
-      "source_location": "L1"
     },
     {
       "community": 43,
@@ -57678,6 +57864,60 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeview_tsx",
+      "label": "StoreView.tsx",
+      "norm_label": "storeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "storeview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
+      "label": "StoresDropdown.tsx",
+      "norm_label": "storesdropdown.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "storesdropdown_storesdropdown",
+      "label": "StoresDropdown()",
+      "norm_label": "storesdropdown()",
+      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
+      "id": "barcodeqrviewer_handleprint",
+      "label": "handlePrint()",
+      "norm_label": "handleprint()",
+      "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
+      "label": "BarcodeQRViewer.tsx",
+      "norm_label": "barcodeqrviewer.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 433,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
       "norm_label": "processingfees.tsx",
@@ -57685,7 +57925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 433,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -57694,7 +57934,7 @@
       "source_location": "L10"
     },
     {
-      "community": 431,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -57703,7 +57943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 434,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -57712,7 +57952,7 @@
       "source_location": "L14"
     },
     {
-      "community": 432,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -57721,7 +57961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 435,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -57730,7 +57970,7 @@
       "source_location": "L5"
     },
     {
-      "community": 433,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -57739,7 +57979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 436,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -57748,7 +57988,7 @@
       "source_location": "L10"
     },
     {
-      "community": 434,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -57757,7 +57997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 437,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -57766,7 +58006,7 @@
       "source_location": "L15"
     },
     {
-      "community": 435,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -57775,7 +58015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 438,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -57784,7 +58024,7 @@
       "source_location": "L13"
     },
     {
-      "community": 436,
+      "community": 439,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -57793,66 +58033,12 @@
       "source_location": "L116"
     },
     {
-      "community": 436,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
       "norm_label": "copyimagesview.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
-      "label": "product-variant-columns.tsx",
-      "norm_label": "product-variant-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "product_variant_columns_setsourcevariant",
-      "label": "setSourceVariant()",
-      "norm_label": "setsourcevariant()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "activitytimeline_capitalizefirstletter",
-      "label": "capitalizeFirstLetter()",
-      "norm_label": "capitalizefirstletter()",
-      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
-      "source_location": "L151"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
-      "label": "ActivityTimeline.tsx",
-      "norm_label": "activitytimeline.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "analyticsitems_analyticsitems",
-      "label": "AnalyticsItems()",
-      "norm_label": "analyticsitems()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
-      "label": "AnalyticsItems.tsx",
-      "norm_label": "analyticsitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
       "source_location": "L1"
     },
     {
@@ -57948,6 +58134,60 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
+      "label": "product-variant-columns.tsx",
+      "norm_label": "product-variant-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "product_variant_columns_setsourcevariant",
+      "label": "setSourceVariant()",
+      "norm_label": "setsourcevariant()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "activitytimeline_capitalizefirstletter",
+      "label": "capitalizeFirstLetter()",
+      "norm_label": "capitalizefirstletter()",
+      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
+      "source_location": "L151"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
+      "label": "ActivityTimeline.tsx",
+      "norm_label": "activitytimeline.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
+      "id": "analyticsitems_analyticsitems",
+      "label": "AnalyticsItems()",
+      "norm_label": "analyticsitems()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
+      "label": "AnalyticsItems.tsx",
+      "norm_label": "analyticsitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 443,
+      "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
       "norm_label": "analyticsproducts()",
@@ -57955,7 +58195,7 @@
       "source_location": "L19"
     },
     {
-      "community": 440,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -57964,7 +58204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 444,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -57973,7 +58213,7 @@
       "source_location": "L7"
     },
     {
-      "community": 441,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -57982,7 +58222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 445,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -57991,7 +58231,7 @@
       "source_location": "L42"
     },
     {
-      "community": 442,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -58000,7 +58240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -58009,7 +58249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 446,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -58018,7 +58258,7 @@
       "source_location": "L66"
     },
     {
-      "community": 444,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -58027,7 +58267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 447,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -58036,7 +58276,7 @@
       "source_location": "L18"
     },
     {
-      "community": 445,
+      "community": 448,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -58045,7 +58285,7 @@
       "source_location": "L6"
     },
     {
-      "community": 445,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -58054,7 +58294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 449,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -58063,66 +58303,12 @@
       "source_location": "L10"
     },
     {
-      "community": 446,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
       "norm_label": "logview.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 447,
-      "file_type": "code",
-      "id": "logsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 447,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
-      "label": "LogsView.tsx",
-      "norm_label": "logsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
-      "label": "useLoadLogItems.ts",
-      "norm_label": "useloadlogitems.ts",
-      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "useloadlogitems_useloadlogitems",
-      "label": "useLoadLogItems()",
-      "norm_label": "useloadlogitems()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "auth_auth",
-      "label": "Auth()",
-      "norm_label": "auth()",
-      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_auth_tsx",
-      "label": "Auth.tsx",
-      "norm_label": "auth.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
       "source_location": "L1"
     },
     {
@@ -58218,6 +58404,60 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "logsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
+      "label": "LogsView.tsx",
+      "norm_label": "logsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
+      "label": "useLoadLogItems.ts",
+      "norm_label": "useloadlogitems.ts",
+      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "useloadlogitems_useloadlogitems",
+      "label": "useLoadLogItems()",
+      "norm_label": "useloadlogitems()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
+      "id": "auth_auth",
+      "label": "Auth()",
+      "norm_label": "auth()",
+      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_auth_tsx",
+      "label": "Auth.tsx",
+      "norm_label": "auth.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 453,
+      "file_type": "code",
       "id": "index_login",
       "label": "Login()",
       "norm_label": "login()",
@@ -58225,7 +58465,7 @@
       "source_location": "L5"
     },
     {
-      "community": 450,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -58234,7 +58474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 454,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -58243,7 +58483,7 @@
       "source_location": "L49"
     },
     {
-      "community": 451,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -58252,7 +58492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 455,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -58261,7 +58501,7 @@
       "source_location": "L23"
     },
     {
-      "community": 452,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -58270,7 +58510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 456,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -58279,7 +58519,7 @@
       "source_location": "L50"
     },
     {
-      "community": 453,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -58288,7 +58528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 457,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -58297,7 +58537,7 @@
       "source_location": "L13"
     },
     {
-      "community": 454,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -58306,7 +58546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 458,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -58315,7 +58555,7 @@
       "source_location": "L11"
     },
     {
-      "community": 455,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -58324,7 +58564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -58333,67 +58573,13 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 459,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
       "norm_label": "pageheader()",
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
       "source_location": "L7"
-    },
-    {
-      "community": 457,
-      "file_type": "code",
-      "id": "expensecompletion_expensecompletion",
-      "label": "ExpenseCompletion()",
-      "norm_label": "expensecompletion()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L32"
-    },
-    {
-      "community": 457,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
-      "label": "ExpenseCompletion.tsx",
-      "norm_label": "expensecompletion.tsx",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "bestsellersdialog_handleaddbestseller",
-      "label": "handleAddBestSeller()",
-      "norm_label": "handleaddbestseller()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
-      "label": "BestSellersDialog.tsx",
-      "norm_label": "bestsellersdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "featuredsectiondialog_handleaddfeatureditem",
-      "label": "handleAddFeaturedItem()",
-      "norm_label": "handleaddfeatureditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
-      "label": "FeaturedSectionDialog.tsx",
-      "norm_label": "featuredsectiondialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
-      "source_location": "L1"
     },
     {
       "community": 46,
@@ -58488,6 +58674,60 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "expensecompletion_expensecompletion",
+      "label": "ExpenseCompletion()",
+      "norm_label": "expensecompletion()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
+      "source_location": "L32"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
+      "label": "ExpenseCompletion.tsx",
+      "norm_label": "expensecompletion.tsx",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "bestsellersdialog_handleaddbestseller",
+      "label": "handleAddBestSeller()",
+      "norm_label": "handleaddbestseller()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
+      "label": "BestSellersDialog.tsx",
+      "norm_label": "bestsellersdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
+      "id": "featuredsectiondialog_handleaddfeatureditem",
+      "label": "handleAddFeaturedItem()",
+      "norm_label": "handleaddfeatureditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
+      "label": "FeaturedSectionDialog.tsx",
+      "norm_label": "featuredsectiondialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 463,
+      "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
@@ -58495,7 +58735,7 @@
       "source_location": "L25"
     },
     {
-      "community": 460,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -58504,7 +58744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 464,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -58513,7 +58753,7 @@
       "source_location": "L83"
     },
     {
-      "community": 461,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -58522,7 +58762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -58531,7 +58771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 465,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -58540,7 +58780,7 @@
       "source_location": "L35"
     },
     {
-      "community": 463,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -58549,7 +58789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 466,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -58558,7 +58798,7 @@
       "source_location": "L28"
     },
     {
-      "community": 464,
+      "community": 467,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -58567,7 +58807,7 @@
       "source_location": "L11"
     },
     {
-      "community": 464,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -58576,7 +58816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 468,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -58585,7 +58825,7 @@
       "source_location": "L13"
     },
     {
-      "community": 465,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -58594,7 +58834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 469,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -58603,66 +58843,12 @@
       "source_location": "L41"
     },
     {
-      "community": 466,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
       "norm_label": "emailstatusview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 467,
-      "file_type": "code",
-      "id": "ordermetricspanel_handletimerangechange",
-      "label": "handleTimeRangeChange()",
-      "norm_label": "handletimerangechange()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 467,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
-      "label": "OrderMetricsPanel.tsx",
-      "norm_label": "ordermetricspanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "orderview_handlerefundorder",
-      "label": "handleRefundOrder()",
-      "norm_label": "handlerefundorder()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
-      "source_location": "L68"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
-      "label": "OrderView.tsx",
-      "norm_label": "orderview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "ordersview_gettimefilter",
-      "label": "getTimeFilter()",
-      "norm_label": "gettimefilter()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
-      "label": "OrdersView.tsx",
-      "norm_label": "ordersview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1"
     },
     {
@@ -58758,6 +58944,60 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "ordermetricspanel_handletimerangechange",
+      "label": "handleTimeRangeChange()",
+      "norm_label": "handletimerangechange()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
+      "label": "OrderMetricsPanel.tsx",
+      "norm_label": "ordermetricspanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "orderview_handlerefundorder",
+      "label": "handleRefundOrder()",
+      "norm_label": "handlerefundorder()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
+      "source_location": "L68"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
+      "label": "OrderView.tsx",
+      "norm_label": "orderview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
+      "id": "ordersview_gettimefilter",
+      "label": "getTimeFilter()",
+      "norm_label": "gettimefilter()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
+      "label": "OrdersView.tsx",
+      "norm_label": "ordersview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 473,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
       "norm_label": "refundsview.tsx",
@@ -58765,7 +59005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 473,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -58774,7 +59014,7 @@
       "source_location": "L79"
     },
     {
-      "community": 471,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -58783,7 +59023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 474,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -58792,7 +59032,7 @@
       "source_location": "L6"
     },
     {
-      "community": 472,
+      "community": 475,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -58801,7 +59041,7 @@
       "source_location": "L34"
     },
     {
-      "community": 472,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -58810,7 +59050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 476,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -58819,7 +59059,7 @@
       "source_location": "L89"
     },
     {
-      "community": 473,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -58828,7 +59068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 477,
       "file_type": "code",
       "id": "cashierview_cashierview",
       "label": "CashierView()",
@@ -58837,7 +59077,7 @@
       "source_location": "L8"
     },
     {
-      "community": 474,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -58846,7 +59086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 478,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -58855,7 +59095,7 @@
       "source_location": "L5"
     },
     {
-      "community": 475,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -58864,7 +59104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 479,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -58873,67 +59113,13 @@
       "source_location": "L7"
     },
     {
-      "community": 476,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
       "norm_label": "noresultsmessage.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 477,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
-      "label": "PinInput.tsx",
-      "norm_label": "pininput.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 477,
-      "file_type": "code",
-      "id": "pininput_pininput",
-      "label": "PinInput()",
-      "norm_label": "pininput()",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
-      "label": "PointOfSaleView.tsx",
-      "norm_label": "pointofsaleview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "pointofsaleview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
-      "label": "PrintInstructions.tsx",
-      "norm_label": "printinstructions.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "printinstructions_printinstructions",
-      "label": "PrintInstructions()",
-      "norm_label": "printinstructions()",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L3"
     },
     {
       "community": 48,
@@ -59028,6 +59214,60 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
+      "label": "PinInput.tsx",
+      "norm_label": "pininput.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "pininput_pininput",
+      "label": "PinInput()",
+      "norm_label": "pininput()",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
+      "label": "PointOfSaleView.tsx",
+      "norm_label": "pointofsaleview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "pointofsaleview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
+      "label": "PrintInstructions.tsx",
+      "norm_label": "printinstructions.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
+      "id": "printinstructions_printinstructions",
+      "label": "PrintInstructions()",
+      "norm_label": "printinstructions()",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 483,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
       "norm_label": "productcard.tsx",
@@ -59035,7 +59275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 483,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -59044,7 +59284,7 @@
       "source_location": "L14"
     },
     {
-      "community": 481,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -59053,7 +59293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 484,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -59062,7 +59302,7 @@
       "source_location": "L86"
     },
     {
-      "community": 482,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -59071,7 +59311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 485,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -59080,7 +59320,7 @@
       "source_location": "L15"
     },
     {
-      "community": 483,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -59089,7 +59329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 486,
       "file_type": "code",
       "id": "totalsdisplay_totalsdisplay",
       "label": "TotalsDisplay()",
@@ -59098,7 +59338,7 @@
       "source_location": "L14"
     },
     {
-      "community": 484,
+      "community": 487,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -59107,7 +59347,7 @@
       "source_location": "L18"
     },
     {
-      "community": 484,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -59116,7 +59356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -59125,7 +59365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 488,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -59134,7 +59374,7 @@
       "source_location": "L8"
     },
     {
-      "community": 486,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -59143,67 +59383,13 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 489,
       "file_type": "code",
       "id": "registerdrawergate_registerdrawergate",
       "label": "RegisterDrawerGate()",
       "norm_label": "registerdrawergate()",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx",
       "source_location": "L8"
-    },
-    {
-      "community": 487,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
-      "label": "RegisterSessionPanel.tsx",
-      "norm_label": "registersessionpanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 487,
-      "file_type": "code",
-      "id": "registersessionpanel_registersessionpanel",
-      "label": "RegisterSessionPanel()",
-      "norm_label": "registersessionpanel()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
-      "label": "transactionColumns.test.tsx",
-      "norm_label": "transactioncolumns.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "transactioncolumns_test_rendertransactioncell",
-      "label": "renderTransactionCell()",
-      "norm_label": "rendertransactioncell()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
-      "label": "transactionColumns.tsx",
-      "norm_label": "transactioncolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "transactioncolumns_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L27"
     },
     {
       "community": 49,
@@ -59289,6 +59475,60 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
+      "label": "RegisterSessionPanel.tsx",
+      "norm_label": "registersessionpanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "registersessionpanel_registersessionpanel",
+      "label": "RegisterSessionPanel()",
+      "norm_label": "registersessionpanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
+      "label": "transactionColumns.test.tsx",
+      "norm_label": "transactioncolumns.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "transactioncolumns_test_rendertransactioncell",
+      "label": "renderTransactionCell()",
+      "norm_label": "rendertransactioncell()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
+      "label": "transactionColumns.tsx",
+      "norm_label": "transactioncolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
+      "id": "transactioncolumns_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 493,
+      "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
       "norm_label": "barcodeview()",
@@ -59296,7 +59536,7 @@
       "source_location": "L14"
     },
     {
-      "community": 490,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -59305,7 +59545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 494,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -59314,7 +59554,7 @@
       "source_location": "L6"
     },
     {
-      "community": 491,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -59323,7 +59563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 495,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -59332,7 +59572,7 @@
       "source_location": "L38"
     },
     {
-      "community": 492,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -59341,7 +59581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -59350,7 +59590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 496,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -59359,7 +59599,7 @@
       "source_location": "L10"
     },
     {
-      "community": 494,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -59368,7 +59608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 497,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -59377,7 +59617,7 @@
       "source_location": "L6"
     },
     {
-      "community": 495,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -59386,7 +59626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 498,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -59395,7 +59635,7 @@
       "source_location": "L5"
     },
     {
-      "community": 496,
+      "community": 499,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -59404,67 +59644,13 @@
       "source_location": "L17"
     },
     {
-      "community": 496,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
       "norm_label": "add-product-command.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 497,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 497,
-      "file_type": "code",
-      "id": "products_products",
-      "label": "Products()",
-      "norm_label": "products()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
-      "label": "PromoCodeForm.tsx",
-      "norm_label": "promocodeform.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "promocodeform_togglediscounttype",
-      "label": "toggleDiscountType()",
-      "norm_label": "togglediscounttype()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
-      "source_location": "L84"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
-      "label": "PromoCodeHeader.tsx",
-      "norm_label": "promocodeheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "promocodeheader_handledeletepromocode",
-      "label": "handleDeletePromoCode()",
-      "norm_label": "handledeletepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L22"
     },
     {
       "community": 5,
@@ -59802,6 +59988,60 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "products_products",
+      "label": "Products()",
+      "norm_label": "products()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
+      "label": "PromoCodeForm.tsx",
+      "norm_label": "promocodeform.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "promocodeform_togglediscounttype",
+      "label": "toggleDiscountType()",
+      "norm_label": "togglediscounttype()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
+      "source_location": "L84"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
+      "label": "PromoCodeHeader.tsx",
+      "norm_label": "promocodeheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
+      "id": "promocodeheader_handledeletepromocode",
+      "label": "handleDeletePromoCode()",
+      "norm_label": "handledeletepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 503,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
       "norm_label": "promocodesview.tsx",
@@ -59809,7 +60049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 503,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -59818,7 +60058,7 @@
       "source_location": "L9"
     },
     {
-      "community": 501,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -59827,7 +60067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 504,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -59836,7 +60076,7 @@
       "source_location": "L23"
     },
     {
-      "community": 502,
+      "community": 505,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -59845,7 +60085,7 @@
       "source_location": "L5"
     },
     {
-      "community": 502,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -59854,7 +60094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -59863,7 +60103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 506,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -59872,7 +60112,7 @@
       "source_location": "L4"
     },
     {
-      "community": 504,
+      "community": 507,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -59881,7 +60121,7 @@
       "source_location": "L13"
     },
     {
-      "community": 504,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -59890,7 +60130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -59899,7 +60139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 508,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -59908,7 +60148,7 @@
       "source_location": "L29"
     },
     {
-      "community": 506,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -59917,67 +60157,13 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 509,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
       "norm_label": "reviewactions()",
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L20"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
-      "label": "ServiceCasesView.tsx",
-      "norm_label": "servicecasesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "servicecasesview_handlecreatecase",
-      "label": "handleCreateCase()",
-      "norm_label": "handlecreatecase()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L171"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
-      "label": "ServiceIntakeForm.tsx",
-      "norm_label": "serviceintakeform.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "serviceintakeform_serviceintakeform",
-      "label": "ServiceIntakeForm()",
-      "norm_label": "serviceintakeform()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "empty_state_onclick",
-      "label": "onClick()",
-      "norm_label": "onclick()",
-      "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
-      "label": "empty-state.tsx",
-      "norm_label": "empty-state.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
-      "source_location": "L1"
     },
     {
       "community": 51,
@@ -60063,6 +60249,114 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
+      "label": "ServiceCasesView.test.tsx",
+      "norm_label": "servicecasesview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "servicecasesview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
+      "label": "ServiceCasesView.tsx",
+      "norm_label": "servicecasesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "servicecasesview_handlecreatecase",
+      "label": "handleCreateCase()",
+      "norm_label": "handlecreatecase()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L178"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
+      "label": "ServiceCatalogView.test.tsx",
+      "norm_label": "servicecatalogview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
+      "id": "servicecatalogview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 513,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
+      "label": "ServiceIntakeForm.tsx",
+      "norm_label": "serviceintakeform.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 513,
+      "file_type": "code",
+      "id": "serviceintakeform_serviceintakeform",
+      "label": "ServiceIntakeForm()",
+      "norm_label": "serviceintakeform()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 514,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
+      "label": "ServiceIntakeView.test.tsx",
+      "norm_label": "serviceintakeview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 514,
+      "file_type": "code",
+      "id": "serviceintakeview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 515,
+      "file_type": "code",
+      "id": "empty_state_onclick",
+      "label": "onClick()",
+      "norm_label": "onclick()",
+      "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 515,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
+      "label": "empty-state.tsx",
+      "norm_label": "empty-state.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 516,
+      "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
       "norm_label": "nopermission()",
@@ -60070,7 +60364,7 @@
       "source_location": "L3"
     },
     {
-      "community": 510,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -60079,7 +60373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 517,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -60088,7 +60382,7 @@
       "source_location": "L4"
     },
     {
-      "community": 511,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -60097,7 +60391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 518,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -60106,7 +60400,7 @@
       "source_location": "L4"
     },
     {
-      "community": 512,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -60115,7 +60409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
@@ -60124,121 +60418,13 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 519,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
       "norm_label": "protectedadminsigninview()",
       "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 514,
-      "file_type": "code",
-      "id": "contactview_contactview",
-      "label": "ContactView()",
-      "norm_label": "contactview()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 514,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
-      "label": "ContactView.tsx",
-      "norm_label": "contactview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 515,
-      "file_type": "code",
-      "id": "header_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 515,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
-      "label": "Header.tsx",
-      "norm_label": "header.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 516,
-      "file_type": "code",
-      "id": "maintenanceview_maintenanceview",
-      "label": "MaintenanceView()",
-      "norm_label": "maintenanceview()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 516,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
-      "label": "MaintenanceView.tsx",
-      "norm_label": "maintenanceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
-      "label": "TaxView.tsx",
-      "norm_label": "taxview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "taxview_handleupdatetaxsettings",
-      "label": "handleUpdateTaxSettings()",
-      "norm_label": "handleupdatetaxsettings()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
-      "label": "useStoreConfigUpdate.ts",
-      "norm_label": "usestoreconfigupdate.ts",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "usestoreconfigupdate_usestoreconfigupdate",
-      "label": "useStoreConfigUpdate()",
-      "norm_label": "usestoreconfigupdate()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_switcher_tsx",
-      "label": "store-switcher.tsx",
-      "norm_label": "store-switcher.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "store_switcher_onstoreselect",
-      "label": "onStoreSelect()",
-      "norm_label": "onstoreselect()",
-      "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
-      "source_location": "L63"
     },
     {
       "community": 52,
@@ -60324,6 +60510,114 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "contactview_contactview",
+      "label": "ContactView()",
+      "norm_label": "contactview()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
+      "label": "ContactView.tsx",
+      "norm_label": "contactview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "header_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
+      "label": "Header.tsx",
+      "norm_label": "header.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
+      "id": "maintenanceview_maintenanceview",
+      "label": "MaintenanceView()",
+      "norm_label": "maintenanceview()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
+      "label": "MaintenanceView.tsx",
+      "norm_label": "maintenanceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 523,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
+      "label": "TaxView.tsx",
+      "norm_label": "taxview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 523,
+      "file_type": "code",
+      "id": "taxview_handleupdatetaxsettings",
+      "label": "handleUpdateTaxSettings()",
+      "norm_label": "handleupdatetaxsettings()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 524,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
+      "label": "useStoreConfigUpdate.ts",
+      "norm_label": "usestoreconfigupdate.ts",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 524,
+      "file_type": "code",
+      "id": "usestoreconfigupdate_usestoreconfigupdate",
+      "label": "useStoreConfigUpdate()",
+      "norm_label": "usestoreconfigupdate()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 525,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_switcher_tsx",
+      "label": "store-switcher.tsx",
+      "norm_label": "store-switcher.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 525,
+      "file_type": "code",
+      "id": "store_switcher_onstoreselect",
+      "label": "onStoreSelect()",
+      "norm_label": "onstoreselect()",
+      "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 526,
+      "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
       "norm_label": "calendar()",
@@ -60331,7 +60625,7 @@
       "source_location": "L7"
     },
     {
-      "community": 520,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -60340,7 +60634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 527,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -60349,7 +60643,7 @@
       "source_location": "L25"
     },
     {
-      "community": 521,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -60358,7 +60652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 528,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -60367,7 +60661,7 @@
       "source_location": "L15"
     },
     {
-      "community": 522,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -60376,7 +60670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 529,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -60385,121 +60679,13 @@
       "source_location": "L21"
     },
     {
-      "community": 523,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
       "norm_label": "copy-wrapper.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 524,
-      "file_type": "code",
-      "id": "date_time_picker_datetimepicker",
-      "label": "DateTimePicker()",
-      "norm_label": "datetimepicker()",
-      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 524,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
-      "label": "date-time-picker.tsx",
-      "norm_label": "date-time-picker.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 525,
-      "file_type": "code",
-      "id": "label_label",
-      "label": "Label()",
-      "norm_label": "label()",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 525,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 526,
-      "file_type": "code",
-      "id": "custom_modal_custommodal",
-      "label": "CustomModal()",
-      "norm_label": "custommodal()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 526,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
-      "label": "custom-modal.tsx",
-      "norm_label": "custom-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 527,
-      "file_type": "code",
-      "id": "organization_modal_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 527,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
-      "label": "organization-modal.tsx",
-      "norm_label": "organization-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
-      "label": "store-modal.tsx",
-      "norm_label": "store-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "store_modal_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
-      "label": "welcome-back-modal-example.tsx",
-      "norm_label": "welcome-back-modal-example.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "welcome_back_modal_example_welcomebackmodalexample",
-      "label": "WelcomeBackModalExample()",
-      "norm_label": "welcomebackmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
-      "source_location": "L5"
     },
     {
       "community": 53,
@@ -60585,6 +60771,96 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "label_label",
+      "label": "Label()",
+      "norm_label": "label()",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "custom_modal_custommodal",
+      "label": "CustomModal()",
+      "norm_label": "custommodal()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
+      "label": "custom-modal.tsx",
+      "norm_label": "custom-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
+      "id": "organization_modal_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
+      "label": "organization-modal.tsx",
+      "norm_label": "organization-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 533,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
+      "label": "store-modal.tsx",
+      "norm_label": "store-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 533,
+      "file_type": "code",
+      "id": "store_modal_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 534,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
+      "label": "welcome-back-modal-example.tsx",
+      "norm_label": "welcome-back-modal-example.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 534,
+      "file_type": "code",
+      "id": "welcome_back_modal_example_welcomebackmodalexample",
+      "label": "WelcomeBackModalExample()",
+      "norm_label": "welcomebackmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 535,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
       "norm_label": "welcome-back-modal.tsx",
@@ -60592,7 +60868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 535,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -60601,7 +60877,7 @@
       "source_location": "L12"
     },
     {
-      "community": 531,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -60610,7 +60886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 536,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -60619,7 +60895,7 @@
       "source_location": "L15"
     },
     {
-      "community": 532,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -60628,7 +60904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 537,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -60637,7 +60913,7 @@
       "source_location": "L3"
     },
     {
-      "community": 533,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -60646,7 +60922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 538,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -60655,7 +60931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 539,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -60664,103 +60940,13 @@
       "source_location": "L5"
     },
     {
-      "community": 534,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
       "norm_label": "bagitems.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 535,
-      "file_type": "code",
-      "id": "bagitemsview_bagitemsview",
-      "label": "BagItemsView()",
-      "norm_label": "bagitemsview()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 535,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
-      "label": "BagItemsView.tsx",
-      "norm_label": "bagitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 536,
-      "file_type": "code",
-      "id": "bags_bags",
-      "label": "Bags()",
-      "norm_label": "bags()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 536,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
-      "label": "Bags.tsx",
-      "norm_label": "bags.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_string",
-      "label": "String()",
-      "norm_label": "string()",
-      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
-      "label": "CustomerBehaviorTimeline.tsx",
-      "norm_label": "customerbehaviortimeline.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
-      "label": "UserAnalyticsName.tsx",
-      "norm_label": "useranalyticsname.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "useranalyticsname_useranalyticsname",
-      "label": "UserAnalyticsName()",
-      "norm_label": "useranalyticsname()",
-      "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userbag_tsx",
-      "label": "UserBag.tsx",
-      "norm_label": "userbag.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "userbag_userbag",
-      "label": "UserBag()",
-      "norm_label": "userbag()",
-      "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
-      "source_location": "L7"
     },
     {
       "community": 54,
@@ -60846,6 +61032,96 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "bagitemsview_bagitemsview",
+      "label": "BagItemsView()",
+      "norm_label": "bagitemsview()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
+      "label": "BagItemsView.tsx",
+      "norm_label": "bagitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "bags_bags",
+      "label": "Bags()",
+      "norm_label": "bags()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
+      "label": "Bags.tsx",
+      "norm_label": "bags.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_string",
+      "label": "String()",
+      "norm_label": "string()",
+      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
+      "label": "CustomerBehaviorTimeline.tsx",
+      "norm_label": "customerbehaviortimeline.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 543,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
+      "label": "UserAnalyticsName.tsx",
+      "norm_label": "useranalyticsname.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 543,
+      "file_type": "code",
+      "id": "useranalyticsname_useranalyticsname",
+      "label": "UserAnalyticsName()",
+      "norm_label": "useranalyticsname()",
+      "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 544,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userbag_tsx",
+      "label": "UserBag.tsx",
+      "norm_label": "userbag.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 544,
+      "file_type": "code",
+      "id": "userbag_userbag",
+      "label": "UserBag()",
+      "norm_label": "userbag()",
+      "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 545,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
       "norm_label": "useronlineorders.tsx",
@@ -60853,7 +61129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 545,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -60862,7 +61138,7 @@
       "source_location": "L11"
     },
     {
-      "community": 541,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -60871,7 +61147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 546,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -60880,7 +61156,7 @@
       "source_location": "L7"
     },
     {
-      "community": 542,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -60889,7 +61165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 547,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -60898,7 +61174,7 @@
       "source_location": "L45"
     },
     {
-      "community": 543,
+      "community": 548,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -60907,7 +61183,7 @@
       "source_location": "L13"
     },
     {
-      "community": 543,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -60916,7 +61192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -60925,103 +61201,13 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 549,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
       "norm_label": "useimageupload()",
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
       "source_location": "L7"
-    },
-    {
-      "community": 545,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
-      "label": "use-mobile.tsx",
-      "norm_label": "use-mobile.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 545,
-      "file_type": "code",
-      "id": "use_mobile_useismobile",
-      "label": "useIsMobile()",
-      "norm_label": "useismobile()",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 546,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
-      "label": "use-navigate-back.ts",
-      "norm_label": "use-navigate-back.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 546,
-      "file_type": "code",
-      "id": "use_navigate_back_usenavigateback",
-      "label": "useNavigateBack()",
-      "norm_label": "usenavigateback()",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 547,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
-      "label": "use-navigation-keyboard-shortcuts.ts",
-      "norm_label": "use-navigation-keyboard-shortcuts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 547,
-      "file_type": "code",
-      "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
-      "label": "useNavigationKeyboardShortcuts()",
-      "norm_label": "usenavigationkeyboardshortcuts()",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
-      "label": "use-pagination-persistence.ts",
-      "norm_label": "use-pagination-persistence.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "use_pagination_persistence_usepaginationpersistence",
-      "label": "usePaginationPersistence()",
-      "norm_label": "usepaginationpersistence()",
-      "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
-      "label": "use-table-keyboard-pagination.ts",
-      "norm_label": "use-table-keyboard-pagination.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
-      "label": "useTableKeyboardPagination()",
-      "norm_label": "usetablekeyboardpagination()",
-      "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
-      "source_location": "L6"
     },
     {
       "community": 55,
@@ -61107,6 +61293,96 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
+      "label": "use-mobile.tsx",
+      "norm_label": "use-mobile.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "use_mobile_useismobile",
+      "label": "useIsMobile()",
+      "norm_label": "useismobile()",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
+      "label": "use-navigate-back.ts",
+      "norm_label": "use-navigate-back.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "use_navigate_back_usenavigateback",
+      "label": "useNavigateBack()",
+      "norm_label": "usenavigateback()",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
+      "label": "use-navigation-keyboard-shortcuts.ts",
+      "norm_label": "use-navigation-keyboard-shortcuts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
+      "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
+      "label": "useNavigationKeyboardShortcuts()",
+      "norm_label": "usenavigationkeyboardshortcuts()",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 553,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
+      "label": "use-pagination-persistence.ts",
+      "norm_label": "use-pagination-persistence.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 553,
+      "file_type": "code",
+      "id": "use_pagination_persistence_usepaginationpersistence",
+      "label": "usePaginationPersistence()",
+      "norm_label": "usepaginationpersistence()",
+      "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 554,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
+      "label": "use-table-keyboard-pagination.ts",
+      "norm_label": "use-table-keyboard-pagination.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 554,
+      "file_type": "code",
+      "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
+      "label": "useTableKeyboardPagination()",
+      "norm_label": "usetablekeyboardpagination()",
+      "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 555,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
       "norm_label": "usebulkoperations.test.ts",
@@ -61114,7 +61390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 555,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -61123,7 +61399,7 @@
       "source_location": "L168"
     },
     {
-      "community": 551,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -61132,7 +61408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 556,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
@@ -61141,7 +61417,7 @@
       "source_location": "L5"
     },
     {
-      "community": 552,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -61150,7 +61426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 557,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -61159,7 +61435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -61168,7 +61444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 558,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -61177,7 +61453,7 @@
       "source_location": "L6"
     },
     {
-      "community": 554,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -61186,103 +61462,13 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 559,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
       "norm_label": "usedebounce()",
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 555,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
-      "label": "useExpenseOperations.ts",
-      "norm_label": "useexpenseoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 555,
-      "file_type": "code",
-      "id": "useexpenseoperations_useexpenseoperations",
-      "label": "useExpenseOperations()",
-      "norm_label": "useexpenseoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 556,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
-      "label": "useGetActiveProduct.ts",
-      "norm_label": "usegetactiveproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 556,
-      "file_type": "code",
-      "id": "usegetactiveproduct_usegetactiveproduct",
-      "label": "useGetActiveProduct()",
-      "norm_label": "usegetactiveproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 557,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
-      "label": "useGetAuthedUser.ts",
-      "norm_label": "usegetautheduser.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 557,
-      "file_type": "code",
-      "id": "usegetautheduser_usegetautheduser",
-      "label": "useGetAuthedUser()",
-      "norm_label": "usegetautheduser()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
-      "label": "useGetCategories.ts",
-      "norm_label": "usegetcategories.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "usegetcategories_usegetcategories",
-      "label": "useGetCategories()",
-      "norm_label": "usegetcategories()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
-      "label": "useGetComplimentaryProducts.ts",
-      "norm_label": "usegetcomplimentaryproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
-      "label": "useGetComplimentaryProducts()",
-      "norm_label": "usegetcomplimentaryproducts()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
-      "source_location": "L5"
     },
     {
       "community": 56,
@@ -61300,7 +61486,7 @@
       "label": "handleChange()",
       "norm_label": "handlechange()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L142"
+      "source_location": "L149"
     },
     {
       "community": 56,
@@ -61309,7 +61495,7 @@
       "label": "handleEdit()",
       "norm_label": "handleedit()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L152"
+      "source_location": "L159"
     },
     {
       "community": 56,
@@ -61318,7 +61504,7 @@
       "label": "handleReset()",
       "norm_label": "handlereset()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L158"
+      "source_location": "L165"
     },
     {
       "community": 56,
@@ -61327,7 +61513,7 @@
       "label": "handleSubmit()",
       "norm_label": "handlesubmit()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L164"
+      "source_location": "L171"
     },
     {
       "community": 56,
@@ -61336,7 +61522,7 @@
       "label": "itemToFormState()",
       "norm_label": "itemtoformstate()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L75"
+      "source_location": "L82"
     },
     {
       "community": 56,
@@ -61345,7 +61531,7 @@
       "label": "parseServiceCatalogForm()",
       "norm_label": "parseservicecatalogform()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L89"
+      "source_location": "L96"
     },
     {
       "community": 56,
@@ -61354,7 +61540,7 @@
       "label": "validateServiceCatalogForm()",
       "norm_label": "validateservicecatalogform()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L60"
+      "source_location": "L67"
     },
     {
       "community": 56,
@@ -61363,10 +61549,100 @@
       "label": "withSaveState()",
       "norm_label": "withsavestate()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L443"
+      "source_location": "L461"
     },
     {
       "community": 560,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
+      "label": "useExpenseOperations.ts",
+      "norm_label": "useexpenseoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "useexpenseoperations_useexpenseoperations",
+      "label": "useExpenseOperations()",
+      "norm_label": "useexpenseoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
+      "label": "useGetActiveProduct.ts",
+      "norm_label": "usegetactiveproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "usegetactiveproduct_usegetactiveproduct",
+      "label": "useGetActiveProduct()",
+      "norm_label": "usegetactiveproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
+      "label": "useGetAuthedUser.ts",
+      "norm_label": "usegetautheduser.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
+      "id": "usegetautheduser_usegetautheduser",
+      "label": "useGetAuthedUser()",
+      "norm_label": "usegetautheduser()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 563,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
+      "label": "useGetCategories.ts",
+      "norm_label": "usegetcategories.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 563,
+      "file_type": "code",
+      "id": "usegetcategories_usegetcategories",
+      "label": "useGetCategories()",
+      "norm_label": "usegetcategories()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 564,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
+      "label": "useGetComplimentaryProducts.ts",
+      "norm_label": "usegetcomplimentaryproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 564,
+      "file_type": "code",
+      "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
+      "label": "useGetComplimentaryProducts()",
+      "norm_label": "usegetcomplimentaryproducts()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -61375,7 +61651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 560,
+      "community": 565,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -61384,7 +61660,7 @@
       "source_location": "L4"
     },
     {
-      "community": 561,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -61393,7 +61669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 566,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -61402,7 +61678,7 @@
       "source_location": "L5"
     },
     {
-      "community": 562,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -61411,7 +61687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 567,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -61420,7 +61696,7 @@
       "source_location": "L5"
     },
     {
-      "community": 563,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -61429,7 +61705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 568,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -61438,7 +61714,7 @@
       "source_location": "L8"
     },
     {
-      "community": 564,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -61447,103 +61723,13 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 569,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
       "norm_label": "usepermissions()",
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L13"
-    },
-    {
-      "community": 565,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useprint_ts",
-      "label": "usePrint.ts",
-      "norm_label": "useprint.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 565,
-      "file_type": "code",
-      "id": "useprint_useprint",
-      "label": "usePrint()",
-      "norm_label": "useprint()",
-      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 566,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
-      "label": "useProductSearchResults.ts",
-      "norm_label": "useproductsearchresults.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 566,
-      "file_type": "code",
-      "id": "useproductsearchresults_useproductsearchresults",
-      "label": "useProductSearchResults()",
-      "norm_label": "useproductsearchresults()",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
-      "label": "useProductWithNoImagesNotification.tsx",
-      "norm_label": "useproductwithnoimagesnotification.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 567,
-      "file_type": "code",
-      "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
-      "label": "useProductWithNoImagesNotification()",
-      "norm_label": "useproductwithnoimagesnotification()",
-      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
-      "label": "useProtectedAdminPageState.ts",
-      "norm_label": "useprotectedadminpagestate.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "useprotectedadminpagestate_useprotectedadminpagestate",
-      "label": "useProtectedAdminPageState()",
-      "norm_label": "useprotectedadminpagestate()",
-      "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
-      "label": "useSessionManagementExpense.ts",
-      "norm_label": "usesessionmanagementexpense.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "usesessionmanagementexpense_usesessionmanagementexpense",
-      "label": "useSessionManagementExpense()",
-      "norm_label": "usesessionmanagementexpense()",
-      "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
-      "source_location": "L17"
     },
     {
       "community": 57,
@@ -61629,6 +61815,96 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useprint_ts",
+      "label": "usePrint.ts",
+      "norm_label": "useprint.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "useprint_useprint",
+      "label": "usePrint()",
+      "norm_label": "useprint()",
+      "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
+      "label": "useProductSearchResults.ts",
+      "norm_label": "useproductsearchresults.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "useproductsearchresults_useproductsearchresults",
+      "label": "useProductSearchResults()",
+      "norm_label": "useproductsearchresults()",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
+      "label": "useProductWithNoImagesNotification.tsx",
+      "norm_label": "useproductwithnoimagesnotification.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
+      "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
+      "label": "useProductWithNoImagesNotification()",
+      "norm_label": "useproductwithnoimagesnotification()",
+      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 573,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
+      "label": "useProtectedAdminPageState.ts",
+      "norm_label": "useprotectedadminpagestate.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 573,
+      "file_type": "code",
+      "id": "useprotectedadminpagestate_useprotectedadminpagestate",
+      "label": "useProtectedAdminPageState()",
+      "norm_label": "useprotectedadminpagestate()",
+      "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 574,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
+      "label": "useSessionManagementExpense.ts",
+      "norm_label": "usesessionmanagementexpense.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 574,
+      "file_type": "code",
+      "id": "usesessionmanagementexpense_usesessionmanagementexpense",
+      "label": "useSessionManagementExpense()",
+      "norm_label": "usesessionmanagementexpense()",
+      "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 575,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
       "norm_label": "useskusreservedincheckout.ts",
@@ -61636,7 +61912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 575,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -61645,7 +61921,7 @@
       "source_location": "L12"
     },
     {
-      "community": 571,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -61654,7 +61930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 576,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -61663,7 +61939,7 @@
       "source_location": "L12"
     },
     {
-      "community": 572,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -61672,7 +61948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 577,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -61681,7 +61957,7 @@
       "source_location": "L5"
     },
     {
-      "community": 573,
+      "community": 578,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -61690,7 +61966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -61699,7 +61975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 579,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -61708,102 +61984,12 @@
       "source_location": "L5"
     },
     {
-      "community": 574,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
       "norm_label": "additem.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/addItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 575,
-      "file_type": "code",
-      "id": "bootstrapregister_bootstrapregister",
-      "label": "bootstrapRegister()",
-      "norm_label": "bootstrapregister()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 575,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
-      "label": "bootstrapRegister.ts",
-      "norm_label": "bootstrapregister.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 576,
-      "file_type": "code",
-      "id": "holdsession_holdsession",
-      "label": "holdSession()",
-      "norm_label": "holdsession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 576,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
-      "label": "holdSession.ts",
-      "norm_label": "holdsession.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 577,
-      "file_type": "code",
-      "id": "opendrawer_opendrawer",
-      "label": "openDrawer()",
-      "norm_label": "opendrawer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/openDrawer.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 577,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
-      "label": "openDrawer.ts",
-      "norm_label": "opendrawer.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/openDrawer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
-      "label": "startSession.ts",
-      "norm_label": "startsession.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "startsession_startsession",
-      "label": "startSession()",
-      "norm_label": "startsession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "calculations_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
-      "label": "calculations.ts",
-      "norm_label": "calculations.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L1"
     },
     {
@@ -61890,6 +62076,96 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "bootstrapregister_bootstrapregister",
+      "label": "bootstrapRegister()",
+      "norm_label": "bootstrapregister()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
+      "label": "bootstrapRegister.ts",
+      "norm_label": "bootstrapregister.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/bootstrapRegister.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "holdsession_holdsession",
+      "label": "holdSession()",
+      "norm_label": "holdsession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
+      "label": "holdSession.ts",
+      "norm_label": "holdsession.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "opendrawer_opendrawer",
+      "label": "openDrawer()",
+      "norm_label": "opendrawer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/openDrawer.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
+      "label": "openDrawer.ts",
+      "norm_label": "opendrawer.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/openDrawer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 583,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
+      "label": "startSession.ts",
+      "norm_label": "startsession.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 583,
+      "file_type": "code",
+      "id": "startsession_startsession",
+      "label": "startSession()",
+      "norm_label": "startsession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 584,
+      "file_type": "code",
+      "id": "calculations_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 584,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
+      "label": "calculations.ts",
+      "norm_label": "calculations.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 585,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
       "norm_label": "pinhash.ts",
@@ -61897,7 +62173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 585,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -61906,7 +62182,7 @@
       "source_location": "L12"
     },
     {
-      "community": 581,
+      "community": 586,
       "file_type": "code",
       "id": "closeouts_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -61915,7 +62191,7 @@
       "source_location": "L10"
     },
     {
-      "community": 581,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_closeouts_index_tsx",
       "label": "closeouts.index.tsx",
@@ -61924,7 +62200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 587,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -61933,7 +62209,7 @@
       "source_location": "L6"
     },
     {
-      "community": 582,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
@@ -61942,7 +62218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
@@ -61951,7 +62227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 588,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -61960,7 +62236,7 @@
       "source_location": "L6"
     },
     {
-      "community": 584,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
@@ -61969,103 +62245,13 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 589,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
       "norm_label": "hasorgnotfoundpayload()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers.index.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 585,
-      "file_type": "code",
-      "id": "index_storerootredirect",
-      "label": "StoreRootRedirect()",
-      "norm_label": "storerootredirect()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 585,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 586,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
-      "label": "published.index.tsx",
-      "norm_label": "published.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 586,
-      "file_type": "code",
-      "id": "published_index_routecomponent",
-      "label": "RouteComponent()",
-      "norm_label": "routecomponent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "index_index",
-      "label": "Index()",
-      "norm_label": "index()",
-      "source_file": "packages/athena-webapp/src/routes/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "layout_index_athenaloginreadyview",
-      "label": "AthenaLoginReadyView()",
-      "norm_label": "athenaloginreadyview()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
-      "label": "_layout.index.tsx",
-      "norm_label": "_layout.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "organizationssettingsaccordion_organizationsettingsaccordion",
-      "label": "OrganizationSettingsAccordion()",
-      "norm_label": "organizationsettingsaccordion()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
-      "label": "OrganizationsSettingsAccordion.tsx",
-      "norm_label": "organizationssettingsaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
-      "source_location": "L1"
     },
     {
       "community": 59,
@@ -62142,6 +62328,96 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "index_storerootredirect",
+      "label": "StoreRootRedirect()",
+      "norm_label": "storerootredirect()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
+      "label": "published.index.tsx",
+      "norm_label": "published.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "published_index_routecomponent",
+      "label": "RouteComponent()",
+      "norm_label": "routecomponent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
+      "id": "index_index",
+      "label": "Index()",
+      "norm_label": "index()",
+      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 593,
+      "file_type": "code",
+      "id": "layout_index_athenaloginreadyview",
+      "label": "AthenaLoginReadyView()",
+      "norm_label": "athenaloginreadyview()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 593,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
+      "label": "_layout.index.tsx",
+      "norm_label": "_layout.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 594,
+      "file_type": "code",
+      "id": "organizationssettingsaccordion_organizationsettingsaccordion",
+      "label": "OrganizationSettingsAccordion()",
+      "norm_label": "organizationsettingsaccordion()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 594,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
+      "label": "OrganizationsSettingsAccordion.tsx",
+      "norm_label": "organizationssettingsaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 595,
+      "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
       "norm_label": "patternsoverview()",
@@ -62149,7 +62425,7 @@
       "source_location": "L5"
     },
     {
-      "community": 590,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -62158,7 +62434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 596,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -62167,7 +62443,7 @@
       "source_location": "L17"
     },
     {
-      "community": 591,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -62176,7 +62452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 597,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -62185,7 +62461,7 @@
       "source_location": "L15"
     },
     {
-      "community": 592,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -62194,7 +62470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 598,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -62203,7 +62479,7 @@
       "source_location": "L12"
     },
     {
-      "community": 593,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -62212,7 +62488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 599,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -62221,103 +62497,13 @@
       "source_location": "L5"
     },
     {
-      "community": 594,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
       "norm_label": "overview.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 595,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
-      "label": "Popover.stories.tsx",
-      "norm_label": "popover.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 595,
-      "file_type": "code",
-      "id": "popover_stories_popovershowcase",
-      "label": "PopoverShowcase()",
-      "norm_label": "popovershowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 596,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
-      "label": "Sheet.stories.tsx",
-      "norm_label": "sheet.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 596,
-      "file_type": "code",
-      "id": "sheet_stories_sheetshowcase",
-      "label": "SheetShowcase()",
-      "norm_label": "sheetshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 597,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
-      "label": "Tooltip.stories.tsx",
-      "norm_label": "tooltip.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 597,
-      "file_type": "code",
-      "id": "tooltip_stories_tooltipshowcase",
-      "label": "TooltipShowcase()",
-      "norm_label": "tooltipshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "overview_stories_templatesoverview",
-      "label": "TemplatesOverview()",
-      "norm_label": "templatesoverview()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
-      "label": "storybook-theme-decorator.tsx",
-      "norm_label": "storybook-theme-decorator.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "storybook_theme_decorator_withathenatheme",
-      "label": "withAthenaTheme()",
-      "norm_label": "withathenatheme()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
-      "source_location": "L17"
     },
     {
       "community": 6,
@@ -62628,6 +62814,96 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
+      "label": "Popover.stories.tsx",
+      "norm_label": "popover.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "popover_stories_popovershowcase",
+      "label": "PopoverShowcase()",
+      "norm_label": "popovershowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
+      "label": "Sheet.stories.tsx",
+      "norm_label": "sheet.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "sheet_stories_sheetshowcase",
+      "label": "SheetShowcase()",
+      "norm_label": "sheetshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Sheet.stories.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
+      "label": "Tooltip.stories.tsx",
+      "norm_label": "tooltip.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "tooltip_stories_tooltipshowcase",
+      "label": "TooltipShowcase()",
+      "norm_label": "tooltipshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Tooltip.stories.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 603,
+      "file_type": "code",
+      "id": "overview_stories_templatesoverview",
+      "label": "TemplatesOverview()",
+      "norm_label": "templatesoverview()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 603,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 604,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
+      "label": "storybook-theme-decorator.tsx",
+      "norm_label": "storybook-theme-decorator.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 604,
+      "file_type": "code",
+      "id": "storybook_theme_decorator_withathenatheme",
+      "label": "withAthenaTheme()",
+      "norm_label": "withathenatheme()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 605,
+      "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
       "norm_label": "formatnumber()",
@@ -62635,7 +62911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -62644,7 +62920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 606,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -62653,7 +62929,7 @@
       "source_location": "L4"
     },
     {
-      "community": 601,
+      "community": 606,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -62662,7 +62938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 607,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -62671,7 +62947,7 @@
       "source_location": "L27"
     },
     {
-      "community": 602,
+      "community": 607,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -62680,7 +62956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 608,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -62689,7 +62965,7 @@
       "source_location": "L4"
     },
     {
-      "community": 603,
+      "community": 608,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -62698,7 +62974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 609,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -62707,103 +62983,13 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 609,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/storefront-webapp/src/api/storefront.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 605,
-      "file_type": "code",
-      "id": "entitypage_entitypage",
-      "label": "EntityPage()",
-      "norm_label": "entitypage()",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 605,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
-      "label": "EntityPage.tsx",
-      "norm_label": "entitypage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 606,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productspage_tsx",
-      "label": "ProductsPage.tsx",
-      "norm_label": "productspage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 606,
-      "file_type": "code",
-      "id": "productspage_productcardloadingskeleton",
-      "label": "ProductCardLoadingSkeleton()",
-      "norm_label": "productcardloadingskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "auth_authcomponent",
-      "label": "AuthComponent()",
-      "norm_label": "authcomponent()",
-      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 607,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
-      "label": "Auth.tsx",
-      "norm_label": "auth.tsx",
-      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "bagsummary_tobagsummaryitems",
-      "label": "toBagSummaryItems()",
-      "norm_label": "tobagsummaryitems()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
-      "source_location": "L39"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
-      "label": "BagSummary.tsx",
-      "norm_label": "bagsummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "checkoutform_checkoutform",
-      "label": "CheckoutForm()",
-      "norm_label": "checkoutform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
-      "label": "CheckoutForm.tsx",
-      "norm_label": "checkoutform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
-      "source_location": "L1"
     },
     {
       "community": 61,
@@ -62880,6 +63066,96 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "entitypage_entitypage",
+      "label": "EntityPage()",
+      "norm_label": "entitypage()",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
+      "label": "EntityPage.tsx",
+      "norm_label": "entitypage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productspage_tsx",
+      "label": "ProductsPage.tsx",
+      "norm_label": "productspage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "productspage_productcardloadingskeleton",
+      "label": "ProductCardLoadingSkeleton()",
+      "norm_label": "productcardloadingskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "auth_authcomponent",
+      "label": "AuthComponent()",
+      "norm_label": "authcomponent()",
+      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
+      "label": "Auth.tsx",
+      "norm_label": "auth.tsx",
+      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 613,
+      "file_type": "code",
+      "id": "bagsummary_tobagsummaryitems",
+      "label": "toBagSummaryItems()",
+      "norm_label": "tobagsummaryitems()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 613,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
+      "label": "BagSummary.tsx",
+      "norm_label": "bagsummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 614,
+      "file_type": "code",
+      "id": "checkoutform_checkoutform",
+      "label": "CheckoutForm()",
+      "norm_label": "checkoutform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 614,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
+      "label": "CheckoutForm.tsx",
+      "norm_label": "checkoutform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 615,
+      "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
       "norm_label": "checkoutprovider()",
@@ -62887,7 +63163,7 @@
       "source_location": "L71"
     },
     {
-      "community": 610,
+      "community": 615,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -62896,7 +63172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 616,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -62905,7 +63181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 616,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -62914,7 +63190,7 @@
       "source_location": "L12"
     },
     {
-      "community": 612,
+      "community": 617,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -62923,7 +63199,7 @@
       "source_location": "L6"
     },
     {
-      "community": 612,
+      "community": 617,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -62932,7 +63208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 618,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -62941,7 +63217,7 @@
       "source_location": "L18"
     },
     {
-      "community": 613,
+      "community": 618,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -62950,7 +63226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 619,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -62959,102 +63235,12 @@
       "source_location": "L10"
     },
     {
-      "community": 614,
+      "community": 619,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 615,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
-      "label": "PaymentMethodSection.tsx",
-      "norm_label": "paymentmethodsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 615,
-      "file_type": "code",
-      "id": "paymentmethodsection_paymentmethodsection",
-      "label": "PaymentMethodSection()",
-      "norm_label": "paymentmethodsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 616,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
-      "label": "PaymentSection.tsx",
-      "norm_label": "paymentsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 616,
-      "file_type": "code",
-      "id": "paymentsection_paymentsection",
-      "label": "PaymentSection()",
-      "norm_label": "paymentsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 617,
-      "file_type": "code",
-      "id": "deliveryfees_calculatedeliveryfee",
-      "label": "calculateDeliveryFee()",
-      "norm_label": "calculatedeliveryfee()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 617,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
-      "label": "deliveryFees.ts",
-      "norm_label": "deliveryfees.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "derivecheckoutstate_derivecheckoutstate",
-      "label": "deriveCheckoutState()",
-      "norm_label": "derivecheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
-      "label": "deriveCheckoutState.ts",
-      "norm_label": "derivecheckoutstate.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "checkoutschemas_test_getissuemap",
-      "label": "getIssueMap()",
-      "norm_label": "getissuemap()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
-      "label": "checkoutSchemas.test.ts",
-      "norm_label": "checkoutschemas.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
       "source_location": "L1"
     },
     {
@@ -63132,6 +63318,96 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
+      "label": "PaymentMethodSection.tsx",
+      "norm_label": "paymentmethodsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "paymentmethodsection_paymentmethodsection",
+      "label": "PaymentMethodSection()",
+      "norm_label": "paymentmethodsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
+      "label": "PaymentSection.tsx",
+      "norm_label": "paymentsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "paymentsection_paymentsection",
+      "label": "PaymentSection()",
+      "norm_label": "paymentsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
+      "id": "deliveryfees_calculatedeliveryfee",
+      "label": "calculateDeliveryFee()",
+      "norm_label": "calculatedeliveryfee()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
+      "label": "deliveryFees.ts",
+      "norm_label": "deliveryfees.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 623,
+      "file_type": "code",
+      "id": "derivecheckoutstate_derivecheckoutstate",
+      "label": "deriveCheckoutState()",
+      "norm_label": "derivecheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 623,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
+      "label": "deriveCheckoutState.ts",
+      "norm_label": "derivecheckoutstate.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 624,
+      "file_type": "code",
+      "id": "checkoutschemas_test_getissuemap",
+      "label": "getIssueMap()",
+      "norm_label": "getissuemap()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 624,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
+      "label": "checkoutSchemas.test.ts",
+      "norm_label": "checkoutschemas.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 625,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
       "norm_label": "weborderschema.test.ts",
@@ -63139,7 +63415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 625,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -63148,7 +63424,7 @@
       "source_location": "L12"
     },
     {
-      "community": 621,
+      "community": 626,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -63157,7 +63433,7 @@
       "source_location": "L77"
     },
     {
-      "community": 621,
+      "community": 626,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -63166,7 +63442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 627,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -63175,7 +63451,7 @@
       "source_location": "L161"
     },
     {
-      "community": 622,
+      "community": 627,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -63184,7 +63460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 628,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -63193,7 +63469,7 @@
       "source_location": "L3"
     },
     {
-      "community": 623,
+      "community": 628,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -63202,7 +63478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 629,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -63211,103 +63487,13 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 629,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
       "norm_label": "trustsignals()",
       "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
       "source_location": "L4"
-    },
-    {
-      "community": 625,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
-      "label": "ProductFilter.tsx",
-      "norm_label": "productfilter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 625,
-      "file_type": "code",
-      "id": "productfilter_productfilter",
-      "label": "ProductFilter()",
-      "norm_label": "productfilter()",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 626,
-      "file_type": "code",
-      "id": "filter_handlecheckboxchange",
-      "label": "handleCheckboxChange()",
-      "norm_label": "handlecheckboxchange()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 626,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
-      "label": "Filter.tsx",
-      "norm_label": "filter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 627,
-      "file_type": "code",
-      "id": "bestsellerssection_bestsellerssection",
-      "label": "BestSellersSection()",
-      "norm_label": "bestsellerssection()",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 627,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
-      "label": "BestSellersSection.tsx",
-      "norm_label": "bestsellerssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "homepagecontent_resolvehomepagecontent",
-      "label": "resolveHomepageContent()",
-      "norm_label": "resolvehomepagecontent()",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
-      "label": "homePageContent.ts",
-      "norm_label": "homepagecontent.ts",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "bagmenu_handleonlinkclick",
-      "label": "handleOnLinkClick()",
-      "norm_label": "handleonlinkclick()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
-      "label": "BagMenu.tsx",
-      "norm_label": "bagmenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
-      "source_location": "L1"
     },
     {
       "community": 63,
@@ -63384,6 +63570,96 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
+      "label": "ProductFilter.tsx",
+      "norm_label": "productfilter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "productfilter_productfilter",
+      "label": "ProductFilter()",
+      "norm_label": "productfilter()",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "filter_handlecheckboxchange",
+      "label": "handleCheckboxChange()",
+      "norm_label": "handlecheckboxchange()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
+      "label": "Filter.tsx",
+      "norm_label": "filter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
+      "id": "bestsellerssection_bestsellerssection",
+      "label": "BestSellersSection()",
+      "norm_label": "bestsellerssection()",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
+      "label": "BestSellersSection.tsx",
+      "norm_label": "bestsellerssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 633,
+      "file_type": "code",
+      "id": "homepagecontent_resolvehomepagecontent",
+      "label": "resolveHomepageContent()",
+      "norm_label": "resolvehomepagecontent()",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 633,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
+      "label": "homePageContent.ts",
+      "norm_label": "homepagecontent.ts",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 634,
+      "file_type": "code",
+      "id": "bagmenu_handleonlinkclick",
+      "label": "handleOnLinkClick()",
+      "norm_label": "handleonlinkclick()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 634,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
+      "label": "BagMenu.tsx",
+      "norm_label": "bagmenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 635,
+      "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
       "norm_label": "mobilebagmenu()",
@@ -63391,7 +63667,7 @@
       "source_location": "L7"
     },
     {
-      "community": 630,
+      "community": 635,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -63400,7 +63676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 636,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -63409,7 +63685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 636,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -63418,7 +63694,7 @@
       "source_location": "L17"
     },
     {
-      "community": 632,
+      "community": 637,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -63427,7 +63703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 637,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -63436,7 +63712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 638,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -63445,7 +63721,7 @@
       "source_location": "L12"
     },
     {
-      "community": 633,
+      "community": 638,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -63454,7 +63730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 639,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -63463,103 +63739,13 @@
       "source_location": "L7"
     },
     {
-      "community": 634,
+      "community": 639,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
       "norm_label": "discountbadge.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 635,
-      "file_type": "code",
-      "id": "galleryviewer_handleclickonpreview",
-      "label": "handleClickOnPreview()",
-      "norm_label": "handleclickonpreview()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 635,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
-      "label": "GalleryViewer.tsx",
-      "norm_label": "galleryviewer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 636,
-      "file_type": "code",
-      "id": "onsaleproduct_onsaleproduct",
-      "label": "OnsaleProduct()",
-      "norm_label": "onsaleproduct()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 636,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
-      "label": "OnSaleProduct.tsx",
-      "norm_label": "onsaleproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 637,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
-      "label": "ProductActions.tsx",
-      "norm_label": "productactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 637,
-      "file_type": "code",
-      "id": "productactions_productactions",
-      "label": "ProductActions()",
-      "norm_label": "productactions()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
-      "label": "ProductAttributes.tsx",
-      "norm_label": "productattributes.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "productattributes_productattributes",
-      "label": "ProductAttributes()",
-      "norm_label": "productattributes()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
-      "label": "ProductPage.tsx",
-      "norm_label": "productpage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "productpage_showshippingpolicy",
-      "label": "showShippingPolicy()",
-      "norm_label": "showshippingpolicy()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
-      "source_location": "L78"
     },
     {
       "community": 64,
@@ -63636,6 +63822,96 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "galleryviewer_handleclickonpreview",
+      "label": "handleClickOnPreview()",
+      "norm_label": "handleclickonpreview()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
+      "label": "GalleryViewer.tsx",
+      "norm_label": "galleryviewer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "onsaleproduct_onsaleproduct",
+      "label": "OnsaleProduct()",
+      "norm_label": "onsaleproduct()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
+      "label": "OnSaleProduct.tsx",
+      "norm_label": "onsaleproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
+      "label": "ProductActions.tsx",
+      "norm_label": "productactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
+      "id": "productactions_productactions",
+      "label": "ProductActions()",
+      "norm_label": "productactions()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 643,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
+      "label": "ProductAttributes.tsx",
+      "norm_label": "productattributes.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 643,
+      "file_type": "code",
+      "id": "productattributes_productattributes",
+      "label": "ProductAttributes()",
+      "norm_label": "productattributes()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 644,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
+      "label": "ProductPage.tsx",
+      "norm_label": "productpage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 644,
+      "file_type": "code",
+      "id": "productpage_showshippingpolicy",
+      "label": "showShippingPolicy()",
+      "norm_label": "showshippingpolicy()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
+      "source_location": "L78"
+    },
+    {
+      "community": 645,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
       "norm_label": "productreview.tsx",
@@ -63643,7 +63919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 645,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -63652,7 +63928,7 @@
       "source_location": "L87"
     },
     {
-      "community": 641,
+      "community": 646,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -63661,7 +63937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 646,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -63670,7 +63946,7 @@
       "source_location": "L8"
     },
     {
-      "community": 642,
+      "community": 647,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -63679,7 +63955,7 @@
       "source_location": "L12"
     },
     {
-      "community": 642,
+      "community": 647,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -63688,7 +63964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 648,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -63697,7 +63973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 648,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -63706,7 +63982,7 @@
       "source_location": "L18"
     },
     {
-      "community": 644,
+      "community": 649,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -63715,102 +63991,12 @@
       "source_location": "L10"
     },
     {
-      "community": 644,
+      "community": 649,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
       "norm_label": "guestrewardsprompt.tsx",
       "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 645,
-      "file_type": "code",
-      "id": "orderpointsdisplay_orderpointsdisplay",
-      "label": "OrderPointsDisplay()",
-      "norm_label": "orderpointsdisplay()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 645,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
-      "label": "OrderPointsDisplay.tsx",
-      "norm_label": "orderpointsdisplay.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 646,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
-      "label": "PastOrdersRewards.tsx",
-      "norm_label": "pastordersrewards.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 646,
-      "file_type": "code",
-      "id": "pastordersrewards_handleclaimpoints",
-      "label": "handleClaimPoints()",
-      "norm_label": "handleclaimpoints()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
-      "source_location": "L59"
-    },
-    {
-      "community": 647,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
-      "label": "RewardsPanel.tsx",
-      "norm_label": "rewardspanel.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 647,
-      "file_type": "code",
-      "id": "rewardspanel_handleredeemreward",
-      "label": "handleRedeemReward()",
-      "norm_label": "handleredeemreward()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "bagitem_bagitem",
-      "label": "BagItem()",
-      "norm_label": "bagitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
-      "label": "BagItem.tsx",
-      "norm_label": "bagitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "checkoutunavailable_checkoutunavailable",
-      "label": "CheckoutUnavailable()",
-      "norm_label": "checkoutunavailable()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
-      "label": "CheckoutUnavailable.tsx",
-      "norm_label": "checkoutunavailable.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
       "source_location": "L1"
     },
     {
@@ -63888,6 +64074,96 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "orderpointsdisplay_orderpointsdisplay",
+      "label": "OrderPointsDisplay()",
+      "norm_label": "orderpointsdisplay()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
+      "label": "OrderPointsDisplay.tsx",
+      "norm_label": "orderpointsdisplay.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
+      "label": "PastOrdersRewards.tsx",
+      "norm_label": "pastordersrewards.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "pastordersrewards_handleclaimpoints",
+      "label": "handleClaimPoints()",
+      "norm_label": "handleclaimpoints()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
+      "label": "RewardsPanel.tsx",
+      "norm_label": "rewardspanel.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
+      "id": "rewardspanel_handleredeemreward",
+      "label": "handleRedeemReward()",
+      "norm_label": "handleredeemreward()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 653,
+      "file_type": "code",
+      "id": "bagitem_bagitem",
+      "label": "BagItem()",
+      "norm_label": "bagitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 653,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
+      "label": "BagItem.tsx",
+      "norm_label": "bagitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 654,
+      "file_type": "code",
+      "id": "checkoutunavailable_checkoutunavailable",
+      "label": "CheckoutUnavailable()",
+      "norm_label": "checkoutunavailable()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 654,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
+      "label": "CheckoutUnavailable.tsx",
+      "norm_label": "checkoutunavailable.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 655,
+      "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
       "norm_label": "errorboundary()",
@@ -63895,7 +64171,7 @@
       "source_location": "L22"
     },
     {
-      "community": 650,
+      "community": 655,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -63904,7 +64180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 656,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -63913,7 +64189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 656,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -63922,7 +64198,7 @@
       "source_location": "L11"
     },
     {
-      "community": 652,
+      "community": 657,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -63931,7 +64207,7 @@
       "source_location": "L3"
     },
     {
-      "community": 652,
+      "community": 657,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -63940,7 +64216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 658,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -63949,7 +64225,7 @@
       "source_location": "L3"
     },
     {
-      "community": 653,
+      "community": 658,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -63958,7 +64234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 659,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -63967,103 +64243,13 @@
       "source_location": "L9"
     },
     {
-      "community": 654,
+      "community": 659,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
       "norm_label": "ghost-button.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "leaveareviewmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
-      "label": "LeaveAReviewModal.tsx",
-      "norm_label": "leaveareviewmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 656,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
-      "label": "UpsellModalSuccess.tsx",
-      "norm_label": "upsellmodalsuccess.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 656,
-      "file_type": "code",
-      "id": "upsellmodalsuccess_upsellmodalsuccess",
-      "label": "UpsellModalSuccess()",
-      "norm_label": "upsellmodalsuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
-      "label": "WelcomeBackModalSuccess.tsx",
-      "norm_label": "welcomebackmodalsuccess.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 657,
-      "file_type": "code",
-      "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
-      "label": "WelcomeBackModalSuccess()",
-      "norm_label": "welcomebackmodalsuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "leavereviewmodalconfig_getmodalconfig",
-      "label": "getModalConfig()",
-      "norm_label": "getmodalconfig()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
-      "label": "leaveReviewModalConfig.tsx",
-      "norm_label": "leavereviewmodalconfig.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
-      "label": "welcomeBackModalConfig.tsx",
-      "norm_label": "welcomebackmodalconfig.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "welcomebackmodalconfig_getmodalconfig",
-      "label": "getModalConfig()",
-      "norm_label": "getmodalconfig()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
-      "source_location": "L46"
     },
     {
       "community": 66,
@@ -64140,6 +64326,96 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "leaveareviewmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
+      "label": "LeaveAReviewModal.tsx",
+      "norm_label": "leaveareviewmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
+      "label": "UpsellModalSuccess.tsx",
+      "norm_label": "upsellmodalsuccess.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "upsellmodalsuccess_upsellmodalsuccess",
+      "label": "UpsellModalSuccess()",
+      "norm_label": "upsellmodalsuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
+      "label": "WelcomeBackModalSuccess.tsx",
+      "norm_label": "welcomebackmodalsuccess.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
+      "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
+      "label": "WelcomeBackModalSuccess()",
+      "norm_label": "welcomebackmodalsuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 663,
+      "file_type": "code",
+      "id": "leavereviewmodalconfig_getmodalconfig",
+      "label": "getModalConfig()",
+      "norm_label": "getmodalconfig()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 663,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
+      "label": "leaveReviewModalConfig.tsx",
+      "norm_label": "leavereviewmodalconfig.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 664,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
+      "label": "welcomeBackModalConfig.tsx",
+      "norm_label": "welcomebackmodalconfig.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 664,
+      "file_type": "code",
+      "id": "welcomebackmodalconfig_getmodalconfig",
+      "label": "getModalConfig()",
+      "norm_label": "getmodalconfig()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 665,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
       "norm_label": "webp-jpg.tsx",
@@ -64147,7 +64423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 660,
+      "community": 665,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -64156,7 +64432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 666,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -64165,7 +64441,7 @@
       "source_location": "L15"
     },
     {
-      "community": 661,
+      "community": 666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -64174,7 +64450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -64183,7 +64459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 667,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -64192,7 +64468,7 @@
       "source_location": "L5"
     },
     {
-      "community": 663,
+      "community": 668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -64201,7 +64477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 668,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -64210,7 +64486,7 @@
       "source_location": "L14"
     },
     {
-      "community": 664,
+      "community": 669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -64219,103 +64495,13 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 669,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
       "norm_label": "useenhancedtracking()",
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L29"
-    },
-    {
-      "community": 665,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
-      "label": "useGetActiveCheckoutSession.tsx",
-      "norm_label": "usegetactivecheckoutsession.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 665,
-      "file_type": "code",
-      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
-      "label": "useGetActiveCheckoutSession()",
-      "norm_label": "usegetactivecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 666,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
-      "label": "useGetProduct.tsx",
-      "norm_label": "usegetproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 666,
-      "file_type": "code",
-      "id": "usegetproduct_usegetproductquery",
-      "label": "useGetProductQuery()",
-      "norm_label": "usegetproductquery()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 667,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
-      "label": "useGetProductFilters.ts",
-      "norm_label": "usegetproductfilters.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 667,
-      "file_type": "code",
-      "id": "usegetproductfilters_usegetproductfilters",
-      "label": "useGetProductFilters()",
-      "norm_label": "usegetproductfilters()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
-      "label": "useGetProductReviews.ts",
-      "norm_label": "usegetproductreviews.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "usegetproductreviews_usegetproductreviewsquery",
-      "label": "useGetProductReviewsQuery()",
-      "norm_label": "usegetproductreviewsquery()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
-      "label": "useGetStore.ts",
-      "norm_label": "usegetstore.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "usegetstore_usegetstore",
-      "label": "useGetStore()",
-      "norm_label": "usegetstore()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
-      "source_location": "L4"
     },
     {
       "community": 67,
@@ -64392,6 +64578,96 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
+      "label": "useGetActiveCheckoutSession.tsx",
+      "norm_label": "usegetactivecheckoutsession.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
+      "label": "useGetActiveCheckoutSession()",
+      "norm_label": "usegetactivecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
+      "label": "useGetProduct.tsx",
+      "norm_label": "usegetproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "usegetproduct_usegetproductquery",
+      "label": "useGetProductQuery()",
+      "norm_label": "usegetproductquery()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
+      "label": "useGetProductFilters.ts",
+      "norm_label": "usegetproductfilters.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
+      "id": "usegetproductfilters_usegetproductfilters",
+      "label": "useGetProductFilters()",
+      "norm_label": "usegetproductfilters()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 673,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
+      "label": "useGetProductReviews.ts",
+      "norm_label": "usegetproductreviews.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 673,
+      "file_type": "code",
+      "id": "usegetproductreviews_usegetproductreviewsquery",
+      "label": "useGetProductReviewsQuery()",
+      "norm_label": "usegetproductreviewsquery()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 674,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
+      "label": "useGetStore.ts",
+      "norm_label": "usegetstore.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 674,
+      "file_type": "code",
+      "id": "usegetstore_usegetstore",
+      "label": "useGetStore()",
+      "norm_label": "usegetstore()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 675,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
       "norm_label": "useinventorystatus.ts",
@@ -64399,7 +64675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 670,
+      "community": 675,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -64408,7 +64684,7 @@
       "source_location": "L9"
     },
     {
-      "community": 671,
+      "community": 676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -64417,7 +64693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 676,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -64426,7 +64702,7 @@
       "source_location": "L17"
     },
     {
-      "community": 672,
+      "community": 677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -64435,7 +64711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 677,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -64444,7 +64720,7 @@
       "source_location": "L5"
     },
     {
-      "community": 673,
+      "community": 678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -64453,7 +64729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 678,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -64462,7 +64738,7 @@
       "source_location": "L15"
     },
     {
-      "community": 674,
+      "community": 679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -64471,103 +64747,13 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 679,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
       "norm_label": "useproductpagelogic()",
       "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
       "source_location": "L18"
-    },
-    {
-      "community": 675,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
-      "label": "useProductReminder.tsx",
-      "norm_label": "useproductreminder.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 675,
-      "file_type": "code",
-      "id": "useproductreminder_useproductreminder",
-      "label": "useProductReminder()",
-      "norm_label": "useproductreminder()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 676,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
-      "label": "usePromoAlert.tsx",
-      "norm_label": "usepromoalert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 676,
-      "file_type": "code",
-      "id": "usepromoalert_usepromoalert",
-      "label": "usePromoAlert()",
-      "norm_label": "usepromoalert()",
-      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 677,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
-      "label": "useQueryEnabled.ts",
-      "norm_label": "usequeryenabled.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 677,
-      "file_type": "code",
-      "id": "usequeryenabled_usequeryenabled",
-      "label": "useQueryEnabled()",
-      "norm_label": "usequeryenabled()",
-      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
-      "label": "useRewardsAlert.tsx",
-      "norm_label": "userewardsalert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "userewardsalert_userewardsalert",
-      "label": "useRewardsAlert()",
-      "norm_label": "userewardsalert()",
-      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
-      "label": "useScrollToTop.ts",
-      "norm_label": "usescrolltotop.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "usescrolltotop_usescrolltotop",
-      "label": "useScrollToTop()",
-      "norm_label": "usescrolltotop()",
-      "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
-      "source_location": "L3"
     },
     {
       "community": 68,
@@ -64644,6 +64830,96 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
+      "label": "useProductReminder.tsx",
+      "norm_label": "useproductreminder.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "useproductreminder_useproductreminder",
+      "label": "useProductReminder()",
+      "norm_label": "useproductreminder()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
+      "label": "usePromoAlert.tsx",
+      "norm_label": "usepromoalert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "usepromoalert_usepromoalert",
+      "label": "usePromoAlert()",
+      "norm_label": "usepromoalert()",
+      "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
+      "label": "useQueryEnabled.ts",
+      "norm_label": "usequeryenabled.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
+      "id": "usequeryenabled_usequeryenabled",
+      "label": "useQueryEnabled()",
+      "norm_label": "usequeryenabled()",
+      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 683,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
+      "label": "useRewardsAlert.tsx",
+      "norm_label": "userewardsalert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 683,
+      "file_type": "code",
+      "id": "userewardsalert_userewardsalert",
+      "label": "useRewardsAlert()",
+      "norm_label": "userewardsalert()",
+      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 684,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
+      "label": "useScrollToTop.ts",
+      "norm_label": "usescrolltotop.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 684,
+      "file_type": "code",
+      "id": "usescrolltotop_usescrolltotop",
+      "label": "useScrollToTop()",
+      "norm_label": "usescrolltotop()",
+      "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 685,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
       "norm_label": "usetrackaction.ts",
@@ -64651,7 +64927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 680,
+      "community": 685,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -64660,7 +64936,7 @@
       "source_location": "L7"
     },
     {
-      "community": 681,
+      "community": 686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -64669,7 +64945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 686,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -64678,7 +64954,7 @@
       "source_location": "L4"
     },
     {
-      "community": 682,
+      "community": 687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -64687,7 +64963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 687,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -64696,7 +64972,7 @@
       "source_location": "L14"
     },
     {
-      "community": 683,
+      "community": 688,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -64705,7 +64981,7 @@
       "source_location": "L4"
     },
     {
-      "community": 683,
+      "community": 688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -64714,7 +64990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 689,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -64723,103 +64999,13 @@
       "source_location": "L7"
     },
     {
-      "community": 684,
+      "community": 689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 685,
-      "file_type": "code",
-      "id": "bannermessage_usebannermessagequeries",
-      "label": "useBannerMessageQueries()",
-      "norm_label": "usebannermessagequeries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 685,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 686,
-      "file_type": "code",
-      "id": "checkout_usecheckoutsessionqueries",
-      "label": "useCheckoutSessionQueries()",
-      "norm_label": "usecheckoutsessionqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 686,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
-      "label": "checkout.ts",
-      "norm_label": "checkout.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 687,
-      "file_type": "code",
-      "id": "inventory_useinventoryqueries",
-      "label": "useInventoryQueries()",
-      "norm_label": "useinventoryqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 687,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
-      "label": "inventory.ts",
-      "norm_label": "inventory.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "onlineorder_useonlineorderqueries",
-      "label": "useOnlineOrderQueries()",
-      "norm_label": "useonlineorderqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "product_useproductqueries",
-      "label": "useProductQueries()",
-      "norm_label": "useproductqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
-      "source_location": "L14"
     },
     {
       "community": 69,
@@ -64896,6 +65082,96 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "bannermessage_usebannermessagequeries",
+      "label": "useBannerMessageQueries()",
+      "norm_label": "usebannermessagequeries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "checkout_usecheckoutsessionqueries",
+      "label": "useCheckoutSessionQueries()",
+      "norm_label": "usecheckoutsessionqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
+      "label": "checkout.ts",
+      "norm_label": "checkout.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
+      "id": "inventory_useinventoryqueries",
+      "label": "useInventoryQueries()",
+      "norm_label": "useinventoryqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
+      "label": "inventory.ts",
+      "norm_label": "inventory.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 693,
+      "file_type": "code",
+      "id": "onlineorder_useonlineorderqueries",
+      "label": "useOnlineOrderQueries()",
+      "norm_label": "useonlineorderqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 693,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 694,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 694,
+      "file_type": "code",
+      "id": "product_useproductqueries",
+      "label": "useProductQueries()",
+      "norm_label": "useproductqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 695,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
       "norm_label": "promocode.ts",
@@ -64903,7 +65179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 690,
+      "community": 695,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -64912,7 +65188,7 @@
       "source_location": "L9"
     },
     {
-      "community": 691,
+      "community": 696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -64921,7 +65197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 696,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -64930,7 +65206,7 @@
       "source_location": "L10"
     },
     {
-      "community": 692,
+      "community": 697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -64939,7 +65215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 697,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -64948,7 +65224,7 @@
       "source_location": "L11"
     },
     {
-      "community": 693,
+      "community": 698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -64957,7 +65233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 698,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -64966,7 +65242,7 @@
       "source_location": "L6"
     },
     {
-      "community": 694,
+      "community": 699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -64975,103 +65251,13 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 699,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
       "norm_label": "useuserqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 695,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 695,
-      "file_type": "code",
-      "id": "useroffers_useuseroffersqueries",
-      "label": "useUserOffersQueries()",
-      "norm_label": "useuseroffersqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 696,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
-      "label": "storeConfig.test.ts",
-      "norm_label": "storeconfig.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 696,
-      "file_type": "code",
-      "id": "storeconfig_test_buildv2config",
-      "label": "buildV2Config()",
-      "norm_label": "buildv2config()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 697,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
-      "label": "storefrontObservability.test.ts",
-      "norm_label": "storefrontobservability.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 697,
-      "file_type": "code",
-      "id": "storefrontobservability_test_creatememorystorage",
-      "label": "createMemoryStorage()",
-      "norm_label": "creatememorystorage()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "email_validateemail",
-      "label": "validateEmail()",
-      "norm_label": "validateemail()",
-      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_validations_email_ts",
-      "label": "email.ts",
-      "norm_label": "email.ts",
-      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_router_tsx",
-      "label": "router.tsx",
-      "norm_label": "router.tsx",
-      "source_file": "packages/storefront-webapp/src/router.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "router_createrouter",
-      "label": "createRouter()",
-      "norm_label": "createrouter()",
-      "source_file": "packages/storefront-webapp/src/router.tsx",
-      "source_location": "L6"
     },
     {
       "community": 7,
@@ -65373,6 +65559,96 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "useroffers_useuseroffersqueries",
+      "label": "useUserOffersQueries()",
+      "norm_label": "useuseroffersqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
+      "label": "storeConfig.test.ts",
+      "norm_label": "storeconfig.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "storeconfig_test_buildv2config",
+      "label": "buildV2Config()",
+      "norm_label": "buildv2config()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
+      "label": "storefrontObservability.test.ts",
+      "norm_label": "storefrontobservability.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
+      "id": "storefrontobservability_test_creatememorystorage",
+      "label": "createMemoryStorage()",
+      "norm_label": "creatememorystorage()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 703,
+      "file_type": "code",
+      "id": "email_validateemail",
+      "label": "validateEmail()",
+      "norm_label": "validateemail()",
+      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 703,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_validations_email_ts",
+      "label": "email.ts",
+      "norm_label": "email.ts",
+      "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 704,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_router_tsx",
+      "label": "router.tsx",
+      "norm_label": "router.tsx",
+      "source_file": "packages/storefront-webapp/src/router.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 704,
+      "file_type": "code",
+      "id": "router_createrouter",
+      "label": "createRouter()",
+      "norm_label": "createrouter()",
+      "source_file": "packages/storefront-webapp/src/router.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 705,
+      "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
       "norm_label": "loadhomepagedata()",
@@ -65380,7 +65656,7 @@
       "source_location": "L13"
     },
     {
-      "community": 700,
+      "community": 705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -65389,7 +65665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 706,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -65398,7 +65674,7 @@
       "source_location": "L8"
     },
     {
-      "community": 701,
+      "community": 706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -65407,7 +65683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 707,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -65416,7 +65692,7 @@
       "source_location": "L14"
     },
     {
-      "community": 702,
+      "community": 707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -65425,7 +65701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 708,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -65434,7 +65710,7 @@
       "source_location": "L13"
     },
     {
-      "community": 703,
+      "community": 708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -65443,7 +65719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -65452,103 +65728,13 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 709,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
       "norm_label": "privacypolicy()",
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 705,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
-      "label": "tos.index.tsx",
-      "norm_label": "tos.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 705,
-      "file_type": "code",
-      "id": "tos_index_tossection",
-      "label": "TosSection()",
-      "norm_label": "tossection()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 706,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
-      "label": "shop.product.$productSlug.tsx",
-      "norm_label": "shop.product.$productslug.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 706,
-      "file_type": "code",
-      "id": "shop_product_productslug_component",
-      "label": "Component()",
-      "norm_label": "component()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 707,
-      "file_type": "code",
-      "id": "layout_layoutcomponent",
-      "label": "LayoutComponent()",
-      "norm_label": "layoutcomponent()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 707,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_tsx",
-      "label": "_layout.tsx",
-      "norm_label": "_layout.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "index_homeroute",
-      "label": "HomeRoute()",
-      "norm_label": "homeroute()",
-      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "canceled_checkoutcanceledview",
-      "label": "CheckoutCanceledView()",
-      "norm_label": "checkoutcanceledview()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
-      "label": "canceled.tsx",
-      "norm_label": "canceled.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
-      "source_location": "L1"
     },
     {
       "community": 71,
@@ -65625,6 +65811,96 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
+      "label": "tos.index.tsx",
+      "norm_label": "tos.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 710,
+      "file_type": "code",
+      "id": "tos_index_tossection",
+      "label": "TosSection()",
+      "norm_label": "tossection()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
+      "label": "shop.product.$productSlug.tsx",
+      "norm_label": "shop.product.$productslug.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "shop_product_productslug_component",
+      "label": "Component()",
+      "norm_label": "component()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
+      "id": "layout_layoutcomponent",
+      "label": "LayoutComponent()",
+      "norm_label": "layoutcomponent()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_tsx",
+      "label": "_layout.tsx",
+      "norm_label": "_layout.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 713,
+      "file_type": "code",
+      "id": "index_homeroute",
+      "label": "HomeRoute()",
+      "norm_label": "homeroute()",
+      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 713,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 714,
+      "file_type": "code",
+      "id": "canceled_checkoutcanceledview",
+      "label": "CheckoutCanceledView()",
+      "norm_label": "checkoutcanceledview()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 714,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
+      "label": "canceled.tsx",
+      "norm_label": "canceled.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 715,
+      "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
       "norm_label": "checkoutcomplete()",
@@ -65632,7 +65908,7 @@
       "source_location": "L33"
     },
     {
-      "community": 710,
+      "community": 715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -65641,7 +65917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -65650,7 +65926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 716,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -65659,7 +65935,7 @@
       "source_location": "L193"
     },
     {
-      "community": 712,
+      "community": 717,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -65668,7 +65944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 717,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -65677,7 +65953,7 @@
       "source_location": "L7"
     },
     {
-      "community": 713,
+      "community": 718,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -65686,7 +65962,7 @@
       "source_location": "L10"
     },
     {
-      "community": 713,
+      "community": 718,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -65695,7 +65971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 719,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -65704,84 +65980,12 @@
       "source_location": "L32"
     },
     {
-      "community": 714,
+      "community": 719,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
       "norm_label": "architecture-boundary-check.ts",
       "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 715,
-      "file_type": "code",
-      "id": "athena_runtime_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 715,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
-      "label": "athena-runtime-app.ts",
-      "norm_label": "athena-runtime-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 716,
-      "file_type": "code",
-      "id": "sample_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 716,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_sample_app_ts",
-      "label": "sample-app.ts",
-      "norm_label": "sample-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 717,
-      "file_type": "code",
-      "id": "harness_runtime_trends_test_buildreportline",
-      "label": "buildReportLine()",
-      "norm_label": "buildreportline()",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 717,
-      "file_type": "code",
-      "id": "scripts_harness_runtime_trends_test_ts",
-      "label": "harness-runtime-trends.test.ts",
-      "norm_label": "harness-runtime-trends.test.ts",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_api_d_ts",
-      "label": "api.d.ts",
-      "norm_label": "api.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_api_js",
-      "label": "api.js",
-      "norm_label": "api.js",
-      "source_file": "packages/athena-webapp/convex/_generated/api.js",
       "source_location": "L1"
     },
     {
@@ -65859,6 +66063,78 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "athena_runtime_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 720,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
+      "label": "athena-runtime-app.ts",
+      "norm_label": "athena-runtime-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "sample_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_sample_app_ts",
+      "label": "sample-app.ts",
+      "norm_label": "sample-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
+      "id": "harness_runtime_trends_test_buildreportline",
+      "label": "buildReportLine()",
+      "norm_label": "buildreportline()",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
+      "id": "scripts_harness_runtime_trends_test_ts",
+      "label": "harness-runtime-trends.test.ts",
+      "norm_label": "harness-runtime-trends.test.ts",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 723,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_api_d_ts",
+      "label": "api.d.ts",
+      "norm_label": "api.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 724,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_api_js",
+      "label": "api.js",
+      "norm_label": "api.js",
+      "source_file": "packages/athena-webapp/convex/_generated/api.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 725,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
       "norm_label": "datamodel.d.ts",
@@ -65866,7 +66142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -65875,7 +66151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -65884,7 +66160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -65893,57 +66169,12 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
       "norm_label": "auth.config.js",
       "source_file": "packages/athena-webapp/convex/auth.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 725,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 726,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
-      "label": "registerSessions.test.ts",
-      "norm_label": "registersessions.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/registerSessions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 727,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_email_ts",
-      "label": "email.ts",
-      "norm_label": "email.ts",
-      "source_file": "packages/athena-webapp/convex/constants/email.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
       "source_location": "L1"
     },
     {
@@ -66012,6 +66243,51 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
+      "label": "registerSessions.test.ts",
+      "norm_label": "registersessions.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/registerSessions.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 732,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 733,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_email_ts",
+      "label": "email.ts",
+      "norm_label": "email.ts",
+      "source_file": "packages/athena-webapp/convex/constants/email.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 734,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 735,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
       "norm_label": "payment.ts",
@@ -66019,7 +66295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -66028,7 +66304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -66037,7 +66313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -66046,57 +66322,12 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
       "norm_label": "orderemail.tsx",
       "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 735,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
-      "label": "PosReceiptEmail.tsx",
-      "norm_label": "posreceiptemail.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 736,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_env_ts",
-      "label": "env.ts",
-      "norm_label": "env.ts",
-      "source_file": "packages/athena-webapp/convex/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 737,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/bannerMessage.ts",
       "source_location": "L1"
     },
     {
@@ -66165,6 +66396,51 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
+      "label": "PosReceiptEmail.tsx",
+      "norm_label": "posreceiptemail.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_env_ts",
+      "label": "env.ts",
+      "norm_label": "env.ts",
+      "source_file": "packages/athena-webapp/convex/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 742,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 743,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 744,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 745,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
       "norm_label": "categories.ts",
@@ -66172,7 +66448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -66181,7 +66457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -66190,7 +66466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
@@ -66199,57 +66475,12 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
       "norm_label": "products.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/products.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 745,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 746,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
-      "label": "subcategories.ts",
-      "norm_label": "subcategories.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 747,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 748,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/guest.ts",
       "source_location": "L1"
     },
     {
@@ -66318,6 +66549,51 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
+      "label": "subcategories.ts",
+      "norm_label": "subcategories.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 752,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 753,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 754,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 755,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -66325,7 +66601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
@@ -66334,7 +66610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
@@ -66343,7 +66619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -66352,57 +66628,12 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
       "norm_label": "paystack.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 755,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 756,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 757,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 758,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
-      "label": "security.test.ts",
-      "norm_label": "security.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
-      "label": "storefront.ts",
-      "norm_label": "storefront.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/storefront.ts",
       "source_location": "L1"
     },
     {
@@ -66471,6 +66702,51 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 762,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 763,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
+      "label": "security.test.ts",
+      "norm_label": "security.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 764,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
+      "label": "storefront.ts",
+      "norm_label": "storefront.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/storefront.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 765,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
       "norm_label": "upsells.ts",
@@ -66478,7 +66754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -66487,7 +66763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -66496,7 +66772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -66505,57 +66781,12 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
       "norm_label": "http.ts",
       "source_file": "packages/athena-webapp/convex/http.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 765,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
-      "label": "athenaUser.ts",
-      "norm_label": "athenauser.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 766,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 767,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 768,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
-      "label": "bestSeller.ts",
-      "norm_label": "bestseller.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_categories_ts",
-      "label": "categories.ts",
-      "norm_label": "categories.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/categories.ts",
       "source_location": "L1"
     },
     {
@@ -66624,6 +66855,51 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
+      "label": "athenaUser.ts",
+      "norm_label": "athenauser.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 772,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 773,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
+      "label": "bestSeller.ts",
+      "norm_label": "bestseller.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 774,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_categories_ts",
+      "label": "categories.ts",
+      "norm_label": "categories.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/categories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 775,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
       "norm_label": "colors.ts",
@@ -66631,7 +66907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -66640,7 +66916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -66649,7 +66925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -66658,57 +66934,12 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
       "norm_label": "featureditem.ts",
       "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 775,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
-      "label": "inviteCode.ts",
-      "norm_label": "invitecode.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 776,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
-      "label": "organizationMembers.ts",
-      "norm_label": "organizationmembers.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 777,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_organizations_ts",
-      "label": "organizations.ts",
-      "norm_label": "organizations.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 778,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_pos_ts",
-      "label": "pos.ts",
-      "norm_label": "pos.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
-      "label": "posCustomers.ts",
-      "norm_label": "poscustomers.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
       "source_location": "L1"
     },
     {
@@ -66777,6 +67008,51 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
+      "label": "inviteCode.ts",
+      "norm_label": "invitecode.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
+      "label": "organizationMembers.ts",
+      "norm_label": "organizationmembers.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 782,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_organizations_ts",
+      "label": "organizations.ts",
+      "norm_label": "organizations.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 783,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_pos_ts",
+      "label": "pos.ts",
+      "norm_label": "pos.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 784,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
+      "label": "posCustomers.ts",
+      "norm_label": "poscustomers.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 785,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
       "norm_label": "possessionitems.ts",
@@ -66784,7 +67060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -66793,7 +67069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -66802,7 +67078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -66811,57 +67087,12 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
       "norm_label": "promocode.ts",
       "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 785,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
-      "label": "stockValidation.ts",
-      "norm_label": "stockvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 786,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
-      "label": "storeConfigV2.test.ts",
-      "norm_label": "storeconfigv2.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 787,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
-      "label": "subcategories.ts",
-      "norm_label": "subcategories.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/subcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 788,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_test_ts",
-      "label": "currency.test.ts",
-      "norm_label": "currency.test.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
-      "label": "storeInsights.ts",
-      "norm_label": "storeinsights.ts",
-      "source_file": "packages/athena-webapp/convex/llm/storeInsights.ts",
       "source_location": "L1"
     },
     {
@@ -66930,6 +67161,51 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
+      "label": "stockValidation.ts",
+      "norm_label": "stockvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
+      "label": "storeConfigV2.test.ts",
+      "norm_label": "storeconfigv2.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 792,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
+      "label": "subcategories.ts",
+      "norm_label": "subcategories.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/subcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 793,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_test_ts",
+      "label": "currency.test.ts",
+      "norm_label": "currency.test.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 794,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
+      "label": "storeInsights.ts",
+      "norm_label": "storeinsights.ts",
+      "source_file": "packages/athena-webapp/convex/llm/storeInsights.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 795,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
       "norm_label": "userinsights.ts",
@@ -66937,7 +67213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -66946,7 +67222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -66955,7 +67231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -66964,57 +67240,12 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
       "norm_label": "normalize.test.ts",
       "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 795,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 796,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
-      "label": "customerProfiles.test.ts",
-      "norm_label": "customerprofiles.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 797,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
-      "label": "inventoryMovements.test.ts",
-      "norm_label": "inventorymovements.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
-      "label": "paymentAllocations.test.ts",
-      "norm_label": "paymentallocations.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
-      "label": "staffProfiles.test.ts",
-      "norm_label": "staffprofiles.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
       "source_location": "L1"
     },
     {
@@ -67281,6 +67512,51 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
+      "label": "customerProfiles.test.ts",
+      "norm_label": "customerprofiles.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 802,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
+      "label": "inventoryMovements.test.ts",
+      "norm_label": "inventorymovements.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 803,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
+      "label": "paymentAllocations.test.ts",
+      "norm_label": "paymentallocations.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 804,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
+      "label": "staffProfiles.test.ts",
+      "norm_label": "staffprofiles.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 805,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
       "norm_label": "emailotp.test.ts",
@@ -67288,7 +67564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -67297,7 +67573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
@@ -67306,7 +67582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
@@ -67315,57 +67591,12 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
       "norm_label": "gettransactions.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/getTransactions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 805,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
-      "label": "openDrawer.test.ts",
-      "norm_label": "opendrawer.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 806,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
-      "label": "posSessionTracing.test.ts",
-      "norm_label": "possessiontracing.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/posSessionTracing.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 807,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_domain_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/convex/pos/domain/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 808,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
-      "label": "sessionCommandRepository.test.ts",
-      "norm_label": "sessioncommandrepository.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
-      "label": "catalog.ts",
-      "norm_label": "catalog.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
       "source_location": "L1"
     },
     {
@@ -67434,6 +67665,51 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
+      "label": "openDrawer.test.ts",
+      "norm_label": "opendrawer.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
+      "label": "posSessionTracing.test.ts",
+      "norm_label": "possessiontracing.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/posSessionTracing.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 812,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_domain_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/convex/pos/domain/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 813,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
+      "label": "sessionCommandRepository.test.ts",
+      "norm_label": "sessioncommandrepository.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 814,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
+      "label": "catalog.ts",
+      "norm_label": "catalog.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 815,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
       "norm_label": "customers.ts",
@@ -67441,7 +67717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -67450,7 +67726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -67459,7 +67735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -67468,57 +67744,12 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
       "norm_label": "schema.ts",
       "source_file": "packages/athena-webapp/convex/schema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 815,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
-      "label": "appVerificationCode.ts",
-      "norm_label": "appverificationcode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/appVerificationCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 816,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
-      "label": "athenaUser.ts",
-      "norm_label": "athenauser.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/athenaUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 817,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 818,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
-      "label": "bestSeller.ts",
-      "norm_label": "bestseller.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
-      "label": "cashier.ts",
-      "norm_label": "cashier.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/cashier.ts",
       "source_location": "L1"
     },
     {
@@ -67587,6 +67818,51 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
+      "label": "appVerificationCode.ts",
+      "norm_label": "appverificationcode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/appVerificationCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
+      "label": "athenaUser.ts",
+      "norm_label": "athenauser.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/athenaUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 822,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 823,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
+      "label": "bestSeller.ts",
+      "norm_label": "bestseller.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 824,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
+      "label": "cashier.ts",
+      "norm_label": "cashier.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/cashier.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 825,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
@@ -67594,7 +67870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -67603,7 +67879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -67612,7 +67888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -67621,57 +67897,12 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 825,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
-      "label": "inviteCode.ts",
-      "norm_label": "invitecode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 826,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/organization.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 827,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
-      "label": "organizationMember.ts",
-      "norm_label": "organizationmember.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/organizationMember.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 828,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
-      "label": "promoCode.ts",
-      "norm_label": "promocode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
       "source_location": "L1"
     },
     {
@@ -67740,6 +67971,51 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
+      "label": "inviteCode.ts",
+      "norm_label": "invitecode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/organization.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 832,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
+      "label": "organizationMember.ts",
+      "norm_label": "organizationmember.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/organizationMember.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 833,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 834,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
+      "label": "promoCode.ts",
+      "norm_label": "promocode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 835,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
       "norm_label": "redeemedpromocode.ts",
@@ -67747,7 +68023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -67756,7 +68032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -67765,7 +68041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -67774,57 +68050,12 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
       "norm_label": "workflowtrace.ts",
       "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTrace.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 835,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
-      "label": "workflowTraceEvent.ts",
-      "norm_label": "workflowtraceevent.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceEvent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 836,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
-      "label": "workflowTraceLookup.ts",
-      "norm_label": "workflowtracelookup.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceLookup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 837,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
-      "label": "approvalRequest.ts",
-      "norm_label": "approvalrequest.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/approvalRequest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 838,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
-      "label": "customerProfile.ts",
-      "norm_label": "customerprofile.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/customerProfile.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/index.ts",
       "source_location": "L1"
     },
     {
@@ -67893,6 +68124,51 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
+      "label": "workflowTraceEvent.ts",
+      "norm_label": "workflowtraceevent.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
+      "label": "workflowTraceLookup.ts",
+      "norm_label": "workflowtracelookup.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/observability/workflowTraceLookup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 842,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
+      "label": "approvalRequest.ts",
+      "norm_label": "approvalrequest.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/approvalRequest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 843,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
+      "label": "customerProfile.ts",
+      "norm_label": "customerprofile.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/customerProfile.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 844,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 845,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
       "norm_label": "inventorymovement.ts",
@@ -67900,7 +68176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -67909,7 +68185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -67918,7 +68194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -67927,57 +68203,12 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
       "norm_label": "registersession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/registerSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 845,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
-      "label": "staffProfile.ts",
-      "norm_label": "staffprofile.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/staffProfile.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 846,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
-      "label": "staffRoleAssignment.ts",
-      "norm_label": "staffroleassignment.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/staffRoleAssignment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 847,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
-      "label": "mtnCollections.ts",
-      "norm_label": "mtncollections.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 848,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
-      "label": "customer.ts",
-      "norm_label": "customer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
-      "label": "expenseSession.ts",
-      "norm_label": "expensesession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
       "source_location": "L1"
     },
     {
@@ -68046,6 +68277,51 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
+      "label": "staffProfile.ts",
+      "norm_label": "staffprofile.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/staffProfile.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
+      "label": "staffRoleAssignment.ts",
+      "norm_label": "staffroleassignment.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/staffRoleAssignment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 852,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
+      "label": "mtnCollections.ts",
+      "norm_label": "mtncollections.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 853,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
+      "label": "customer.ts",
+      "norm_label": "customer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/customer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 854,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
+      "label": "expenseSession.ts",
+      "norm_label": "expensesession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 855,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
       "norm_label": "expensesessionitem.ts",
@@ -68053,7 +68329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -68062,7 +68338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -68071,7 +68347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -68080,57 +68356,12 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
       "norm_label": "possession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 855,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
-      "label": "posSessionItem.ts",
-      "norm_label": "possessionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posSessionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 856,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
-      "label": "posTerminal.ts",
-      "norm_label": "posterminal.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 857,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
-      "label": "posTransaction.ts",
-      "norm_label": "postransaction.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 858,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
-      "label": "posTransactionItem.ts",
-      "norm_label": "postransactionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/index.ts",
       "source_location": "L1"
     },
     {
@@ -68199,6 +68430,51 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
+      "label": "posSessionItem.ts",
+      "norm_label": "possessionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posSessionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
+      "label": "posTerminal.ts",
+      "norm_label": "posterminal.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 862,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
+      "label": "posTransaction.ts",
+      "norm_label": "postransaction.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 863,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
+      "label": "posTransactionItem.ts",
+      "norm_label": "postransactionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 864,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 865,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
       "norm_label": "serviceappointment.ts",
@@ -68206,7 +68482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -68215,7 +68491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -68224,7 +68500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -68233,57 +68509,12 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
       "norm_label": "serviceinventoryusage.ts",
       "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceInventoryUsage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 865,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 866,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
-      "label": "purchaseOrder.ts",
-      "norm_label": "purchaseorder.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 867,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
-      "label": "purchaseOrderLineItem.ts",
-      "norm_label": "purchaseorderlineitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrderLineItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 868,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
-      "label": "receivingBatch.ts",
-      "norm_label": "receivingbatch.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/receivingBatch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
-      "label": "stockAdjustmentBatch.ts",
-      "norm_label": "stockadjustmentbatch.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/stockAdjustmentBatch.ts",
       "source_location": "L1"
     },
     {
@@ -68352,6 +68583,51 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
+      "label": "purchaseOrder.ts",
+      "norm_label": "purchaseorder.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 872,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
+      "label": "purchaseOrderLineItem.ts",
+      "norm_label": "purchaseorderlineitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrderLineItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 873,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
+      "label": "receivingBatch.ts",
+      "norm_label": "receivingbatch.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/receivingBatch.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 874,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
+      "label": "stockAdjustmentBatch.ts",
+      "norm_label": "stockadjustmentbatch.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/stockAdjustmentBatch.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 875,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
       "norm_label": "vendor.ts",
@@ -68359,7 +68635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -68368,7 +68644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -68377,7 +68653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -68386,57 +68662,12 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
       "norm_label": "checkoutsession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 875,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
-      "label": "checkoutSessionItem.ts",
-      "norm_label": "checkoutsessionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 876,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
-      "label": "customer.ts",
-      "norm_label": "customer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 877,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 878,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
-      "label": "offer.ts",
-      "norm_label": "offer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
       "source_location": "L1"
     },
     {
@@ -68505,6 +68736,51 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
+      "label": "checkoutSessionItem.ts",
+      "norm_label": "checkoutsessionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
+      "label": "customer.ts",
+      "norm_label": "customer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/customer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 882,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 883,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 884,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
+      "label": "offer.ts",
+      "norm_label": "offer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 885,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
@@ -68512,7 +68788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -68521,7 +68797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -68530,7 +68806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -68539,57 +68815,12 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
       "norm_label": "savedbag.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 885,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
-      "label": "savedBagItem.ts",
-      "norm_label": "savedbagitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 886,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
-      "label": "storeFrontSession.ts",
-      "norm_label": "storefrontsession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 887,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
-      "label": "storeFrontUser.ts",
-      "norm_label": "storefrontuser.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 888,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
-      "label": "storeFrontVerificationCode.ts",
-      "norm_label": "storefrontverificationcode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
-      "label": "supportTicket.ts",
-      "norm_label": "supportticket.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
       "source_location": "L1"
     },
     {
@@ -68658,6 +68889,51 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
+      "label": "savedBagItem.ts",
+      "norm_label": "savedbagitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
+      "label": "storeFrontSession.ts",
+      "norm_label": "storefrontsession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 892,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
+      "label": "storeFrontUser.ts",
+      "norm_label": "storefrontuser.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 893,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
+      "label": "storeFrontVerificationCode.ts",
+      "norm_label": "storefrontverificationcode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 894,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
+      "label": "supportTicket.ts",
+      "norm_label": "supportticket.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 895,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
       "norm_label": "catalogappointments.test.ts",
@@ -68665,7 +68941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -68674,7 +68950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -68683,7 +68959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -68692,57 +68968,12 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 895,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
-      "label": "onlineOrderUtilFns.ts",
-      "norm_label": "onlineorderutilfns.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 896,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
-      "label": "orderOperations.test.ts",
-      "norm_label": "orderoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/orderOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 897,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_payment_ts",
-      "label": "payment.ts",
-      "norm_label": "payment.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/payment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
-      "label": "paystackActions.ts",
-      "norm_label": "paystackactions.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
-      "label": "savedBagItem.ts",
-      "norm_label": "savedbagitem.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
       "source_location": "L1"
     },
     {
@@ -69000,6 +69231,51 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
+      "label": "onlineOrderUtilFns.ts",
+      "norm_label": "onlineorderutilfns.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
+      "label": "orderOperations.test.ts",
+      "norm_label": "orderoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/orderOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 902,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_payment_ts",
+      "label": "payment.ts",
+      "norm_label": "payment.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/payment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 903,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
+      "label": "paystackActions.ts",
+      "norm_label": "paystackactions.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 904,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
+      "label": "savedBagItem.ts",
+      "norm_label": "savedbagitem.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 905,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
       "norm_label": "supportticket.ts",
@@ -69007,7 +69283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -69016,7 +69292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -69025,7 +69301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possale_test_ts",
       "label": "posSale.test.ts",
@@ -69034,57 +69310,12 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
       "norm_label": "possession.test.ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 905,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
-      "label": "registerSession.test.ts",
-      "norm_label": "registersession.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 906,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
-      "label": "presentation.test.ts",
-      "norm_label": "presentation.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 907,
-      "file_type": "code",
-      "id": "packages_athena_webapp_eslint_config_js",
-      "label": "eslint.config.js",
-      "norm_label": "eslint.config.js",
-      "source_file": "packages/athena-webapp/eslint.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 908,
-      "file_type": "code",
-      "id": "packages_athena_webapp_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_postcss_config_js",
-      "label": "postcss.config.js",
-      "norm_label": "postcss.config.js",
-      "source_file": "packages/athena-webapp/postcss.config.js",
       "source_location": "L1"
     },
     {
@@ -69153,6 +69384,51 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
+      "label": "registerSession.test.ts",
+      "norm_label": "registersession.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
+      "label": "presentation.test.ts",
+      "norm_label": "presentation.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 912,
+      "file_type": "code",
+      "id": "packages_athena_webapp_eslint_config_js",
+      "label": "eslint.config.js",
+      "norm_label": "eslint.config.js",
+      "source_file": "packages/athena-webapp/eslint.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 913,
+      "file_type": "code",
+      "id": "packages_athena_webapp_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 914,
+      "file_type": "code",
+      "id": "packages_athena_webapp_postcss_config_js",
+      "label": "postcss.config.js",
+      "norm_label": "postcss.config.js",
+      "source_file": "packages/athena-webapp/postcss.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 915,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
@@ -69160,7 +69436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -69169,7 +69445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -69178,7 +69454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -69187,57 +69463,12 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
       "norm_label": "themetoggle.tsx",
       "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 915,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
-      "label": "DefaultAttributesToggleGroup.tsx",
-      "norm_label": "defaultattributestogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 916,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
-      "label": "ProductAttributesView.tsx",
-      "norm_label": "productattributesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 917,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 918,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -69306,6 +69537,51 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
+      "label": "DefaultAttributesToggleGroup.tsx",
+      "norm_label": "defaultattributestogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
+      "label": "ProductAttributesView.tsx",
+      "norm_label": "productattributesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 922,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 923,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 924,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 925,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -69313,7 +69589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -69322,7 +69598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -69331,7 +69607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -69340,57 +69616,12 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
       "norm_label": "analytics-columns.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 925,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 926,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 927,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 928,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -69459,6 +69690,51 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 932,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 933,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 934,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 935,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -69466,7 +69742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -69475,7 +69751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -69484,7 +69760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -69493,57 +69769,12 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 935,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 936,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 937,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 938,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
-      "label": "chart.tsx",
-      "norm_label": "chart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -69603,6 +69834,51 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 942,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 943,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
+      "label": "chart.tsx",
+      "norm_label": "chart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 944,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 945,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -69610,7 +69886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -69619,7 +69895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -69628,7 +69904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -69637,57 +69913,12 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 945,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 946,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 947,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 948,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -69747,6 +69978,51 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 952,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 953,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 954,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 955,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -69754,7 +70030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -69763,7 +70039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -69772,7 +70048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -69781,57 +70057,12 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 955,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 956,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 957,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
-      "label": "app-sidebar.tsx",
-      "norm_label": "app-sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 958,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
-      "label": "assetsColumns.tsx",
-      "norm_label": "assetscolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -69891,6 +70122,51 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 962,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
+      "label": "app-sidebar.tsx",
+      "norm_label": "app-sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 963,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
+      "label": "assetsColumns.tsx",
+      "norm_label": "assetscolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 964,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 965,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -69898,7 +70174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -69907,7 +70183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -69916,7 +70192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -69925,57 +70201,12 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
       "norm_label": "defaultcatchboundary.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 965,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
-      "label": "InputOTP.test.tsx",
-      "norm_label": "inputotp.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 966,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
-      "label": "LoginForm.test.tsx",
-      "norm_label": "loginform.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 967,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
-      "label": "LoginForm.tsx",
-      "norm_label": "loginform.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 968,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-column-header.tsx",
       "source_location": "L1"
     },
     {
@@ -70035,6 +70266,51 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
+      "label": "InputOTP.test.tsx",
+      "norm_label": "inputotp.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
+      "label": "LoginForm.test.tsx",
+      "norm_label": "loginform.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 972,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
+      "label": "LoginForm.tsx",
+      "norm_label": "loginform.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 973,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 974,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 975,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -70042,7 +70318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -70051,7 +70327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -70060,7 +70336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -70069,57 +70345,12 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/base/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 975,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 976,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 977,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 978,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
-      "label": "BulkOperationsPage.tsx",
-      "norm_label": "bulkoperationspage.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
       "source_location": "L1"
     },
     {
@@ -70179,6 +70410,51 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 982,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 983,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 984,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
+      "label": "BulkOperationsPage.tsx",
+      "norm_label": "bulkoperationspage.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 985,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
       "norm_label": "cashcontrolsdashboard.auth.test.tsx",
@@ -70186,7 +70462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -70195,7 +70471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registercloseoutview_test_tsx",
       "label": "RegisterCloseoutView.test.tsx",
@@ -70204,7 +70480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
@@ -70213,57 +70489,12 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
       "norm_label": "registersessionview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 985,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/cashiers/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 986,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 987,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 988,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
-      "label": "MetricCard.tsx",
-      "norm_label": "metriccard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
       "source_location": "L1"
     },
     {
@@ -70323,6 +70554,51 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/cashiers/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 992,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 993,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 994,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
+      "label": "MetricCard.tsx",
+      "norm_label": "metriccard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 995,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
       "norm_label": "operationsqueueview.auth.test.tsx",
@@ -70330,7 +70606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -70339,7 +70615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -70348,7 +70624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -70357,57 +70633,12 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
       "norm_label": "orderstatus.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 995,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 996,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
-      "label": "Orders.tsx",
-      "norm_label": "orders.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 997,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
-      "label": "ReturnExchangeView.test.tsx",
-      "norm_label": "returnexchangeview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1473
-- Graph nodes: 3644
-- Graph edges: 3134
+- Graph nodes: 3655
+- Graph edges: 3145
 - Communities: 1388
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 32) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 230) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 231) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 32) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 32) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 32) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/docs/agent/validation-guide.md
+++ b/packages/athena-webapp/docs/agent/validation-guide.md
@@ -82,7 +82,7 @@ Reach for the package suite first, then typecheck when helpers or shared state c
 
 ## Frontend test harness edits
 
-Touched surfaces: `src/test`, `src/tests`
+Touched surfaces: `src/test`, `src/tests`, `vitest.setup.ts`
 
 Run:
 

--- a/packages/athena-webapp/docs/agent/validation-map.json
+++ b/packages/athena-webapp/docs/agent/validation-map.json
@@ -172,7 +172,8 @@
       "name": "frontend-test-harness-edits",
       "pathPrefixes": [
         "packages/athena-webapp/src/test",
-        "packages/athena-webapp/src/tests"
+        "packages/athena-webapp/src/tests",
+        "packages/athena-webapp/vitest.setup.ts"
       ],
       "commands": [
         {

--- a/packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx
@@ -46,6 +46,45 @@ const baseProps = {
   ],
 };
 
+async function chooseSelectOption(
+  user: ReturnType<typeof userEvent.setup>,
+  label: RegExp,
+  option: RegExp
+) {
+  await user.click(screen.getByRole("combobox", { name: label }));
+  await user.click(await screen.findByRole("option", { name: option }));
+}
+
+async function chooseDateTime(
+  user: ReturnType<typeof userEvent.setup>,
+  label: RegExp,
+  hours: string,
+  minutes: string
+) {
+  await user.click(screen.getByLabelText(label));
+
+  const dayCell = (await screen.findAllByRole("gridcell")).find((cell) =>
+    /^\d+$/.test((cell.textContent ?? "").trim())
+  );
+
+  if (!dayCell) {
+    throw new Error("No calendar day button found.");
+  }
+
+  const dayButton = dayCell.querySelector("button");
+
+  if (dayButton) {
+    await user.click(dayButton);
+  } else {
+    await user.click(dayCell);
+  }
+  await user.clear(screen.getByPlaceholderText("HH"));
+  await user.type(screen.getByPlaceholderText("HH"), hours);
+  await user.clear(screen.getByPlaceholderText("MM"));
+  await user.type(screen.getByPlaceholderText("MM"), minutes);
+  await user.click(screen.getByRole("button", { name: /done/i }));
+}
+
 describe("ServiceAppointmentsViewContent", () => {
   beforeEach(() => {
     window.scrollTo = vi.fn();
@@ -84,9 +123,9 @@ describe("ServiceAppointmentsViewContent", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /use customer/i }));
-    await user.selectOptions(screen.getByLabelText(/service catalog/i), "catalog-1");
-    await user.selectOptions(screen.getByLabelText(/assigned staff/i), "staff-1");
-    await user.type(screen.getByLabelText(/appointment start/i), "2026-05-01T10:00");
+    await chooseSelectOption(user, /service catalog/i, /closure repair/i);
+    await chooseSelectOption(user, /assigned staff/i, /adjoa tetteh/i);
+    await chooseDateTime(user, /appointment start/i, "10", "00");
     await user.click(screen.getByRole("button", { name: /schedule appointment/i }));
 
     await waitFor(() => expect(onCreateAppointment).toHaveBeenCalledTimes(1));
@@ -113,10 +152,7 @@ describe("ServiceAppointmentsViewContent", () => {
       />,
     );
 
-    await user.type(
-      screen.getByLabelText(/new time for closure repair/i),
-      "2026-05-02T12:30",
-    );
+    await chooseDateTime(user, /new time for closure repair/i, "12", "30");
     await user.click(screen.getByRole("button", { name: /reschedule closure repair/i }));
 
     await waitFor(() => expect(onRescheduleAppointment).toHaveBeenCalledTimes(1));

--- a/packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx
@@ -7,8 +7,16 @@ import { EmptyState } from "../states/empty/empty-state";
 import { NoPermissionView } from "../states/no-permission/NoPermissionView";
 import { ProtectedAdminSignInView } from "../states/signed-out/ProtectedAdminSignInView";
 import { Button } from "../ui/button";
+import { DateTimePicker } from "../ui/date-time-picker";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
 import { api } from "~/convex/_generated/api";
 
@@ -77,6 +85,14 @@ const initialFormState = {
 function parseDateTimeLocal(value: string) {
   const timestamp = new Date(value).getTime();
   return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function formatDateTimeLocal(value: Date) {
+  const pad = (part: number) => part.toString().padStart(2, "0");
+
+  return `${value.getFullYear()}-${pad(value.getMonth() + 1)}-${pad(
+    value.getDate()
+  )}T${pad(value.getHours())}:${pad(value.getMinutes())}`;
 }
 
 export function ServiceAppointmentsViewContent({
@@ -216,60 +232,64 @@ export function ServiceAppointmentsViewContent({
 
           <div className="space-y-2">
             <Label htmlFor="service-catalog">Service catalog</Label>
-            <select
-              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-              id="service-catalog"
-              onChange={(event) =>
+            <Select
+              onValueChange={(value) =>
                 setForm((current) => ({
                   ...current,
-                  serviceCatalogId: event.target.value,
+                  serviceCatalogId: value,
                 }))
               }
               value={form.serviceCatalogId}
             >
-              <option value="">Select service</option>
-              {catalogItems.map((item) => (
-                <option key={item._id} value={item._id}>
-                  {item.name}
-                </option>
-              ))}
-            </select>
+              <SelectTrigger aria-label="Service catalog" id="service-catalog">
+                <SelectValue placeholder="Select service" />
+              </SelectTrigger>
+              <SelectContent>
+                {catalogItems.map((item) => (
+                  <SelectItem key={item._id} value={item._id}>
+                    {item.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
           <div className="space-y-2">
             <Label htmlFor="assigned-staff">Assigned staff</Label>
-            <select
-              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-              id="assigned-staff"
-              onChange={(event) =>
+            <Select
+              onValueChange={(value) =>
                 setForm((current) => ({
                   ...current,
-                  assignedStaffProfileId: event.target.value,
+                  assignedStaffProfileId: value,
                 }))
               }
               value={form.assignedStaffProfileId}
             >
-              <option value="">Select staff member</option>
-              {staffOptions.map((staff) => (
-                <option key={staff._id} value={staff._id}>
-                  {staff.fullName}
-                </option>
-              ))}
-            </select>
+              <SelectTrigger aria-label="Assigned staff" id="assigned-staff">
+                <SelectValue placeholder="Select staff member" />
+              </SelectTrigger>
+              <SelectContent>
+                {staffOptions.map((staff) => (
+                  <SelectItem key={staff._id} value={staff._id}>
+                    {staff.fullName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
           <div className="space-y-2">
             <Label htmlFor="appointment-start">Appointment start</Label>
-            <Input
+            <DateTimePicker
               id="appointment-start"
-              onChange={(event) =>
+              onChange={(value) =>
                 setForm((current) => ({
                   ...current,
-                  startAt: event.target.value,
+                  startAt: value ? formatDateTimeLocal(value) : "",
                 }))
               }
-              type="datetime-local"
-              value={form.startAt}
+              placeholder="Choose an appointment start time"
+              value={form.startAt ? new Date(form.startAt) : undefined}
             />
           </div>
 
@@ -328,16 +348,20 @@ export function ServiceAppointmentsViewContent({
                   <Label htmlFor={`reschedule-${appointment._id}`}>
                     {`New time for ${appointment.serviceCatalogName ?? "appointment"}`}
                   </Label>
-                  <Input
+                  <DateTimePicker
                     id={`reschedule-${appointment._id}`}
-                    onChange={(event) =>
+                    onChange={(value) =>
                       setRescheduleTimes((current) => ({
                         ...current,
-                        [appointment._id]: event.target.value,
+                        [appointment._id]: value ? formatDateTimeLocal(value) : "",
                       }))
                     }
-                    type="datetime-local"
-                    value={rescheduleTimes[appointment._id] ?? ""}
+                    placeholder="Choose a new appointment time"
+                    value={
+                      rescheduleTimes[appointment._id]
+                        ? new Date(rescheduleTimes[appointment._id])
+                        : undefined
+                    }
                   />
                 </div>
 

--- a/packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx
@@ -59,6 +59,15 @@ const baseProps = {
   ],
 };
 
+async function chooseSelectOption(
+  user: ReturnType<typeof userEvent.setup>,
+  label: RegExp,
+  option: RegExp
+) {
+  await user.click(screen.getByRole("combobox", { name: label }));
+  await user.click(await screen.findByRole("option", { name: option }));
+}
+
 describe("ServiceCasesViewContent", () => {
   beforeEach(() => {
     window.scrollTo = vi.fn();
@@ -87,9 +96,9 @@ describe("ServiceCasesViewContent", () => {
 
     await user.click(screen.getByRole("button", { name: /use customer/i }));
     await user.type(screen.getByLabelText(/service title/i), "Closure Repair");
-    await user.selectOptions(screen.getByLabelText(/service mode/i), "repair");
-    await user.selectOptions(screen.getByLabelText(/service catalog/i), "catalog-1");
-    await user.selectOptions(screen.getByLabelText(/assigned staff/i), "staff-1");
+    await chooseSelectOption(user, /service mode/i, /^repair$/i);
+    await chooseSelectOption(user, /service catalog/i, /closure repair/i);
+    await chooseSelectOption(user, /assigned staff/i, /adjoa tetteh/i);
     await user.type(screen.getByLabelText(/quoted amount/i), "450");
     await user.click(screen.getByRole("button", { name: /create service case/i }));
 
@@ -124,7 +133,7 @@ describe("ServiceCasesViewContent", () => {
     expect(screen.getByText("1 pending approval")).toBeInTheDocument();
 
     await user.type(screen.getByLabelText(/payment amount/i), "75");
-    await user.selectOptions(screen.getByLabelText(/payment method/i), "card");
+    await chooseSelectOption(user, /payment method/i, /^card$/i);
     await user.click(screen.getByRole("button", { name: /record payment/i }));
     expect(onRecordPayment).toHaveBeenCalledWith({
       amount: 75,
@@ -154,7 +163,7 @@ describe("ServiceCasesViewContent", () => {
       usageType: "consumed",
     });
 
-    await user.selectOptions(screen.getByLabelText(/case status/i), "awaiting_pickup");
+    await chooseSelectOption(user, /case status/i, /awaiting pickup/i);
     await user.click(screen.getByRole("button", { name: /update status/i }));
     expect(onUpdateStatus).toHaveBeenCalledWith({
       serviceCaseId: "case-1",

--- a/packages/athena-webapp/src/components/services/ServiceCasesView.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCasesView.tsx
@@ -9,6 +9,13 @@ import { ProtectedAdminSignInView } from "../states/signed-out/ProtectedAdminSig
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
 import { api } from "~/convex/_generated/api";
 
@@ -287,66 +294,73 @@ export function ServiceCasesViewContent({
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
               <Label htmlFor="case-service-mode">Service mode</Label>
-              <select
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="case-service-mode"
-                onChange={(event) =>
+              <Select
+                onValueChange={(value) =>
                   setCreateForm((current) => ({
                     ...current,
-                    serviceMode: event.target.value as CreateServiceCaseArgs["serviceMode"],
+                    serviceMode: value as CreateServiceCaseArgs["serviceMode"],
                   }))
                 }
                 value={createForm.serviceMode}
               >
-                <option value="same_day">Same-day</option>
-                <option value="consultation">Consultation</option>
-                <option value="repair">Repair</option>
-                <option value="revamp">Revamp</option>
-              </select>
+                <SelectTrigger aria-label="Service mode" id="case-service-mode">
+                  <SelectValue placeholder="Select service mode" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="same_day">Same-day</SelectItem>
+                  <SelectItem value="consultation">Consultation</SelectItem>
+                  <SelectItem value="repair">Repair</SelectItem>
+                  <SelectItem value="revamp">Revamp</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="case-service-catalog">Service catalog</Label>
-              <select
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="case-service-catalog"
-                onChange={(event) =>
+              <Select
+                onValueChange={(value) =>
                   setCreateForm((current) => ({
                     ...current,
-                    serviceCatalogId: event.target.value,
+                    serviceCatalogId: value,
                   }))
                 }
                 value={createForm.serviceCatalogId}
               >
-                <option value="">Optional catalog item</option>
-                {catalogItems.map((item) => (
-                  <option key={item._id} value={item._id}>
-                    {item.name}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger aria-label="Service catalog" id="case-service-catalog">
+                  <SelectValue placeholder="Optional catalog item" />
+                </SelectTrigger>
+                <SelectContent>
+                  {catalogItems.map((item) => (
+                    <SelectItem key={item._id} value={item._id}>
+                      {item.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="case-assigned-staff">Assigned staff</Label>
-              <select
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="case-assigned-staff"
-                onChange={(event) =>
+              <Select
+                onValueChange={(value) =>
                   setCreateForm((current) => ({
                     ...current,
-                    assignedStaffProfileId: event.target.value,
+                    assignedStaffProfileId: value,
                   }))
                 }
                 value={createForm.assignedStaffProfileId}
               >
-                <option value="">Select staff member</option>
-                {staffOptions.map((staff) => (
-                  <option key={staff._id} value={staff._id}>
-                    {staff.fullName}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger aria-label="Assigned staff" id="case-assigned-staff">
+                  <SelectValue placeholder="Select staff member" />
+                </SelectTrigger>
+                <SelectContent>
+                  {staffOptions.map((staff) => (
+                    <SelectItem key={staff._id} value={staff._id}>
+                      {staff.fullName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="space-y-2">
@@ -453,21 +467,24 @@ export function ServiceCasesViewContent({
                     </div>
                     <div className="space-y-2">
                       <Label htmlFor="payment-method">Payment method</Label>
-                      <select
-                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                        id="payment-method"
-                        onChange={(event) =>
+                      <Select
+                        onValueChange={(value) =>
                           setPaymentForm((current) => ({
                             ...current,
-                            method: event.target.value,
+                            method: value,
                           }))
                         }
                         value={paymentForm.method}
                       >
-                        <option value="cash">Cash</option>
-                        <option value="card">Card</option>
-                        <option value="mobile_money">Mobile money</option>
-                      </select>
+                        <SelectTrigger aria-label="Payment method" id="payment-method">
+                          <SelectValue placeholder="Select payment method" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="cash">Cash</SelectItem>
+                          <SelectItem value="card">Card</SelectItem>
+                          <SelectItem value="mobile_money">Mobile money</SelectItem>
+                        </SelectContent>
+                      </Select>
                     </div>
                     <Button
                       onClick={() =>
@@ -488,18 +505,22 @@ export function ServiceCasesViewContent({
                     <h4 className="font-medium">Case status</h4>
                     <div className="space-y-2">
                       <Label htmlFor="case-status">Case status</Label>
-                      <select
-                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                        id="case-status"
-                        onChange={(event) => setStatusValue(event.target.value)}
-                        value={statusValue}
-                      >
-                        <option value="in_progress">In progress</option>
-                        <option value="awaiting_approval">Awaiting approval</option>
-                        <option value="awaiting_pickup">Awaiting pickup</option>
-                        <option value="completed">Completed</option>
-                        <option value="cancelled">Cancelled</option>
-                      </select>
+                      <Select onValueChange={setStatusValue} value={statusValue}>
+                        <SelectTrigger aria-label="Case status" id="case-status">
+                          <SelectValue placeholder="Select case status" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="in_progress">In progress</SelectItem>
+                          <SelectItem value="awaiting_approval">
+                            Awaiting approval
+                          </SelectItem>
+                          <SelectItem value="awaiting_pickup">
+                            Awaiting pickup
+                          </SelectItem>
+                          <SelectItem value="completed">Completed</SelectItem>
+                          <SelectItem value="cancelled">Cancelled</SelectItem>
+                        </SelectContent>
+                      </Select>
                     </div>
                     <Button
                       onClick={() =>

--- a/packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx
@@ -25,6 +25,15 @@ const baseProps = {
   onUpdate: vi.fn().mockResolvedValue(undefined),
 };
 
+async function chooseSelectOption(
+  user: ReturnType<typeof userEvent.setup>,
+  label: RegExp,
+  option: RegExp
+) {
+  await user.click(screen.getByRole("combobox", { name: label }));
+  await user.click(await screen.findByRole("option", { name: option }));
+}
+
 describe("ServiceCatalogViewContent", () => {
   beforeEach(() => {
     window.scrollTo = vi.fn();
@@ -63,8 +72,8 @@ describe("ServiceCatalogViewContent", () => {
     await user.type(screen.getByLabelText(/service name/i), "Wash and Restyle");
     await user.clear(screen.getByLabelText(/duration/i));
     await user.type(screen.getByLabelText(/duration/i), "75");
-    await user.selectOptions(screen.getByLabelText(/service mode/i), "same_day");
-    await user.selectOptions(screen.getByLabelText(/deposit rule/i), "flat");
+    await chooseSelectOption(user, /service mode/i, /^same-day$/i);
+    await chooseSelectOption(user, /deposit rule/i, /flat deposit/i);
     await user.clear(screen.getByLabelText(/deposit value/i));
     await user.type(screen.getByLabelText(/deposit value/i), "45");
     await user.clear(screen.getByLabelText(/base price/i));

--- a/packages/athena-webapp/src/components/services/ServiceCatalogView.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCatalogView.tsx
@@ -9,6 +9,13 @@ import { ProtectedAdminSignInView } from "../states/signed-out/ProtectedAdminSig
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 import { Textarea } from "../ui/textarea";
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
 import { api } from "~/convex/_generated/api";
@@ -243,41 +250,49 @@ export function ServiceCatalogViewContent({
 
             <div className="space-y-2">
               <Label htmlFor="service-mode">Service mode</Label>
-              <select
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="service-mode"
-                onChange={(event) =>
+              <Select
+                onValueChange={(value) =>
                   handleChange(
                     "serviceMode",
-                    event.target.value as ServiceCatalogFormState["serviceMode"]
+                    value as ServiceCatalogFormState["serviceMode"]
                   )
                 }
                 value={form.serviceMode}
               >
-                <option value="same_day">Same-day</option>
-                <option value="consultation">Consultation</option>
-                <option value="repair">Repair</option>
-                <option value="revamp">Revamp</option>
-              </select>
+                <SelectTrigger aria-label="Service mode" id="service-mode">
+                  <SelectValue placeholder="Select service mode" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="same_day">Same-day</SelectItem>
+                  <SelectItem value="consultation">Consultation</SelectItem>
+                  <SelectItem value="repair">Repair</SelectItem>
+                  <SelectItem value="revamp">Revamp</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="pricing-model">Pricing model</Label>
-              <select
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="pricing-model"
-                onChange={(event) =>
+              <Select
+                onValueChange={(value) =>
                   handleChange(
                     "pricingModel",
-                    event.target.value as ServiceCatalogFormState["pricingModel"]
+                    value as ServiceCatalogFormState["pricingModel"]
                   )
                 }
                 value={form.pricingModel}
               >
-                <option value="fixed">Fixed</option>
-                <option value="starting_at">Starting at</option>
-                <option value="quote_after_consultation">Quote after consultation</option>
-              </select>
+                <SelectTrigger aria-label="Pricing model" id="pricing-model">
+                  <SelectValue placeholder="Select pricing model" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="fixed">Fixed</SelectItem>
+                  <SelectItem value="starting_at">Starting at</SelectItem>
+                  <SelectItem value="quote_after_consultation">
+                    Quote after consultation
+                  </SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="space-y-2">
@@ -292,21 +307,24 @@ export function ServiceCatalogViewContent({
 
             <div className="space-y-2">
               <Label htmlFor="deposit-rule">Deposit rule</Label>
-              <select
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="deposit-rule"
-                onChange={(event) =>
+              <Select
+                onValueChange={(value) =>
                   handleChange(
                     "depositType",
-                    event.target.value as ServiceCatalogFormState["depositType"]
+                    value as ServiceCatalogFormState["depositType"]
                   )
                 }
                 value={form.depositType}
               >
-                <option value="none">No deposit</option>
-                <option value="flat">Flat deposit</option>
-                <option value="percentage">Percentage deposit</option>
-              </select>
+                <SelectTrigger aria-label="Deposit rule" id="deposit-rule">
+                  <SelectValue placeholder="Select deposit rule" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">No deposit</SelectItem>
+                  <SelectItem value="flat">Flat deposit</SelectItem>
+                  <SelectItem value="percentage">Percentage deposit</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="space-y-2">

--- a/packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx
@@ -1,6 +1,13 @@
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 import { Textarea } from "../ui/textarea";
 
 export type ServiceIntakeCustomerResult = {
@@ -183,59 +190,62 @@ export function ServiceIntakeForm({
 
             <div className="space-y-2">
               <Label htmlFor="assigned-staff">Assigned staff</Label>
-              <select
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="assigned-staff"
-                onChange={(event) =>
-                  onChange("assignedStaffProfileId", event.target.value)
-                }
+              <Select
+                onValueChange={(value) => onChange("assignedStaffProfileId", value)}
                 value={form.assignedStaffProfileId}
               >
-                <option value="">Select staff member</option>
-                {staffOptions.map((staff) => (
-                  <option key={staff._id} value={staff._id}>
-                    {staff.fullName}
-                    {staff.roles.length > 0 ? ` · ${staff.roles.join(", ")}` : ""}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger aria-label="Assigned staff" id="assigned-staff">
+                  <SelectValue placeholder="Select staff member" />
+                </SelectTrigger>
+                <SelectContent>
+                  {staffOptions.map((staff) => (
+                    <SelectItem key={staff._id} value={staff._id}>
+                      {staff.fullName}
+                      {staff.roles.length > 0 ? ` · ${staff.roles.join(", ")}` : ""}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="intake-channel">Channel</Label>
-              <select
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="intake-channel"
-                onChange={(event) =>
+              <Select
+                onValueChange={(value) =>
                   onChange(
                     "intakeChannel",
-                    event.target.value as ServiceIntakeFormState["intakeChannel"]
+                    value as ServiceIntakeFormState["intakeChannel"]
                   )
                 }
                 value={form.intakeChannel}
               >
-                <option value="walk_in">Walk-in</option>
-                <option value="phone_booking">Phone booking</option>
-              </select>
+                <SelectTrigger aria-label="Channel" id="intake-channel">
+                  <SelectValue placeholder="Select channel" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="walk_in">Walk-in</SelectItem>
+                  <SelectItem value="phone_booking">Phone booking</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="priority">Priority</Label>
-              <select
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="priority"
-                onChange={(event) =>
-                  onChange(
-                    "priority",
-                    event.target.value as ServiceIntakeFormState["priority"]
-                  )
+              <Select
+                onValueChange={(value) =>
+                  onChange("priority", value as ServiceIntakeFormState["priority"])
                 }
                 value={form.priority}
               >
-                <option value="normal">Normal</option>
-                <option value="high">High</option>
-                <option value="urgent">Urgent</option>
-              </select>
+                <SelectTrigger aria-label="Priority" id="priority">
+                  <SelectValue placeholder="Select priority" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="normal">Normal</SelectItem>
+                  <SelectItem value="high">High</SelectItem>
+                  <SelectItem value="urgent">Urgent</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="space-y-2">
@@ -251,17 +261,19 @@ export function ServiceIntakeForm({
 
             <div className="space-y-2 sm:col-span-2">
               <Label htmlFor="deposit-method">Deposit method</Label>
-              <select
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                id="deposit-method"
-                onChange={(event) => onChange("depositMethod", event.target.value)}
+              <Select
+                onValueChange={(value) => onChange("depositMethod", value)}
                 value={form.depositMethod}
               >
-                <option value="">No deposit collected</option>
-                <option value="cash">Cash</option>
-                <option value="card">Card</option>
-                <option value="mobile_money">Mobile money</option>
-              </select>
+                <SelectTrigger aria-label="Deposit method" id="deposit-method">
+                  <SelectValue placeholder="No deposit collected" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="cash">Cash</SelectItem>
+                  <SelectItem value="card">Card</SelectItem>
+                  <SelectItem value="mobile_money">Mobile money</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="space-y-2 sm:col-span-2">

--- a/packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx
@@ -37,6 +37,15 @@ const baseProps = {
   userId: "user-1" as Id<"athenaUser">,
 };
 
+async function chooseSelectOption(
+  user: ReturnType<typeof userEvent.setup>,
+  label: RegExp,
+  option: RegExp
+) {
+  await user.click(screen.getByRole("combobox", { name: label }));
+  await user.click(await screen.findByRole("option", { name: option }));
+}
+
 describe("ServiceIntakeViewContent", () => {
   beforeEach(() => {
     window.scrollTo = vi.fn();
@@ -88,17 +97,11 @@ describe("ServiceIntakeViewContent", () => {
       screen.getByLabelText(/service title/i),
       "Wash and restyle closure wig",
     );
-    await user.selectOptions(
-      screen.getByLabelText(/assigned staff/i),
-      "staff-1",
-    );
+    await chooseSelectOption(user, /assigned staff/i, /adjoa tetteh/i);
     await user.type(screen.getByLabelText(/deposit amount/i), "45");
-    await user.selectOptions(screen.getByLabelText(/deposit method/i), "card");
-    await user.selectOptions(screen.getByLabelText(/priority/i), "urgent");
-    await user.selectOptions(
-      screen.getByLabelText(/channel/i),
-      "phone_booking",
-    );
+    await chooseSelectOption(user, /deposit method/i, /^card$/i);
+    await chooseSelectOption(user, /priority/i, /^urgent$/i);
+    await chooseSelectOption(user, /channel/i, /phone booking/i);
     await user.type(
       screen.getByLabelText(/item description/i),
       "Customer dropped off closure wig with tangling at the crown.",

--- a/packages/athena-webapp/src/components/ui/date-time-picker.tsx
+++ b/packages/athena-webapp/src/components/ui/date-time-picker.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 
 interface DateTimePickerProps {
+  id?: string;
   value?: Date;
   onChange: (date: Date | undefined) => void;
   placeholder?: string;
@@ -19,6 +20,7 @@ interface DateTimePickerProps {
 }
 
 export function DateTimePicker({
+  id,
   value,
   onChange,
   placeholder = "Pick a date and time",
@@ -40,7 +42,12 @@ export function DateTimePicker({
       setSelectedDate(value);
       setHours(value.getHours().toString().padStart(2, "0"));
       setMinutes(value.getMinutes().toString().padStart(2, "0"));
+      return;
     }
+
+    setSelectedDate(undefined);
+    setHours("00");
+    setMinutes("00");
   }, [value]);
 
   const handleDateSelect = (date: Date | undefined) => {
@@ -100,6 +107,7 @@ export function DateTimePicker({
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
         <Button
+          id={id}
           variant="outline"
           className={cn(
             "w-full justify-start text-left font-normal",

--- a/packages/athena-webapp/vitest.setup.ts
+++ b/packages/athena-webapp/vitest.setup.ts
@@ -20,6 +20,25 @@ vi.mock("convex/react", () => ({
 
 // Only run browser-specific mocks when a window object exists (e.g. jsdom).
 if (typeof window !== "undefined") {
+  const pointerCaptureStub = () => false;
+  const pointerReleaseStub = () => undefined;
+
+  if (!HTMLElement.prototype.hasPointerCapture) {
+    HTMLElement.prototype.hasPointerCapture = pointerCaptureStub;
+  }
+
+  if (!HTMLElement.prototype.setPointerCapture) {
+    HTMLElement.prototype.setPointerCapture = pointerReleaseStub;
+  }
+
+  if (!HTMLElement.prototype.releasePointerCapture) {
+    HTMLElement.prototype.releasePointerCapture = pointerReleaseStub;
+  }
+
+  if (!HTMLElement.prototype.scrollIntoView) {
+    HTMLElement.prototype.scrollIntoView = pointerReleaseStub;
+  }
+
   // Mock window.print for receipt printing tests
   Object.defineProperty(window, "print", {
     value: vi.fn(),

--- a/scripts/harness-app-registry.test.ts
+++ b/scripts/harness-app-registry.test.ts
@@ -182,6 +182,22 @@ describe("HARNESS_APP_REGISTRY", () => {
     });
   });
 
+  it("covers Athena frontend test harness surfaces including vitest setup", () => {
+    const athena = HARNESS_APP_REGISTRY.find(
+      (entry) => entry.appName === "athena-webapp"
+    );
+    const frontendHarnessScenario = athena?.validationScenarios.find(
+      (scenario) => scenario.title === "Frontend test harness edits"
+    );
+
+    expect(frontendHarnessScenario).toMatchObject({
+      touchedPaths: ["src/test", "src/tests", "vitest.setup.ts"],
+      commands: [{ kind: "script", script: "test" }],
+      note:
+        "Run the package suite when package-local frontend test helpers or focused regression tests change.",
+    });
+  });
+
   it("documents Athena service management as a first-class harness discovery surface", () => {
     const athena = HARNESS_APP_REGISTRY.find(
       (entry) => entry.appName === "athena-webapp"

--- a/scripts/harness-app-registry.ts
+++ b/scripts/harness-app-registry.ts
@@ -401,7 +401,7 @@ export const HARNESS_APP_REGISTRY = [
       },
       {
         title: "Frontend test harness edits",
-        touchedPaths: ["src/test", "src/tests"],
+        touchedPaths: ["src/test", "src/tests", "vitest.setup.ts"],
         commands: [{ kind: "script", script: "test" }],
         note: "Run the package suite when package-local frontend test helpers or focused regression tests change.",
       },

--- a/scripts/harness-audit.test.ts
+++ b/scripts/harness-audit.test.ts
@@ -567,6 +567,7 @@ async function createFixtureRepo() {
     "export {};\n",
     rootDir
   );
+  await write("packages/athena-webapp/vitest.setup.ts", "export {};\n", rootDir);
   await write("packages/athena-webapp/src/routes/_authed/index.tsx", "export {};\n", rootDir);
   await write(
     "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",


### PR DESCRIPTION
## Summary
- swap the services intake, appointments, cases, and catalog forms onto the shared Select primitive
- replace appointment scheduling and rescheduling datetime-local inputs with the shared DateTimePicker
- update service tests and Vitest DOM shims so the shared control stack is exercised reliably

## Why
- keep the services section visually consistent with Athena's shared UI library
- remove handwritten/default control surfaces without changing service workflow behavior
- keep graphify artifacts current after the code changes

## Validation
- bun run --filter '@athena/webapp' test src/components/services/ServiceIntakeView.test.tsx src/components/services/ServiceAppointmentsView.test.tsx src/components/services/ServiceCasesView.test.tsx src/components/services/ServiceCatalogView.test.tsx
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run graphify:rebuild
- git diff --check

Linear: https://linear.app/v26-labs/issue/V26-339/normalize-services-form-controls-onto-shared-ui-primitives