### PR TITLE
[V26-347]: keep edit usernames derived and read-only

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -19295,7 +19295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
-      "source_location": "L114",
+      "source_location": "L125",
       "target": "staffmanagement_test_chooserole",
       "weight": 1
     },
@@ -19321,6 +19321,18 @@
       "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
       "source_location": "L88",
       "target": "staffmanagement_buildusername",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
+      "_tgt": "staffmanagement_credentialpindialog",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L541",
+      "target": "staffmanagement_credentialpindialog",
       "weight": 1
     },
     {
@@ -19373,38 +19385,14 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
-      "_tgt": "staffmanagement_handlepinkeydown",
+      "_tgt": "staffmanagement_handledeactivate",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
       "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L572",
-      "target": "staffmanagement_handlepinkeydown",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
-      "_tgt": "staffmanagement_handlesubmit",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L590",
-      "target": "staffmanagement_handlesubmit",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
-      "_tgt": "staffmanagement_if",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L735",
-      "target": "staffmanagement_if",
+      "source_location": "L733",
+      "target": "staffmanagement_handledeactivate",
       "weight": 1
     },
     {
@@ -19417,6 +19405,18 @@
       "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
       "source_location": "L80",
       "target": "staffmanagement_normalizenamesegment",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
+      "_tgt": "staffmanagement_staffprovisionform",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L194",
+      "target": "staffmanagement_staffprovisionform",
       "weight": 1
     },
     {
@@ -53641,7 +53641,7 @@
       "label": "chooseRole()",
       "norm_label": "chooserole()",
       "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
-      "source_location": "L114"
+      "source_location": "L125"
     },
     {
       "community": 290,
@@ -60162,6 +60162,15 @@
     {
       "community": 48,
       "file_type": "code",
+      "id": "staffmanagement_credentialpindialog",
+      "label": "CredentialPinDialog()",
+      "norm_label": "credentialpindialog()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L541"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
       "id": "staffmanagement_credentialstatusbadge",
       "label": "CredentialStatusBadge()",
       "norm_label": "credentialstatusbadge()",
@@ -60198,29 +60207,11 @@
     {
       "community": 48,
       "file_type": "code",
-      "id": "staffmanagement_handlepinkeydown",
-      "label": "handlePinKeyDown()",
-      "norm_label": "handlepinkeydown()",
+      "id": "staffmanagement_handledeactivate",
+      "label": "handleDeactivate()",
+      "norm_label": "handledeactivate()",
       "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L572"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "staffmanagement_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L344"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "staffmanagement_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
-      "source_location": "L735"
+      "source_location": "L733"
     },
     {
       "community": 48,
@@ -60230,6 +60221,15 @@
       "norm_label": "normalizenamesegment()",
       "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
       "source_location": "L80"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "staffmanagement_staffprovisionform",
+      "label": "StaffProvisionForm()",
+      "norm_label": "staffprovisionform()",
+      "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.tsx",
+      "source_location": "L194"
     },
     {
       "community": 480,

--- a/packages/athena-webapp/src/components/staff/StaffManagement.test.tsx
+++ b/packages/athena-webapp/src/components/staff/StaffManagement.test.tsx
@@ -73,6 +73,10 @@ function mockConvex({
   staffProfiles?: typeof defaultStaffProfiles;
   usernameAvailability?:
     | { available: boolean; normalizedUsername: string }
+    | ((args: { storeId: string; username: string }) => {
+        available: boolean;
+        normalizedUsername: string;
+      })
     | undefined;
 } = {}) {
   mockedUseQuery.mockImplementation((...[_reference, args]) => {
@@ -81,6 +85,13 @@ function mockConvex({
     }
 
     if (args && typeof args === "object" && "username" in args) {
+      if (typeof usernameAvailability === "function") {
+        return usernameAvailability({
+          storeId: args.storeId as string,
+          username: args.username as string,
+        }) as never;
+      }
+
       return usernameAvailability as never;
     }
 
@@ -214,7 +225,12 @@ describe("StaffManagement", () => {
   });
 
   it("edits an existing staff profile from the roster", async () => {
-    mockConvex();
+    mockConvex({
+      usernameAvailability: ({ username }) => ({
+        available: true,
+        normalizedUsername: username,
+      }),
+    });
     const user = userEvent.setup();
 
     render(
@@ -228,7 +244,15 @@ describe("StaffManagement", () => {
 
     const firstNameInput = screen.getByLabelText(/first name/i);
     await user.clear(firstNameInput);
-    await user.type(firstNameInput, "Afi");
+    await user.type(firstNameInput, "Kojo");
+
+    const lastNameInput = screen.getByLabelText(/last name/i);
+    await user.clear(lastNameInput);
+    await user.type(lastNameInput, "Badu");
+
+    const usernameInput = screen.getByLabelText(/username/i);
+    expect(usernameInput).toHaveAttribute("readonly");
+    await waitFor(() => expect(usernameInput).toHaveValue("kbadu"));
 
     const emailInput = screen.getByLabelText(/email/i);
     await user.clear(emailInput);
@@ -240,26 +264,26 @@ describe("StaffManagement", () => {
     await waitFor(() => expect(updateStaffProfile).toHaveBeenCalledTimes(1));
     expect(updateStaffProfile).toHaveBeenCalledWith({
       email: "afi@example.com",
-      firstName: "Afi",
+      firstName: "Kojo",
       hiredAt: new Date("2024-01-15T00:00:00").getTime(),
       jobTitle: "Cashier",
-      lastName: "Mensah",
+      lastName: "Badu",
       organizationId: "org-1",
       phoneNumber: "+233200000000",
       requestedRoles: ["manager"],
       staffCode: undefined,
       staffProfileId: "staff-1",
       storeId: "store-1",
-      username: "amens",
+      username: "kbadu",
     });
   });
 
-  it("blocks edits when a different username is already taken in the store", async () => {
+  it("derives the next available username while editing when the first candidate is taken", async () => {
     mockConvex({
-      usernameAvailability: {
-        available: false,
-        normalizedUsername: "taken",
-      },
+      usernameAvailability: ({ username }) => ({
+        available: username !== "kbadu",
+        normalizedUsername: username,
+      }),
     });
     const user = userEvent.setup();
 
@@ -271,14 +295,16 @@ describe("StaffManagement", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /edit/i }));
-    const usernameInput = screen.getByLabelText(/username/i);
-    await user.clear(usernameInput);
-    await user.type(usernameInput, "taken");
+    const firstNameInput = screen.getByLabelText(/first name/i);
+    await user.clear(firstNameInput);
+    await user.type(firstNameInput, "Kojo");
 
-    expect(
-      await screen.findByText(/username is already in use for this store/i),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /update/i })).toBeDisabled();
-    expect(updateStaffProfile).not.toHaveBeenCalled();
+    const lastNameInput = screen.getByLabelText(/last name/i);
+    await user.clear(lastNameInput);
+    await user.type(lastNameInput, "Badu");
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/username/i)).toHaveValue("kbad2"),
+    );
   });
 });

--- a/packages/athena-webapp/src/components/staff/StaffManagement.tsx
+++ b/packages/athena-webapp/src/components/staff/StaffManagement.tsx
@@ -232,30 +232,35 @@ function StaffProvisionForm({
     api.operations.staffProfiles.updateStaffProfile,
   );
 
+  const initialFirstName = staff?.firstName ?? "";
+  const initialLastName = staff?.lastName ?? "";
   const initialUsername = staff?.username?.trim().toLowerCase() ?? "";
-  const normalizedUsername = username.trim().toLowerCase();
-  const isEditingUsername =
-    mode === "edit" &&
-    normalizedUsername.length > 0 &&
-    normalizedUsername !== initialUsername;
+  const shouldAutoGenerateUsername =
+    mode === "create" ||
+    (mode === "edit" &&
+      (firstName.trim() !== initialFirstName.trim() ||
+        lastName.trim() !== initialLastName.trim()));
 
   const candidateUsername = useMemo(() => {
-    if (mode !== "create" || !isCheckingUsername) {
+    if (!shouldAutoGenerateUsername || !isCheckingUsername) {
       return "";
     }
 
     return buildUsername(firstName, lastName, usernameSuffix);
-  }, [firstName, isCheckingUsername, lastName, mode, usernameSuffix]);
+  }, [
+    firstName,
+    isCheckingUsername,
+    lastName,
+    shouldAutoGenerateUsername,
+    usernameSuffix,
+  ]);
 
   const usernameAvailability = useQuery(
     api.operations.staffCredentials.getStaffCredentialUsernameAvailability,
-    mode === "create"
-      ? candidateUsername
-        ? { storeId, username: candidateUsername }
-        : "skip"
-      : isEditingUsername
-        ? { storeId, username }
-        : "skip",
+    candidateUsername &&
+      !(mode === "edit" && candidateUsername === initialUsername)
+      ? { storeId, username: candidateUsername }
+      : "skip",
   );
 
   useEffect(() => {
@@ -275,7 +280,12 @@ function StaffProvisionForm({
   }, [mode, staff]);
 
   useEffect(() => {
-    if (mode !== "create") {
+    if (!shouldAutoGenerateUsername) {
+      if (mode === "edit") {
+        setUsername(staff?.username ?? "");
+      }
+      setUsernameSuffix(1);
+      setIsCheckingUsername(false);
       return;
     }
 
@@ -292,10 +302,10 @@ function StaffProvisionForm({
     setUsername("");
     setUsernameSuffix(1);
     setIsCheckingUsername(true);
-  }, [firstName, lastName, mode]);
+  }, [firstName, lastName, mode, shouldAutoGenerateUsername, staff]);
 
   useEffect(() => {
-    if (mode !== "create") {
+    if (!shouldAutoGenerateUsername) {
       return;
     }
 
@@ -305,6 +315,12 @@ function StaffProvisionForm({
 
     if (!candidateUsername) {
       setUsername("");
+      setIsCheckingUsername(false);
+      return;
+    }
+
+    if (mode === "edit" && candidateUsername === initialUsername) {
+      setUsername(candidateUsername);
       setIsCheckingUsername(false);
       return;
     }
@@ -320,36 +336,29 @@ function StaffProvisionForm({
     }
 
     setUsernameSuffix((previous) => previous + 1);
-  }, [candidateUsername, isCheckingUsername, mode, usernameAvailability]);
+  }, [
+    candidateUsername,
+    initialUsername,
+    isCheckingUsername,
+    mode,
+    shouldAutoGenerateUsername,
+    usernameAvailability,
+  ]);
 
-  const hasUsernameConflict =
-    mode === "edit" &&
-    isEditingUsername &&
-    usernameAvailability !== undefined &&
-    !usernameAvailability.available;
-
-  const isUsernamePending =
-    mode === "create"
-      ? isCheckingUsername
-      : isEditingUsername && usernameAvailability === undefined;
+  const isUsernamePending = isCheckingUsername;
 
   const isValid =
     firstName.trim() &&
     lastName.trim() &&
     username.trim() &&
     selectedRole &&
-    !isUsernamePending &&
-    !hasUsernameConflict;
+    !isUsernamePending;
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
 
     if (!isValid) {
-      toast.error(
-        hasUsernameConflict
-          ? "Choose a different username for this store."
-          : "Complete the required staff details before saving.",
-      );
+      toast.error("Complete the required staff details before saving.");
       return;
     }
 
@@ -441,23 +450,13 @@ function StaffProvisionForm({
           <Input
             id="staff-username"
             value={isUsernamePending ? "Checking..." : username}
-            readOnly={mode === "create"}
-            className={
-              mode === "create" ? "cursor-not-allowed bg-muted" : undefined
-            }
+            readOnly
+            className="cursor-not-allowed bg-muted"
             disabled={isUsernamePending}
-            onChange={(event) => setUsername(event.target.value)}
           />
           <p className="text-xs text-muted-foreground">
-            {mode === "create"
-              ? "Auto-generated from first and last name"
-              : "Keep the current username or choose a new one"}
+            Auto-generated from first and last name
           </p>
-          {hasUsernameConflict ? (
-            <p className="text-xs text-destructive">
-              Username is already in use for this store
-            </p>
-          ) : null}
         </div>
 
         <div className="space-y-2">


### PR DESCRIPTION
## Summary
- keep the staff username field visible but read-only while editing existing staff profiles
- re-derive edit-mode usernames from first and last name changes and auto-select the next available username when needed
- replace the manual edit conflict test with edit-mode derivation coverage

## Why
- edit mode should not allow manual username entry
- name changes still need to keep staff usernames aligned and valid without trapping the user in conflicts they can no longer resolve manually

## Validation
- `bun run --filter @athena/webapp test -- src/components/staff/StaffManagement.test.tsx`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run --filter @athena/webapp build`
- `bun run graphify:rebuild`
- `bun run graphify:check`
- `bun run pr:athena`
- `git diff --check`

Linear: https://linear.app/v26-labs/issue/V26-347/keep-edit-mode-staff-usernames-visible-read-only-and-name-derived