### PR TITLE
[V26-354]: Migrate service catalog command flows to the shared server/error foundation

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -11879,7 +11879,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L8",
+      "source_location": "L9",
       "target": "catalog_buildservicecatalogitem",
       "weight": 1
     },
@@ -19259,7 +19259,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L28",
+      "source_location": "L29",
       "target": "servicecatalogview_test_chooseselectoption",
       "weight": 1
     },
@@ -19271,7 +19271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L149",
+      "source_location": "L158",
       "target": "servicecatalogview_handlechange",
       "weight": 1
     },
@@ -19283,7 +19283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L159",
+      "source_location": "L168",
       "target": "servicecatalogview_handleedit",
       "weight": 1
     },
@@ -19295,7 +19295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L165",
+      "source_location": "L174",
       "target": "servicecatalogview_handlereset",
       "weight": 1
     },
@@ -19307,7 +19307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L171",
+      "source_location": "L180",
       "target": "servicecatalogview_handlesubmit",
       "weight": 1
     },
@@ -19319,7 +19319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L82",
+      "source_location": "L87",
       "target": "servicecatalogview_itemtoformstate",
       "weight": 1
     },
@@ -19331,7 +19331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L96",
+      "source_location": "L101",
       "target": "servicecatalogview_parseservicecatalogform",
       "weight": 1
     },
@@ -19343,7 +19343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L67",
+      "source_location": "L72",
       "target": "servicecatalogview_validateservicecatalogform",
       "weight": 1
     },
@@ -19355,7 +19355,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L461",
+      "source_location": "L470",
       "target": "servicecatalogview_withsavestate",
       "weight": 1
     },
@@ -36023,7 +36023,7 @@
       "relation": "calls",
       "source": "servicecatalogview_itemtoformstate",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L161",
+      "source_location": "L170",
       "target": "servicecatalogview_handleedit",
       "weight": 1
     },
@@ -36035,7 +36035,7 @@
       "relation": "calls",
       "source": "servicecatalogview_handlereset",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L190",
+      "source_location": "L204",
       "target": "servicecatalogview_handlesubmit",
       "weight": 1
     },
@@ -36047,7 +36047,7 @@
       "relation": "calls",
       "source": "servicecatalogview_parseservicecatalogform",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L179",
+      "source_location": "L188",
       "target": "servicecatalogview_handlesubmit",
       "weight": 1
     },
@@ -36059,7 +36059,7 @@
       "relation": "calls",
       "source": "servicecatalogview_validateservicecatalogform",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L172",
+      "source_location": "L181",
       "target": "servicecatalogview_handlesubmit",
       "weight": 1
     },
@@ -58564,7 +58564,7 @@
       "label": "buildServiceCatalogItem()",
       "norm_label": "buildservicecatalogitem()",
       "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L8"
+      "source_location": "L9"
     },
     {
       "community": 403,
@@ -61885,7 +61885,7 @@
       "label": "chooseSelectOption()",
       "norm_label": "chooseselectoption()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L28"
+      "source_location": "L29"
     },
     {
       "community": 519,
@@ -63748,7 +63748,7 @@
       "label": "handleChange()",
       "norm_label": "handlechange()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L149"
+      "source_location": "L158"
     },
     {
       "community": 59,
@@ -63757,7 +63757,7 @@
       "label": "handleEdit()",
       "norm_label": "handleedit()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L159"
+      "source_location": "L168"
     },
     {
       "community": 59,
@@ -63766,7 +63766,7 @@
       "label": "handleReset()",
       "norm_label": "handlereset()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L165"
+      "source_location": "L174"
     },
     {
       "community": 59,
@@ -63775,7 +63775,7 @@
       "label": "handleSubmit()",
       "norm_label": "handlesubmit()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L171"
+      "source_location": "L180"
     },
     {
       "community": 59,
@@ -63784,7 +63784,7 @@
       "label": "itemToFormState()",
       "norm_label": "itemtoformstate()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L82"
+      "source_location": "L87"
     },
     {
       "community": 59,
@@ -63793,7 +63793,7 @@
       "label": "parseServiceCatalogForm()",
       "norm_label": "parseservicecatalogform()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L96"
+      "source_location": "L101"
     },
     {
       "community": 59,
@@ -63802,7 +63802,7 @@
       "label": "validateServiceCatalogForm()",
       "norm_label": "validateservicecatalogform()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L67"
+      "source_location": "L72"
     },
     {
       "community": 59,
@@ -63811,7 +63811,7 @@
       "label": "withSaveState()",
       "norm_label": "withsavestate()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L461"
+      "source_location": "L470"
     },
     {
       "community": 590,

--- a/packages/athena-webapp/convex/serviceOps/catalog.ts
+++ b/packages/athena-webapp/convex/serviceOps/catalog.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @convex-dev/no-collect-in-query -- V26-276 ships store-scoped service catalog management before pagination; truncating the indexed catalog reads would hide valid services from staff and admins. */
 
 import { mutation, query } from "../_generated/server";
-import { Id } from "../_generated/dataModel";
+import type { Id } from "../_generated/dataModel";
 import { v } from "convex/values";
 import { toSlug } from "../utils";
+import { ok, userError, type CommandResult } from "../../shared/commandResult";
 
 export function buildServiceCatalogItem(args: {
   basePrice?: number;
@@ -17,9 +18,28 @@ export function buildServiceCatalogItem(args: {
   requiresManagerApproval: boolean;
   serviceMode: "same_day" | "consultation" | "repair" | "revamp";
   storeId: Id<"store">;
-}) {
+}): CommandResult<{
+  basePrice?: number;
+  createdAt: number;
+  depositType: "none" | "flat" | "percentage";
+  depositValue?: number;
+  description?: string;
+  durationMinutes: number;
+  name: string;
+  organizationId?: Id<"organization">;
+  pricingModel: "fixed" | "starting_at" | "quote_after_consultation";
+  requiresManagerApproval: boolean;
+  serviceMode: "same_day" | "consultation" | "repair" | "revamp";
+  slug: string;
+  status: "active";
+  storeId: Id<"store">;
+  updatedAt: number;
+}> {
   if (args.durationMinutes <= 0) {
-    throw new Error("Service duration must be greater than zero");
+    return userError({
+      code: "validation_failed",
+      message: "Service duration must be greater than zero.",
+    });
   }
 
   if (args.depositType === "percentage") {
@@ -28,33 +48,45 @@ export function buildServiceCatalogItem(args: {
       args.depositValue < 1 ||
       args.depositValue > 100
     ) {
-      throw new Error("Percentage deposit must be between 1 and 100");
+      return userError({
+        code: "validation_failed",
+        message: "Percentage deposit must be between 1 and 100.",
+      });
     }
   }
 
   if (args.depositType === "flat") {
     if (args.depositValue === undefined || args.depositValue <= 0) {
-      throw new Error("Flat deposit must be greater than zero");
+      return userError({
+        code: "validation_failed",
+        message: "Flat deposit must be greater than zero.",
+      });
     }
   }
 
   if (args.depositType === "none" && args.depositValue !== undefined) {
-    throw new Error("Deposit value is only allowed when a deposit type is set");
+    return userError({
+      code: "validation_failed",
+      message: "Deposit value is only allowed when a deposit type is set.",
+    });
   }
 
   if (args.pricingModel === "fixed" && (args.basePrice ?? 0) <= 0) {
-    throw new Error("Fixed-price services require a base price");
+    return userError({
+      code: "validation_failed",
+      message: "Fixed-price services require a base price.",
+    });
   }
 
   const now = Date.now();
 
-  return {
+  return ok({
     ...args,
     createdAt: now,
     slug: toSlug(args.name),
     status: "active" as const,
     updatedAt: now,
-  };
+  });
 }
 
 export const listServiceCatalogItems = query({
@@ -106,7 +138,12 @@ export const createServiceCatalogItem = mutation({
     storeId: v.id("store"),
   },
   handler: async (ctx, args) => {
-    const catalogItem = buildServiceCatalogItem(args);
+    const catalogItemResult = buildServiceCatalogItem(args);
+    if (catalogItemResult.kind === "user_error") {
+      return catalogItemResult;
+    }
+
+    const catalogItem = catalogItemResult.data;
     const existingCatalogItem = await ctx.db
       .query("serviceCatalog")
       .withIndex("by_storeId_slug", (q) =>
@@ -115,11 +152,14 @@ export const createServiceCatalogItem = mutation({
       .first();
 
     if (existingCatalogItem) {
-      throw new Error("A service catalog item with this name already exists.");
+      return userError({
+        code: "conflict",
+        message: "A service catalog item with this name already exists.",
+      });
     }
 
     const catalogItemId = await ctx.db.insert("serviceCatalog", catalogItem);
-    return ctx.db.get("serviceCatalog", catalogItemId);
+    return ok(await ctx.db.get("serviceCatalog", catalogItemId));
   },
 });
 
@@ -158,10 +198,13 @@ export const updateServiceCatalogItem = mutation({
     );
 
     if (!existingCatalogItem) {
-      throw new Error("Service catalog item not found.");
+      return userError({
+        code: "not_found",
+        message: "Service catalog item not found.",
+      });
     }
 
-    const nextCatalogItem = buildServiceCatalogItem({
+    const nextCatalogItemResult = buildServiceCatalogItem({
       basePrice:
         args.basePrice === undefined ? existingCatalogItem.basePrice : args.basePrice,
       depositType: args.depositType ?? existingCatalogItem.depositType,
@@ -183,6 +226,11 @@ export const updateServiceCatalogItem = mutation({
       serviceMode: args.serviceMode ?? existingCatalogItem.serviceMode,
       storeId: existingCatalogItem.storeId,
     });
+    if (nextCatalogItemResult.kind === "user_error") {
+      return nextCatalogItemResult;
+    }
+
+    const nextCatalogItem = nextCatalogItemResult.data;
 
     const conflictingCatalogItem = await ctx.db
       .query("serviceCatalog")
@@ -195,7 +243,10 @@ export const updateServiceCatalogItem = mutation({
       conflictingCatalogItem &&
       conflictingCatalogItem._id !== existingCatalogItem._id
     ) {
-      throw new Error("A service catalog item with this name already exists.");
+      return userError({
+        code: "conflict",
+        message: "A service catalog item with this name already exists.",
+      });
     }
 
     await ctx.db.patch("serviceCatalog", args.serviceCatalogId, {
@@ -204,7 +255,7 @@ export const updateServiceCatalogItem = mutation({
       status: existingCatalogItem.status,
     });
 
-    return ctx.db.get("serviceCatalog", args.serviceCatalogId);
+    return ok(await ctx.db.get("serviceCatalog", args.serviceCatalogId));
   },
 });
 
@@ -219,7 +270,10 @@ export const archiveServiceCatalogItem = mutation({
     );
 
     if (!existingCatalogItem) {
-      throw new Error("Service catalog item not found.");
+      return userError({
+        code: "not_found",
+        message: "Service catalog item not found.",
+      });
     }
 
     await ctx.db.patch("serviceCatalog", args.serviceCatalogId, {
@@ -227,6 +281,6 @@ export const archiveServiceCatalogItem = mutation({
       updatedAt: Date.now(),
     });
 
-    return ctx.db.get("serviceCatalog", args.serviceCatalogId);
+    return ok(await ctx.db.get("serviceCatalog", args.serviceCatalogId));
   },
 });

--- a/packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts
+++ b/packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts
@@ -7,8 +7,8 @@ import {
 } from "./appointments";
 
 describe("service catalog and appointment helpers", () => {
-  it("normalizes catalog items and enforces duration and deposit rules", () => {
-    expect(() =>
+  it("normalizes catalog items and returns user_error data for expected validation failures", () => {
+    expect(
       buildServiceCatalogItem({
         depositType: "flat",
         depositValue: 100,
@@ -19,9 +19,15 @@ describe("service catalog and appointment helpers", () => {
         serviceMode: "repair",
         storeId: "store_1" as Id<"store">,
       })
-    ).toThrow("Service duration must be greater than zero");
+    ).toEqual({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message: "Service duration must be greater than zero.",
+      },
+    });
 
-    expect(() =>
+    expect(
       buildServiceCatalogItem({
         basePrice: 450,
         depositType: "percentage",
@@ -33,7 +39,13 @@ describe("service catalog and appointment helpers", () => {
         serviceMode: "repair",
         storeId: "store_1" as Id<"store">,
       })
-    ).toThrow("Percentage deposit must be between 1 and 100");
+    ).toEqual({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message: "Percentage deposit must be between 1 and 100.",
+      },
+    });
 
     expect(
       buildServiceCatalogItem({
@@ -48,9 +60,12 @@ describe("service catalog and appointment helpers", () => {
         storeId: "store_1" as Id<"store">,
       })
     ).toMatchObject({
-      durationMinutes: 90,
-      slug: "closure-repair",
-      status: "active",
+      kind: "ok",
+      data: {
+        durationMinutes: 90,
+        slug: "closure-repair",
+        status: "active",
+      },
     });
   });
 

--- a/packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GENERIC_UNEXPECTED_ERROR_MESSAGE, userError } from "~/shared/commandResult";
 import { ServiceCatalogViewContent } from "./ServiceCatalogView";
 
 const baseProps = {
@@ -20,9 +21,9 @@ const baseProps = {
       status: "active" as const,
     },
   ],
-  onArchive: vi.fn().mockResolvedValue(undefined),
-  onCreate: vi.fn().mockResolvedValue(undefined),
-  onUpdate: vi.fn().mockResolvedValue(undefined),
+  onArchive: vi.fn().mockResolvedValue({ kind: "ok", data: null }),
+  onCreate: vi.fn().mockResolvedValue({ kind: "ok", data: null }),
+  onUpdate: vi.fn().mockResolvedValue({ kind: "ok", data: null }),
 };
 
 async function chooseSelectOption(
@@ -42,7 +43,7 @@ describe("ServiceCatalogViewContent", () => {
 
   it("validates required catalog fields before creating", async () => {
     const user = userEvent.setup();
-    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const onCreate = vi.fn().mockResolvedValue({ kind: "ok", data: null });
 
     render(<ServiceCatalogViewContent {...baseProps} onCreate={onCreate} />);
 
@@ -57,8 +58,8 @@ describe("ServiceCatalogViewContent", () => {
 
   it("creates and archives catalog items", async () => {
     const user = userEvent.setup();
-    const onCreate = vi.fn().mockResolvedValue(undefined);
-    const onArchive = vi.fn().mockResolvedValue(undefined);
+    const onCreate = vi.fn().mockResolvedValue({ kind: "ok", data: null });
+    const onArchive = vi.fn().mockResolvedValue({ kind: "ok", data: null });
 
     render(
       <ServiceCatalogViewContent
@@ -100,7 +101,7 @@ describe("ServiceCatalogViewContent", () => {
 
   it("loads existing items into the form for editing", async () => {
     const user = userEvent.setup();
-    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    const onUpdate = vi.fn().mockResolvedValue({ kind: "ok", data: null });
 
     render(<ServiceCatalogViewContent {...baseProps} onUpdate={onUpdate} />);
 
@@ -120,5 +121,63 @@ describe("ServiceCatalogViewContent", () => {
       name: "Custom Closure Repair",
       serviceCatalogId: "catalog-1",
     });
+  });
+
+  it("renders safe user_error copy inline and clears stale errors before retry", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi
+      .fn()
+      .mockResolvedValueOnce(
+        userError({
+          code: "conflict",
+          message: "A service catalog item with this name already exists.",
+        }),
+      )
+      .mockResolvedValueOnce({ kind: "ok", data: null });
+
+    render(<ServiceCatalogViewContent {...baseProps} onCreate={onCreate} />);
+
+    await user.clear(screen.getByLabelText(/service name/i));
+    await user.type(screen.getByLabelText(/service name/i), "Closure Repair");
+    await user.clear(screen.getByLabelText(/duration/i));
+    await user.type(screen.getByLabelText(/duration/i), "90");
+
+    await user.click(screen.getByRole("button", { name: /create service/i }));
+
+    expect(
+      await screen.findByText("A service catalog item with this name already exists."),
+    ).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText(/service name/i));
+    await user.type(screen.getByLabelText(/service name/i), "Wash and Restyle");
+    await user.click(screen.getByRole("button", { name: /create service/i }));
+
+    await waitFor(() => expect(onCreate).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(
+        screen.queryByText("A service catalog item with this name already exists."),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("renders generic fallback copy inline for unexpected failures", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockResolvedValue({
+      kind: "unexpected_error",
+      error: {
+        title: "Something went wrong",
+        message: GENERIC_UNEXPECTED_ERROR_MESSAGE,
+      },
+    });
+
+    render(<ServiceCatalogViewContent {...baseProps} onCreate={onCreate} />);
+
+    await user.clear(screen.getByLabelText(/service name/i));
+    await user.type(screen.getByLabelText(/service name/i), "Wash and Restyle");
+    await user.clear(screen.getByLabelText(/duration/i));
+    await user.type(screen.getByLabelText(/duration/i), "75");
+    await user.click(screen.getByRole("button", { name: /create service/i }));
+
+    expect(await screen.findByText(GENERIC_UNEXPECTED_ERROR_MESSAGE)).toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/services/ServiceCatalogView.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCatalogView.tsx
@@ -18,6 +18,11 @@ import {
 } from "../ui/select";
 import { Textarea } from "../ui/textarea";
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
+import {
+  type NormalizedCommandResult,
+  runCommand,
+} from "@/lib/errors/runCommand";
+import { presentCommandToast } from "@/lib/errors/presentCommandToast";
 import { api } from "~/convex/_generated/api";
 
 type ServiceCatalogItem = {
@@ -115,8 +120,12 @@ type ServiceCatalogViewContentProps = {
   isSaving: boolean;
   items: ServiceCatalogItem[];
   onArchive: (serviceCatalogId: string) => Promise<void>;
-  onCreate: (args: CreateServiceCatalogArgs) => Promise<void>;
-  onUpdate: (args: UpdateServiceCatalogArgs) => Promise<void>;
+  onCreate: (
+    args: CreateServiceCatalogArgs
+  ) => Promise<NormalizedCommandResult<ServiceCatalogItem | null>>;
+  onUpdate: (
+    args: UpdateServiceCatalogArgs
+  ) => Promise<NormalizedCommandResult<ServiceCatalogItem | null>>;
 };
 
 export function ServiceCatalogViewContent({
@@ -177,22 +186,22 @@ export function ServiceCatalogViewContent({
     }
 
     const parsedForm = parseServiceCatalogForm(form);
+    setValidationErrors([]);
 
-    try {
-      if (editingId) {
-        await onUpdate({
+    const result = editingId
+      ? await onUpdate({
           ...parsedForm,
           serviceCatalogId: editingId,
-        });
-      } else {
-        await onCreate(parsedForm);
-      }
-      handleReset();
-    } catch (error) {
-      toast.error("Failed to save service catalog item", {
-        description: (error as Error).message,
-      });
+        })
+      : await onCreate(parsedForm);
+
+    if (result.kind !== "ok") {
+      setValidationErrors([result.error.message]);
+      return;
     }
+
+    toast.success(editingId ? "Service updated" : "Service created");
+    handleReset();
   };
 
   return (
@@ -458,10 +467,10 @@ export function ServiceCatalogView() {
     api.serviceOps.catalog.archiveServiceCatalogItem
   );
 
-  const withSaveState = async (action: () => Promise<void>) => {
+  const withSaveState = async <T,>(action: () => Promise<T>) => {
     setIsSaving(true);
     try {
-      await action();
+      return await action();
     } finally {
       setIsSaving(false);
     }
@@ -508,27 +517,37 @@ export function ServiceCatalogView() {
       items={items ?? []}
       onArchive={(serviceCatalogId) =>
         withSaveState(async () => {
-          await archiveServiceCatalogItem({ serviceCatalogId: serviceCatalogId as any });
+          const result = await runCommand(() =>
+            archiveServiceCatalogItem({ serviceCatalogId: serviceCatalogId as any })
+          );
+
+          if (result.kind !== "ok") {
+            presentCommandToast(result);
+            return;
+          }
+
           toast.success("Service archived");
         })
       }
       onCreate={(args) =>
-        withSaveState(async () => {
-          await createServiceCatalogItem({
-            ...args,
-            storeId: activeStore._id,
-          });
-          toast.success("Service created");
-        })
+        withSaveState(() =>
+          runCommand(() =>
+            createServiceCatalogItem({
+              ...args,
+              storeId: activeStore._id,
+            })
+          )
+        )
       }
       onUpdate={(args) =>
-        withSaveState(async () => {
-          await updateServiceCatalogItem({
-            ...args,
-            serviceCatalogId: args.serviceCatalogId as any,
-          });
-          toast.success("Service updated");
-        })
+        withSaveState(() =>
+          runCommand(() =>
+            updateServiceCatalogItem({
+              ...args,
+              serviceCatalogId: args.serviceCatalogId as any,
+            })
+          )
+        )
       }
     />
   );


### PR DESCRIPTION
## Summary
- migrate service catalog server mutations to return shared `CommandResult` / `user_error` results for expected validation, conflict, and not-found failures
- normalize the service catalog UI through `runCommand`, render create/update failures inline, and route archive failures through the shared toast fallback
- extend catalog helper and UI tests, then rebuild graphify artifacts

## Why
- service catalog was still treating expected business failures as thrown exceptions
- the durable form surface was showing raw `error.message` text from server failures
- this makes the catalog slice consistent with the new Athena client/server error foundation before the rest of service ops migrates

## Validation
- `bun run --filter '@athena/webapp' test -- convex/serviceOps/catalogAppointments.test.ts src/components/services/ServiceCatalogView.test.tsx`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run --filter '@athena/webapp' test convex/serviceOps/serviceCases.test.ts convex/serviceOps/catalogAppointments.test.ts convex/serviceOps/moduleWiring.test.ts convex/operations/serviceIntake.test.ts src/components/services/ServiceIntakeView.test.tsx src/components/services/ServiceIntakeView.auth.test.tsx src/components/services/ServiceAppointmentsView.test.tsx src/components/services/ServiceCasesView.test.tsx src/components/services/ServiceCatalogView.test.tsx src/components/operations/OperationsQueueView.test.tsx`
- `bun run --filter '@athena/webapp' audit:convex`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run --filter '@athena/webapp' build`
- `git diff --check`
- `bun run graphify:rebuild`

Linear: https://linear.app/v26-labs/issue/V26-354/migrate-service-catalog-command-flows-to-the-shared-servererror
