### PR TITLE
[V26-355]: Migrate service appointment command flows to the shared server/error foundation

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3714 nodes · 3236 edges · 1399 communities detected
+- 3716 nodes · 3241 edges · 1399 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1581,20 +1581,20 @@ Cohesion: 0.24
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
 ### Community 36 - "Community 36"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 37 - "Community 37"
 Cohesion: 0.36
 Nodes (9): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), resolveStockAdjustmentApprovalDecisionWithCtx(), submitStockAdjustmentBatchWithCtx() (+1 more)
 
-### Community 38 - "Community 38"
+### Community 37 - "Community 37"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 39 - "Community 39"
+### Community 38 - "Community 38"
 Cohesion: 0.18
 Nodes (0):
+
+### Community 39 - "Community 39"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 40 - "Community 40"
 Cohesion: 0.18
@@ -1690,19 +1690,19 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 63 - "Community 63"
 Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
 ### Community 64 - "Community 64"
 Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
-
-### Community 65 - "Community 65"
-Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 66 - "Community 66"
+### Community 65 - "Community 65"
 Cohesion: 0.25
 Nodes (0):
+
+### Community 66 - "Community 66"
+Cohesion: 0.43
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 67 - "Community 67"
 Cohesion: 0.36
@@ -1789,52 +1789,52 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 88 - "Community 88"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.48
+Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
 ### Community 89 - "Community 89"
-Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
-
-### Community 90 - "Community 90"
 Cohesion: 0.29
 Nodes (0):
+
+### Community 90 - "Community 90"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
 ### Community 91 - "Community 91"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 92 - "Community 92"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 93 - "Community 93"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
+### Community 93 - "Community 93"
+Cohesion: 0.29
+Nodes (0):
+
 ### Community 94 - "Community 94"
+Cohesion: 0.52
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 95 - "Community 95"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.53
 Nodes (5): buildInStorePaymentAllocations(), isActiveRegisterSessionStatus(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 99 - "Community 99"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 100 - "Community 100"
 Cohesion: 0.33
@@ -1845,56 +1845,56 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 102 - "Community 102"
-Cohesion: 0.73
-Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
-
-### Community 103 - "Community 103"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 103 - "Community 103"
+Cohesion: 0.73
+Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 104 - "Community 104"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 105 - "Community 105"
-Cohesion: 0.4
-Nodes (2): appendTransition(), applyOnlineOrderUpdate()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 106 - "Community 106"
 Cohesion: 0.4
-Nodes (2): calculateCycleCountQuantityDelta(), resolveStockAdjustmentQuantityDelta()
+Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
 ### Community 107 - "Community 107"
+Cohesion: 0.4
+Nodes (2): calculateCycleCountQuantityDelta(), resolveStockAdjustmentQuantityDelta()
+
+### Community 108 - "Community 108"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
-
-### Community 109 - "Community 109"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 110 - "Community 110"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 111 - "Community 111"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 112 - "Community 112"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 113 - "Community 113"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 114 - "Community 114"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 115 - "Community 115"
 Cohesion: 0.33
@@ -1905,67 +1905,67 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 117 - "Community 117"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 118 - "Community 118"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 119 - "Community 119"
-Cohesion: 0.4
-Nodes (2): hasCustomerDetails(), useRegisterViewModel()
 
 ### Community 120 - "Community 120"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): hasCustomerDetails(), useRegisterViewModel()
 
 ### Community 121 - "Community 121"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 122 - "Community 122"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 123 - "Community 123"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 124 - "Community 124"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 125 - "Community 125"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
-
-### Community 126 - "Community 126"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 126 - "Community 126"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 127 - "Community 127"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 128 - "Community 128"
-Cohesion: 0.53
-Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
-
-### Community 129 - "Community 129"
-Cohesion: 0.47
-Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
-
-### Community 130 - "Community 130"
-Cohesion: 0.67
-Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
-
-### Community 131 - "Community 131"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 129 - "Community 129"
+Cohesion: 0.53
+Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
+
+### Community 130 - "Community 130"
+Cohesion: 0.47
+Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+
+### Community 131 - "Community 131"
+Cohesion: 0.67
+Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
+
 ### Community 132 - "Community 132"
-Cohesion: 0.4
+Cohesion: 0.33
 Nodes (0):
 
 ### Community 133 - "Community 133"
@@ -1977,40 +1977,40 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 135 - "Community 135"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 136 - "Community 136"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.5
 Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.5
 Nodes (2): buildPaymentAllocation(), recordPaymentAllocationWithCtx()
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.6
 Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 143 - "Community 143"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 144 - "Community 144"
 Cohesion: 0.4
@@ -2025,12 +2025,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 147 - "Community 147"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 148 - "Community 148"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 148 - "Community 148"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 149 - "Community 149"
 Cohesion: 0.4
@@ -2042,11 +2042,11 @@ Nodes (0):
 
 ### Community 151 - "Community 151"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 152 - "Community 152"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 153 - "Community 153"
 Cohesion: 0.4
@@ -2061,8 +2061,8 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 156 - "Community 156"
-Cohesion: 0.5
-Nodes (2): handleSubmit(), parseDateTimeLocal()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 157 - "Community 157"
 Cohesion: 0.4

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -19199,7 +19199,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L446",
+      "source_location": "L449",
       "target": "serviceappointmentsview_async",
       "weight": 1
     },
@@ -19247,7 +19247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L517",
+      "source_location": "L521",
       "target": "serviceappointmentsview_withsavestate",
       "weight": 1
     },
@@ -35975,7 +35975,7 @@
       "relation": "calls",
       "source": "serviceappointmentsview_applycommandresult",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L409",
+      "source_location": "L411",
       "target": "serviceappointmentsview_async",
       "weight": 1
     },
@@ -35987,7 +35987,7 @@
       "relation": "calls",
       "source": "serviceappointmentsview_parsedatetimelocal",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L393",
+      "source_location": "L394",
       "target": "serviceappointmentsview_async",
       "weight": 1
     },
@@ -35999,7 +35999,7 @@
       "relation": "calls",
       "source": "serviceappointmentsview_applycommandresult",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L186",
+      "source_location": "L187",
       "target": "serviceappointmentsview_handlesubmit",
       "weight": 1
     },
@@ -70360,7 +70360,7 @@
       "label": "async()",
       "norm_label": "async()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L392"
+      "source_location": "L393"
     },
     {
       "community": 88,
@@ -70396,7 +70396,7 @@
       "label": "withSaveState()",
       "norm_label": "withsavestate()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L517"
+      "source_location": "L521"
     },
     {
       "community": 880,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -11855,7 +11855,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L16",
+      "source_location": "L17",
       "target": "appointments_buildserviceappointment",
       "weight": 1
     },
@@ -11867,7 +11867,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L42",
+      "source_location": "L61",
       "target": "appointments_findoverlappingappointment",
       "weight": 1
     },
@@ -19163,7 +19163,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
-      "source_location": "L58",
+      "source_location": "L59",
       "target": "serviceappointmentsview_test_choosedatetime",
       "weight": 1
     },
@@ -19175,8 +19175,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
-      "source_location": "L49",
+      "source_location": "L50",
       "target": "serviceappointmentsview_test_chooseselectoption",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "_tgt": "serviceappointmentsview_applycommandresult",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L129",
+      "target": "serviceappointmentsview_applycommandresult",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "_tgt": "serviceappointmentsview_async",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L446",
+      "target": "serviceappointmentsview_async",
       "weight": 1
     },
     {
@@ -19187,7 +19211,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L90",
+      "source_location": "L102",
       "target": "serviceappointmentsview_formatdatetimelocal",
       "weight": 1
     },
@@ -19199,7 +19223,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L131",
+      "source_location": "L153",
       "target": "serviceappointmentsview_handlesubmit",
       "weight": 1
     },
@@ -19211,7 +19235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L85",
+      "source_location": "L97",
       "target": "serviceappointmentsview_parsedatetimelocal",
       "weight": 1
     },
@@ -19223,7 +19247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L472",
+      "source_location": "L517",
       "target": "serviceappointmentsview_withsavestate",
       "weight": 1
     },
@@ -35944,6 +35968,42 @@
       "weight": 1
     },
     {
+      "_src": "serviceappointmentsview_async",
+      "_tgt": "serviceappointmentsview_applycommandresult",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "serviceappointmentsview_applycommandresult",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L409",
+      "target": "serviceappointmentsview_async",
+      "weight": 1
+    },
+    {
+      "_src": "serviceappointmentsview_async",
+      "_tgt": "serviceappointmentsview_parsedatetimelocal",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "serviceappointmentsview_parsedatetimelocal",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L393",
+      "target": "serviceappointmentsview_async",
+      "weight": 1
+    },
+    {
+      "_src": "serviceappointmentsview_handlesubmit",
+      "_tgt": "serviceappointmentsview_applycommandresult",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "serviceappointmentsview_applycommandresult",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L186",
+      "target": "serviceappointmentsview_handlesubmit",
+      "weight": 1
+    },
+    {
       "_src": "serviceappointmentsview_handlesubmit",
       "_tgt": "serviceappointmentsview_parsedatetimelocal",
       "confidence": "EXTRACTED",
@@ -35951,7 +36011,7 @@
       "relation": "calls",
       "source": "serviceappointmentsview_parsedatetimelocal",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L146",
+      "source_location": "L168",
       "target": "serviceappointmentsview_handlesubmit",
       "weight": 1
     },
@@ -39858,56 +39918,56 @@
     {
       "community": 100,
       "file_type": "code",
-      "id": "assigncustomer_createcustomer",
-      "label": "createCustomer()",
-      "norm_label": "createcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "assigncustomer_linktoguest",
-      "label": "linkToGuest()",
-      "norm_label": "linktoguest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L150"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "assigncustomer_linktostorefrontuser",
-      "label": "linkToStoreFrontUser()",
-      "norm_label": "linktostorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L111"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "assigncustomer_updatecustomer",
-      "label": "updateCustomer()",
-      "norm_label": "updatecustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "assigncustomer_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
-      "label": "assignCustomer.ts",
-      "norm_label": "assigncustomer.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "source_location": "L76"
     },
     {
       "community": 1000,
@@ -40002,56 +40062,56 @@
     {
       "community": 101,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
-      "label": "searchCustomers.ts",
-      "norm_label": "searchcustomers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "id": "assigncustomer_createcustomer",
+      "label": "createCustomer()",
+      "norm_label": "createcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "assigncustomer_linktoguest",
+      "label": "linkToGuest()",
+      "norm_label": "linktoguest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "assigncustomer_linktostorefrontuser",
+      "label": "linkToStoreFrontUser()",
+      "norm_label": "linktostorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "assigncustomer_updatecustomer",
+      "label": "updateCustomer()",
+      "norm_label": "updatecustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "assigncustomer_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
+      "label": "assignCustomer.ts",
+      "norm_label": "assigncustomer.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "searchcustomers_findbystorefrontuser",
-      "label": "findByStoreFrontUser()",
-      "norm_label": "findbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "searchcustomers_findpotentialmatches",
-      "label": "findPotentialMatches()",
-      "norm_label": "findpotentialmatches()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "searchcustomers_getcustomerbyid",
-      "label": "getCustomerById()",
-      "norm_label": "getcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "searchcustomers_getcustomertransactions",
-      "label": "getCustomerTransactions()",
-      "norm_label": "getcustomertransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "searchcustomers_searchcustomers",
-      "label": "searchCustomers()",
-      "norm_label": "searchcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L15"
     },
     {
       "community": 1010,
@@ -40146,56 +40206,56 @@
     {
       "community": 102,
       "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L49"
+      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
+      "label": "searchCustomers.ts",
+      "norm_label": "searchcustomers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L1"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "id": "searchcustomers_findbystorefrontuser",
+      "label": "findByStoreFrontUser()",
+      "norm_label": "findbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
       "source_location": "L77"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
+      "id": "searchcustomers_findpotentialmatches",
+      "label": "findPotentialMatches()",
+      "norm_label": "findpotentialmatches()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L104"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
+      "id": "searchcustomers_getcustomerbyid",
+      "label": "getCustomerById()",
+      "norm_label": "getcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L48"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L42"
+      "id": "searchcustomers_getcustomertransactions",
+      "label": "getCustomerTransactions()",
+      "norm_label": "getcustomertransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L57"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L1"
+      "id": "searchcustomers_searchcustomers",
+      "label": "searchCustomers()",
+      "norm_label": "searchcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L15"
     },
     {
       "community": 1020,
@@ -40290,56 +40350,56 @@
     {
       "community": 103,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
-      "label": "purchaseOrders.ts",
-      "norm_label": "purchaseorders.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
-      "label": "assertValidPurchaseOrderStatusTransition()",
-      "norm_label": "assertvalidpurchaseorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordernumber",
-      "label": "buildPurchaseOrderNumber()",
-      "norm_label": "buildpurchaseordernumber()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "purchaseorders_calculatepurchaseordertotals",
-      "label": "calculatePurchaseOrderTotals()",
-      "norm_label": "calculatepurchaseordertotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "purchaseorders_getoperationalworkitemstatus",
-      "label": "getOperationalWorkItemStatus()",
-      "norm_label": "getoperationalworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "purchaseorders_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L21"
     },
     {
       "community": 1030,
@@ -40434,56 +40494,56 @@
     {
       "community": 104,
       "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
+      "label": "purchaseOrders.ts",
+      "norm_label": "purchaseorders.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
+      "label": "assertValidPurchaseOrderStatusTransition()",
+      "norm_label": "assertvalidpurchaseorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "purchaseorders_buildpurchaseordernumber",
+      "label": "buildPurchaseOrderNumber()",
+      "norm_label": "buildpurchaseordernumber()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "purchaseorders_calculatepurchaseordertotals",
+      "label": "calculatePurchaseOrderTotals()",
+      "norm_label": "calculatepurchaseordertotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "purchaseorders_getoperationalworkitemstatus",
+      "label": "getOperationalWorkItemStatus()",
+      "norm_label": "getoperationalworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "purchaseorders_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L21"
     },
     {
       "community": 1040,
@@ -40578,55 +40638,55 @@
     {
       "community": 105,
       "file_type": "code",
-      "id": "onlineorder_appendtransition",
-      "label": "appendTransition()",
-      "norm_label": "appendtransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L59"
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L19"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "onlineorder_applyonlineorderupdate",
-      "label": "applyOnlineOrderUpdate()",
-      "norm_label": "applyonlineorderupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L83"
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L124"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereplacementsourceid",
-      "label": "buildReturnExchangeReplacementSourceId()",
-      "norm_label": "buildreturnexchangereplacementsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L204"
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereturnsourceid",
-      "label": "buildReturnExchangeReturnSourceId()",
-      "norm_label": "buildreturnexchangereturnsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L212"
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L77"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "onlineorder_listorderitems",
-      "label": "listOrderItems()",
-      "norm_label": "listorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L49"
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L182"
     },
     {
       "community": 105,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1"
     },
     {
@@ -40722,56 +40782,56 @@
     {
       "community": 106,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_stockadjustment_ts",
-      "label": "stockAdjustment.ts",
-      "norm_label": "stockadjustment.ts",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "id": "onlineorder_appendtransition",
+      "label": "appendTransition()",
+      "norm_label": "appendtransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "onlineorder_applyonlineorderupdate",
+      "label": "applyOnlineOrderUpdate()",
+      "norm_label": "applyonlineorderupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereplacementsourceid",
+      "label": "buildReturnExchangeReplacementSourceId()",
+      "norm_label": "buildreturnexchangereplacementsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L204"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereturnsourceid",
+      "label": "buildReturnExchangeReturnSourceId()",
+      "norm_label": "buildreturnexchangereturnsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L212"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "onlineorder_listorderitems",
+      "label": "listOrderItems()",
+      "norm_label": "listorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "stockadjustment_assertstockadjustmentreasoncode",
-      "label": "assertStockAdjustmentReasonCode()",
-      "norm_label": "assertstockadjustmentreasoncode()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "stockadjustment_calculatecyclecountquantitydelta",
-      "label": "calculateCycleCountQuantityDelta()",
-      "norm_label": "calculatecyclecountquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "stockadjustment_requiresstockadjustmentapproval",
-      "label": "requiresStockAdjustmentApproval()",
-      "norm_label": "requiresstockadjustmentapproval()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
-      "label": "resolveStockAdjustmentQuantityDelta()",
-      "norm_label": "resolvestockadjustmentquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "stockadjustment_summarizestockadjustmentlineitems",
-      "label": "summarizeStockAdjustmentLineItems()",
-      "norm_label": "summarizestockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L76"
     },
     {
       "community": 1060,
@@ -40866,56 +40926,56 @@
     {
       "community": 107,
       "file_type": "code",
-      "id": "data_table_toolbar_datatabletoolbar",
-      "label": "DataTableToolbar()",
-      "norm_label": "datatabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_shared_stockadjustment_ts",
+      "label": "stockAdjustment.ts",
+      "norm_label": "stockadjustment.ts",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
       "source_location": "L1"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "stockadjustment_assertstockadjustmentreasoncode",
+      "label": "assertStockAdjustmentReasonCode()",
+      "norm_label": "assertstockadjustmentreasoncode()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L25"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "stockadjustment_calculatecyclecountquantitydelta",
+      "label": "calculateCycleCountQuantityDelta()",
+      "norm_label": "calculatecyclecountquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L14"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "stockadjustment_requiresstockadjustmentapproval",
+      "label": "requiresStockAdjustmentApproval()",
+      "norm_label": "requiresstockadjustmentapproval()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L96"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
+      "label": "resolveStockAdjustmentQuantityDelta()",
+      "norm_label": "resolvestockadjustmentquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "stockadjustment_summarizestockadjustmentlineitems",
+      "label": "summarizeStockAdjustmentLineItems()",
+      "norm_label": "summarizestockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L76"
     },
     {
       "community": 1070,
@@ -41010,56 +41070,56 @@
     {
       "community": 108,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "id": "data_table_toolbar_datatabletoolbar",
+      "label": "DataTableToolbar()",
+      "norm_label": "datatabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1080,
@@ -41154,56 +41214,56 @@
     {
       "community": 109,
       "file_type": "code",
-      "id": "bannermessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L123"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleactivetoggle",
-      "label": "handleActiveToggle()",
-      "norm_label": "handleactivetoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleclear",
-      "label": "handleClear()",
-      "norm_label": "handleclear()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L113"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "label": "BannerMessageEditor.tsx",
-      "norm_label": "bannermessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
     },
     {
       "community": 1090,
@@ -41478,56 +41538,56 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "label": "ReviewsView.tsx",
-      "norm_label": "reviewsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "id": "bannermessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L123"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleactivetoggle",
+      "label": "handleActiveToggle()",
+      "norm_label": "handleactivetoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L113"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
+      "label": "BannerMessageEditor.tsx",
+      "norm_label": "bannermessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "reviewsview_handleapprove",
-      "label": "handleApprove()",
-      "norm_label": "handleapprove()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "reviewsview_handlepublish",
-      "label": "handlePublish()",
-      "norm_label": "handlepublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "reviewsview_handlereject",
-      "label": "handleReject()",
-      "norm_label": "handlereject()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "reviewsview_handleunpublish",
-      "label": "handleUnpublish()",
-      "norm_label": "handleunpublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "reviewsview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L13"
     },
     {
       "community": 1100,
@@ -41622,56 +41682,56 @@
     {
       "community": 111,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
+      "label": "ReviewsView.tsx",
+      "norm_label": "reviewsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
+      "id": "reviewsview_handleapprove",
+      "label": "handleApprove()",
+      "norm_label": "handleapprove()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "reviewsview_handlepublish",
+      "label": "handlePublish()",
+      "norm_label": "handlepublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "reviewsview_handlereject",
+      "label": "handleReject()",
+      "norm_label": "handlereject()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "reviewsview_handleunpublish",
+      "label": "handleUnpublish()",
+      "norm_label": "handleunpublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "reviewsview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L13"
     },
     {
       "community": 1110,
@@ -41766,56 +41826,56 @@
     {
       "community": 112,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1120,
@@ -41910,56 +41970,56 @@
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
     },
     {
       "community": 1130,
@@ -42054,56 +42114,56 @@
     {
       "community": 114,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L41"
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L31"
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L61"
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L98"
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L9"
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
     },
     {
       "community": 1140,
@@ -42198,56 +42258,56 @@
     {
       "community": 115,
       "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L9"
     },
     {
       "community": 1150,
@@ -42342,56 +42402,56 @@
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
-      "label": "results.ts",
-      "norm_label": "results.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "results_isposusecasesuccess",
-      "label": "isPosUseCaseSuccess()",
-      "norm_label": "isposusecasesuccess()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "results_mapcommandoutcome",
-      "label": "mapCommandOutcome()",
-      "norm_label": "mapcommandoutcome()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "results_mapcommandresult",
-      "label": "mapCommandResult()",
-      "norm_label": "mapcommandresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "results_maplegacymutationresult",
-      "label": "mapLegacyMutationResult()",
-      "norm_label": "maplegacymutationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "results_mapthrownerror",
-      "label": "mapThrownError()",
-      "norm_label": "mapthrownerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L97"
     },
     {
       "community": 1160,
@@ -42486,56 +42546,56 @@
     {
       "community": 117,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
-      "label": "payments.ts",
-      "norm_label": "payments.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
+      "label": "results.ts",
+      "norm_label": "results.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
       "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "payments_calculateposchange",
-      "label": "calculatePosChange()",
-      "norm_label": "calculateposchange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L3"
+      "id": "results_isposusecasesuccess",
+      "label": "isPosUseCaseSuccess()",
+      "norm_label": "isposusecasesuccess()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L107"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "payments_calculateposremainingdue",
-      "label": "calculatePosRemainingDue()",
-      "norm_label": "calculateposremainingdue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L20"
+      "id": "results_mapcommandoutcome",
+      "label": "mapCommandOutcome()",
+      "norm_label": "mapcommandoutcome()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L63"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "payments_calculatepostotalpaid",
-      "label": "calculatePosTotalPaid()",
-      "norm_label": "calculatepostotalpaid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L14"
+      "id": "results_mapcommandresult",
+      "label": "mapCommandResult()",
+      "norm_label": "mapcommandresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L80"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "payments_ispospaymentsufficient",
-      "label": "isPosPaymentSufficient()",
-      "norm_label": "ispospaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L7"
+      "id": "results_maplegacymutationresult",
+      "label": "mapLegacyMutationResult()",
+      "norm_label": "maplegacymutationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L46"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "payments_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
-      "source_location": "L27"
+      "id": "results_mapthrownerror",
+      "label": "mapThrownError()",
+      "norm_label": "mapthrownerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L97"
     },
     {
       "community": 1170,
@@ -42630,56 +42690,56 @@
     {
       "community": 118,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
-      "label": "selectors.ts",
-      "norm_label": "selectors.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
+      "label": "payments.ts",
+      "norm_label": "payments.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
       "source_location": "L1"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "selectors_buildregisterheaderstate",
-      "label": "buildRegisterHeaderState()",
-      "norm_label": "buildregisterheaderstate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "id": "payments_calculateposchange",
+      "label": "calculatePosChange()",
+      "norm_label": "calculateposchange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "payments_calculateposremainingdue",
+      "label": "calculatePosRemainingDue()",
+      "norm_label": "calculateposremainingdue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "payments_calculatepostotalpaid",
+      "label": "calculatePosTotalPaid()",
+      "norm_label": "calculatepostotalpaid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "payments_ispospaymentsufficient",
+      "label": "isPosPaymentSufficient()",
+      "norm_label": "ispospaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "payments_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/payments.ts",
       "source_location": "L27"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "selectors_buildregisterinfostate",
-      "label": "buildRegisterInfoState()",
-      "norm_label": "buildregisterinfostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "selectors_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "selectors_getregistercustomerinfo",
-      "label": "getRegisterCustomerInfo()",
-      "norm_label": "getregistercustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "selectors_isregistersessionactive",
-      "label": "isRegisterSessionActive()",
-      "norm_label": "isregistersessionactive()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
-      "source_location": "L48"
     },
     {
       "community": 1180,
@@ -42774,56 +42834,56 @@
     {
       "community": 119,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
-      "label": "useRegisterViewModel.ts",
-      "norm_label": "useregisterviewmodel.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
+      "label": "selectors.ts",
+      "norm_label": "selectors.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
       "source_location": "L1"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "useregisterviewmodel_createpaymentid",
-      "label": "createPaymentId()",
-      "norm_label": "createpaymentid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L84"
+      "id": "selectors_buildregisterheaderstate",
+      "label": "buildRegisterHeaderState()",
+      "norm_label": "buildregisterheaderstate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L27"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "useregisterviewmodel_hascustomerdetails",
-      "label": "hasCustomerDetails()",
-      "norm_label": "hascustomerdetails()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L58"
+      "id": "selectors_buildregisterinfostate",
+      "label": "buildRegisterInfoState()",
+      "norm_label": "buildregisterinfostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L36"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "useregisterviewmodel_mapsessioncustomer",
-      "label": "mapSessionCustomer()",
-      "norm_label": "mapsessioncustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L71"
+      "id": "selectors_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L11"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "useregisterviewmodel_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L91"
+      "id": "selectors_getregistercustomerinfo",
+      "label": "getRegisterCustomerInfo()",
+      "norm_label": "getregistercustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L5"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "useregisterviewmodel_useregisterviewmodel",
-      "label": "useRegisterViewModel()",
-      "norm_label": "useregisterviewmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L96"
+      "id": "selectors_isregistersessionactive",
+      "label": "isRegisterSessionActive()",
+      "norm_label": "isregistersessionactive()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
+      "source_location": "L48"
     },
     {
       "community": 1190,
@@ -43089,56 +43149,56 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
+      "label": "useRegisterViewModel.ts",
+      "norm_label": "useregisterviewmodel.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
       "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
+      "id": "useregisterviewmodel_createpaymentid",
+      "label": "createPaymentId()",
+      "norm_label": "createpaymentid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L84"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
+      "id": "useregisterviewmodel_hascustomerdetails",
+      "label": "hasCustomerDetails()",
+      "norm_label": "hascustomerdetails()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L58"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
+      "id": "useregisterviewmodel_mapsessioncustomer",
+      "label": "mapSessionCustomer()",
+      "norm_label": "mapsessioncustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L71"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
+      "id": "useregisterviewmodel_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L91"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
+      "id": "useregisterviewmodel_useregisterviewmodel",
+      "label": "useRegisterViewModel()",
+      "norm_label": "useregisterviewmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L96"
     },
     {
       "community": 1200,
@@ -43233,56 +43293,56 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
-      "label": "$traceId.tsx",
-      "norm_label": "$traceid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "traceid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L12"
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "traceid_workflowtraceloadingstate",
-      "label": "WorkflowTraceLoadingState()",
-      "norm_label": "workflowtraceloadingstate()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L21"
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "traceid_workflowtraceroute",
-      "label": "WorkflowTraceRoute()",
-      "norm_label": "workflowtraceroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L101"
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "traceid_workflowtraceroutecontent",
-      "label": "WorkflowTraceRouteContent()",
-      "norm_label": "workflowtraceroutecontent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L35"
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "traceid_workflowtracerouteshell",
-      "label": "WorkflowTraceRouteShell()",
-      "norm_label": "workflowtracerouteshell()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L66"
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
     },
     {
       "community": 1210,
@@ -43377,56 +43437,56 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L198"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L71"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
+      "label": "$traceId.tsx",
+      "norm_label": "$traceid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "traceid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "traceid_workflowtraceloadingstate",
+      "label": "WorkflowTraceLoadingState()",
+      "norm_label": "workflowtraceloadingstate()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroute",
+      "label": "WorkflowTraceRoute()",
+      "norm_label": "workflowtraceroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroutecontent",
+      "label": "WorkflowTraceRouteContent()",
+      "norm_label": "workflowtraceroutecontent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "traceid_workflowtracerouteshell",
+      "label": "WorkflowTraceRouteShell()",
+      "norm_label": "workflowtracerouteshell()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L66"
     },
     {
       "community": 1220,
@@ -43521,56 +43581,56 @@
     {
       "community": 123,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L232"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
+      "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
       "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L156"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "storesettingsview_onsubmit",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L198"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L105"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
       "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L82"
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L71"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L28"
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1230,
@@ -43665,56 +43725,56 @@
     {
       "community": 124,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L83"
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L232"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L82"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L28"
     },
     {
       "community": 1240,
@@ -43809,56 +43869,56 @@
     {
       "community": 125,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
       "source_location": "L1"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L83"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
     },
     {
       "community": 1250,
@@ -43953,56 +44013,56 @@
     {
       "community": 126,
       "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
     },
     {
       "community": 1260,
@@ -44097,55 +44157,55 @@
     {
       "community": 127,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1"
     },
     {
@@ -44241,55 +44301,55 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "feeutils_getremainingforfreedelivery",
-      "label": "getRemainingForFreeDelivery()",
-      "norm_label": "getremainingforfreedelivery()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L138"
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "feeutils_haswaiverconfigured",
-      "label": "hasWaiverConfigured()",
-      "norm_label": "haswaiverconfigured()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L100"
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "feeutils_isanyfeewaived",
-      "label": "isAnyFeeWaived()",
-      "norm_label": "isanyfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L74"
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "feeutils_isfeewaived",
-      "label": "isFeeWaived()",
-      "norm_label": "isfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L34"
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "feeutils_meetsthreshold",
-      "label": "meetsThreshold()",
-      "norm_label": "meetsthreshold()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L17"
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
-      "label": "feeUtils.ts",
-      "norm_label": "feeutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1"
     },
     {
@@ -44385,55 +44445,55 @@
     {
       "community": 129,
       "file_type": "code",
-      "id": "auth_verify_formattime",
-      "label": "formatTime()",
-      "norm_label": "formattime()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L149"
+      "id": "feeutils_getremainingforfreedelivery",
+      "label": "getRemainingForFreeDelivery()",
+      "norm_label": "getremainingforfreedelivery()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L138"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "auth_verify_handlecodechange",
-      "label": "handleCodeChange()",
-      "norm_label": "handlecodechange()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L156"
+      "id": "feeutils_haswaiverconfigured",
+      "label": "hasWaiverConfigured()",
+      "norm_label": "haswaiverconfigured()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L100"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "auth_verify_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L201"
+      "id": "feeutils_isanyfeewaived",
+      "label": "isAnyFeeWaived()",
+      "norm_label": "isanyfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L74"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "auth_verify_reportauthfailure",
-      "label": "reportAuthFailure()",
-      "norm_label": "reportauthfailure()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L93"
+      "id": "feeutils_isfeewaived",
+      "label": "isFeeWaived()",
+      "norm_label": "isfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L34"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "auth_verify_resendverificationcode",
-      "label": "resendVerificationCode()",
-      "norm_label": "resendverificationcode()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L282"
+      "id": "feeutils_meetsthreshold",
+      "label": "meetsThreshold()",
+      "norm_label": "meetsthreshold()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L17"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
-      "label": "auth.verify.tsx",
-      "norm_label": "auth.verify.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
+      "label": "feeUtils.ts",
+      "norm_label": "feeutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L1"
     },
     {
@@ -44700,55 +44760,55 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "graphify_check_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L72"
+      "id": "auth_verify_formattime",
+      "label": "formatTime()",
+      "norm_label": "formattime()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L149"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "graphify_check_collectstalegraphifyartifacts",
-      "label": "collectStaleGraphifyArtifacts()",
-      "norm_label": "collectstalegraphifyartifacts()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L124"
+      "id": "auth_verify_handlecodechange",
+      "label": "handleCodeChange()",
+      "norm_label": "handlecodechange()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L156"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "graphify_check_copygraphifycheckinputs",
-      "label": "copyGraphifyCheckInputs()",
-      "norm_label": "copygraphifycheckinputs()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L106"
+      "id": "auth_verify_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L201"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "graphify_check_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L63"
+      "id": "auth_verify_reportauthfailure",
+      "label": "reportAuthFailure()",
+      "norm_label": "reportauthfailure()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L93"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "graphify_check_rungraphifycheck",
-      "label": "runGraphifyCheck()",
-      "norm_label": "rungraphifycheck()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L151"
+      "id": "auth_verify_resendverificationcode",
+      "label": "resendVerificationCode()",
+      "norm_label": "resendverificationcode()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L282"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "scripts_graphify_check_ts",
-      "label": "graphify-check.ts",
-      "norm_label": "graphify-check.ts",
-      "source_file": "scripts/graphify-check.ts",
+      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
+      "label": "auth.verify.tsx",
+      "norm_label": "auth.verify.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L1"
     },
     {
@@ -44844,55 +44904,55 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
-      "label": "buildAthenaRuntimeUrl()",
-      "norm_label": "buildathenaruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L129"
+      "id": "graphify_check_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L72"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
-      "label": "buildValkeyRuntimeUrl()",
-      "norm_label": "buildvalkeyruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L145"
+      "id": "graphify_check_collectstalegraphifyartifacts",
+      "label": "collectStaleGraphifyArtifacts()",
+      "norm_label": "collectstalegraphifyartifacts()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L124"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
-      "label": "createAthenaRuntimeProcess()",
-      "norm_label": "createathenaruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L117"
+      "id": "graphify_check_copygraphifycheckinputs",
+      "label": "copyGraphifyCheckInputs()",
+      "norm_label": "copygraphifycheckinputs()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L106"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
-      "label": "createStorefrontRuntimeProcesses()",
-      "norm_label": "createstorefrontruntimeprocesses()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L149"
+      "id": "graphify_check_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L63"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
-      "label": "createValkeyRuntimeProcess()",
-      "norm_label": "createvalkeyruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L133"
+      "id": "graphify_check_rungraphifycheck",
+      "label": "runGraphifyCheck()",
+      "norm_label": "rungraphifycheck()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L151"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "scripts_harness_behavior_scenarios_ts",
-      "label": "harness-behavior-scenarios.ts",
-      "norm_label": "harness-behavior-scenarios.ts",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "id": "scripts_graphify_check_ts",
+      "label": "graphify-check.ts",
+      "norm_label": "graphify-check.ts",
+      "source_file": "scripts/graphify-check.ts",
       "source_location": "L1"
     },
     {
@@ -44988,47 +45048,56 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "label": "r2.ts",
-      "norm_label": "r2.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
+      "label": "buildAthenaRuntimeUrl()",
+      "norm_label": "buildathenaruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
+      "label": "buildValkeyRuntimeUrl()",
+      "norm_label": "buildvalkeyruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
+      "label": "createAthenaRuntimeProcess()",
+      "norm_label": "createathenaruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
+      "label": "createStorefrontRuntimeProcesses()",
+      "norm_label": "createstorefrontruntimeprocesses()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
+      "label": "createValkeyRuntimeProcess()",
+      "norm_label": "createvalkeyruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_scenarios_ts",
+      "label": "harness-behavior-scenarios.ts",
+      "norm_label": "harness-behavior-scenarios.ts",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "r2_deletedirectoryinr2",
-      "label": "deleteDirectoryInR2()",
-      "norm_label": "deletedirectoryinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "r2_deletefileinr2",
-      "label": "deleteFileInR2()",
-      "norm_label": "deletefileinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "r2_listitemsinr2directory",
-      "label": "listItemsInR2Directory()",
-      "norm_label": "listitemsinr2directory()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "r2_uploadfiletor2",
-      "label": "uploadFileToR2()",
-      "norm_label": "uploadfiletor2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L21"
     },
     {
       "community": 1320,
@@ -45123,47 +45192,47 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
-      "label": "validateExpenseItemBelongsToSession()",
-      "norm_label": "validateexpenseitembelongstosession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionactive",
-      "label": "validateExpenseSessionActive()",
-      "norm_label": "validateexpensesessionactive()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionexists",
-      "label": "validateExpenseSessionExists()",
-      "norm_label": "validateexpensesessionexists()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
-      "label": "validateExpenseSessionModifiable()",
-      "norm_label": "validateexpensesessionmodifiable()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
-      "label": "expenseSessionValidation.ts",
-      "norm_label": "expensesessionvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
+      "label": "r2.ts",
+      "norm_label": "r2.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "r2_deletedirectoryinr2",
+      "label": "deleteDirectoryInR2()",
+      "norm_label": "deletedirectoryinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "r2_deletefileinr2",
+      "label": "deleteFileInR2()",
+      "norm_label": "deletefileinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "r2_listitemsinr2directory",
+      "label": "listItemsInR2Directory()",
+      "norm_label": "listitemsinr2directory()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "r2_uploadfiletor2",
+      "label": "uploadFileToR2()",
+      "norm_label": "uploadfiletor2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L21"
     },
     {
       "community": 1330,
@@ -45258,47 +45327,47 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_products_ts",
-      "label": "products.ts",
-      "norm_label": "products.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "id": "expensesessionvalidation_validateexpenseitembelongstosession",
+      "label": "validateExpenseItemBelongsToSession()",
+      "norm_label": "validateexpenseitembelongstosession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionactive",
+      "label": "validateExpenseSessionActive()",
+      "norm_label": "validateexpensesessionactive()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionexists",
+      "label": "validateExpenseSessionExists()",
+      "norm_label": "validateexpensesessionexists()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "expensesessionvalidation_validateexpensesessionmodifiable",
+      "label": "validateExpenseSessionModifiable()",
+      "norm_label": "validateexpensesessionmodifiable()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
+      "label": "expenseSessionValidation.ts",
+      "norm_label": "expensesessionvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "products_calculatetotalavailablecount",
-      "label": "calculateTotalAvailableCount()",
-      "norm_label": "calculatetotalavailablecount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "products_calculatetotalinventorycount",
-      "label": "calculateTotalInventoryCount()",
-      "norm_label": "calculatetotalinventorycount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "products_generatebarcode",
-      "label": "generateBarcode()",
-      "norm_label": "generatebarcode()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "products_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L18"
     },
     {
       "community": 1340,
@@ -45393,47 +45462,47 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "customerprofiles_compactrecord",
-      "label": "compactRecord()",
-      "norm_label": "compactrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
-      "label": "ensureCustomerProfileFromSourcesWithCtx()",
-      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "customerprofiles_findexistingprofile",
-      "label": "findExistingProfile()",
-      "norm_label": "findexistingprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "customerprofiles_loadcustomersources",
-      "label": "loadCustomerSources()",
-      "norm_label": "loadcustomersources()",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
-      "label": "customerProfiles.ts",
-      "norm_label": "customerprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "id": "packages_athena_webapp_convex_inventory_products_ts",
+      "label": "products.ts",
+      "norm_label": "products.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "products_calculatetotalavailablecount",
+      "label": "calculateTotalAvailableCount()",
+      "norm_label": "calculatetotalavailablecount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "products_calculatetotalinventorycount",
+      "label": "calculateTotalInventoryCount()",
+      "norm_label": "calculatetotalinventorycount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "products_generatebarcode",
+      "label": "generateBarcode()",
+      "norm_label": "generatebarcode()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "products_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L18"
     },
     {
       "community": 1350,
@@ -45528,46 +45597,46 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L25"
+      "id": "customerprofiles_compactrecord",
+      "label": "compactRecord()",
+      "norm_label": "compactrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L24"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L51"
+      "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
+      "label": "ensureCustomerProfileFromSourcesWithCtx()",
+      "norm_label": "ensurecustomerprofilefromsourceswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L207"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L70"
+      "id": "customerprofiles_findexistingprofile",
+      "label": "findExistingProfile()",
+      "norm_label": "findexistingprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L45"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L36"
+      "id": "customerprofiles_loadcustomersources",
+      "label": "loadCustomerSources()",
+      "norm_label": "loadcustomersources()",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
+      "source_location": "L30"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
+      "label": "customerProfiles.ts",
+      "norm_label": "customerprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
       "source_location": "L1"
     },
     {
@@ -45663,47 +45732,47 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
     },
     {
       "community": 1370,
@@ -45798,47 +45867,47 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
-      "label": "serviceIntake.test.ts",
-      "norm_label": "serviceintake.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
       "source_location": "L1"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "serviceintake_test_buildcreateserviceintakeargs",
-      "label": "buildCreateServiceIntakeArgs()",
-      "norm_label": "buildcreateserviceintakeargs()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L16"
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "serviceintake_test_createmutationctx",
-      "label": "createMutationCtx()",
-      "norm_label": "createmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L29"
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "serviceintake_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L12"
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L78"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "serviceintake_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L8"
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
     },
     {
       "community": 1380,
@@ -45933,47 +46002,47 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_paystackservice_ts",
-      "label": "paystackService.ts",
-      "norm_label": "paystackservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
+      "label": "serviceIntake.test.ts",
+      "norm_label": "serviceintake.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
       "source_location": "L1"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "paystackservice_getpaystackheaders",
-      "label": "getPaystackHeaders()",
-      "norm_label": "getpaystackheaders()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L11"
+      "id": "serviceintake_test_buildcreateserviceintakeargs",
+      "label": "buildCreateServiceIntakeArgs()",
+      "norm_label": "buildcreateserviceintakeargs()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L16"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "paystackservice_initializetransaction",
-      "label": "initializeTransaction()",
-      "norm_label": "initializetransaction()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L21"
+      "id": "serviceintake_test_createmutationctx",
+      "label": "createMutationCtx()",
+      "norm_label": "createmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L29"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "paystackservice_initiaterefund",
-      "label": "initiateRefund()",
-      "norm_label": "initiaterefund()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L87"
+      "id": "serviceintake_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L12"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "paystackservice_verifytransaction",
-      "label": "verifyTransaction()",
-      "norm_label": "verifytransaction()",
-      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
-      "source_location": "L65"
+      "id": "serviceintake_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L8"
     },
     {
       "community": 1390,
@@ -46230,6 +46299,51 @@
     {
       "community": 140,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_paystackservice_ts",
+      "label": "paystackService.ts",
+      "norm_label": "paystackservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "paystackservice_getpaystackheaders",
+      "label": "getPaystackHeaders()",
+      "norm_label": "getpaystackheaders()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "paystackservice_initializetransaction",
+      "label": "initializeTransaction()",
+      "norm_label": "initializetransaction()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "paystackservice_initiaterefund",
+      "label": "initiateRefund()",
+      "norm_label": "initiaterefund()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "paystackservice_verifytransaction",
+      "label": "verifyTransaction()",
+      "norm_label": "verifytransaction()",
+      "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
       "norm_label": "returnexchangeoperations.ts",
@@ -46237,7 +46351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -46246,7 +46360,7 @@
       "source_location": "L115"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -46255,7 +46369,7 @@
       "source_location": "L90"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -46264,7 +46378,7 @@
       "source_location": "L74"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
@@ -46273,7 +46387,7 @@
       "source_location": "L70"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "offers_createoffer",
       "label": "createOffer()",
@@ -46282,7 +46396,7 @@
       "source_location": "L89"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "offers_getupsellproducts",
       "label": "getUpsellProducts()",
@@ -46291,7 +46405,7 @@
       "source_location": "L765"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "offers_isduplicate",
       "label": "isDuplicate()",
@@ -46300,7 +46414,7 @@
       "source_location": "L37"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "offers_updatestorefrontactoremail",
       "label": "updateStoreFrontActorEmail()",
@@ -46309,7 +46423,7 @@
       "source_location": "L60"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_offers_ts",
       "label": "offers.ts",
@@ -46318,7 +46432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
@@ -46327,7 +46441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -46336,7 +46450,7 @@
       "source_location": "L124"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -46345,7 +46459,7 @@
       "source_location": "L67"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -46354,7 +46468,7 @@
       "source_location": "L106"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -46363,7 +46477,7 @@
       "source_location": "L73"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "navbar_appheader",
       "label": "AppHeader()",
@@ -46372,7 +46486,7 @@
       "source_location": "L61"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "navbar_header",
       "label": "Header()",
@@ -46381,7 +46495,7 @@
       "source_location": "L75"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "navbar_navbar",
       "label": "Navbar()",
@@ -46390,7 +46504,7 @@
       "source_location": "L116"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "navbar_settingsheader",
       "label": "SettingsHeader()",
@@ -46399,7 +46513,7 @@
       "source_location": "L20"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
       "label": "Navbar.tsx",
@@ -46408,7 +46522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
       "label": "ProductCategorization.tsx",
@@ -46417,7 +46531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "productcategorization_getproductname",
       "label": "getProductName()",
@@ -46426,7 +46540,7 @@
       "source_location": "L286"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "productcategorization_handleclose",
       "label": "handleClose()",
@@ -46435,7 +46549,7 @@
       "source_location": "L203"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "productcategorization_handleproductvisibility",
       "label": "handleProductVisibility()",
@@ -46444,7 +46558,7 @@
       "source_location": "L243"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "productcategorization_setinitialselectedoption",
       "label": "setInitialSelectedOption()",
@@ -46453,7 +46567,7 @@
       "source_location": "L230"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -46462,7 +46576,7 @@
       "source_location": "L20"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -46471,7 +46585,7 @@
       "source_location": "L50"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -46480,7 +46594,7 @@
       "source_location": "L342"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -46489,7 +46603,7 @@
       "source_location": "L322"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -46498,7 +46612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -46507,7 +46621,7 @@
       "source_location": "L61"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -46516,7 +46630,7 @@
       "source_location": "L57"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -46525,7 +46639,7 @@
       "source_location": "L98"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -46534,7 +46648,7 @@
       "source_location": "L134"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -46543,7 +46657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -46552,7 +46666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -46561,7 +46675,7 @@
       "source_location": "L38"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -46570,7 +46684,7 @@
       "source_location": "L64"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -46579,7 +46693,7 @@
       "source_location": "L135"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -46588,7 +46702,7 @@
       "source_location": "L43"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -46597,7 +46711,7 @@
       "source_location": "L58"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -46606,7 +46720,7 @@
       "source_location": "L63"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -46615,7 +46729,7 @@
       "source_location": "L50"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -46624,57 +46738,12 @@
       "source_location": "L53"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
       "norm_label": "activityview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "orderdetailsview_fetchtransactions",
-      "label": "fetchTransactions()",
-      "norm_label": "fetchtransactions()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L138"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkasverified",
-      "label": "handleMarkAsVerified()",
-      "norm_label": "handlemarkasverified()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L175"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkpaymentcollected",
-      "label": "handleMarkPaymentCollected()",
-      "norm_label": "handlemarkpaymentcollected()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L189"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "orderdetailsview_verifiedbadge",
-      "label": "VerifiedBadge()",
-      "norm_label": "verifiedbadge()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "label": "OrderDetailsView.tsx",
-      "norm_label": "orderdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L1"
     },
     {
@@ -46842,6 +46911,51 @@
     {
       "community": 150,
       "file_type": "code",
+      "id": "orderdetailsview_fetchtransactions",
+      "label": "fetchTransactions()",
+      "norm_label": "fetchtransactions()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L138"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkasverified",
+      "label": "handleMarkAsVerified()",
+      "norm_label": "handlemarkasverified()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L175"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkpaymentcollected",
+      "label": "handleMarkPaymentCollected()",
+      "norm_label": "handlemarkpaymentcollected()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L189"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "orderdetailsview_verifiedbadge",
+      "label": "VerifiedBadge()",
+      "norm_label": "verifiedbadge()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
+      "label": "OrderDetailsView.tsx",
+      "norm_label": "orderdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
       "norm_label": "handlerequestfeedback()",
@@ -46849,7 +46963,7 @@
       "source_location": "L77"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -46858,7 +46972,7 @@
       "source_location": "L295"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -46867,7 +46981,7 @@
       "source_location": "L61"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -46876,7 +46990,7 @@
       "source_location": "L47"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
@@ -46885,7 +46999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "index_feesview",
       "label": "FeesView()",
@@ -46894,7 +47008,7 @@
       "source_location": "L29"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -46903,7 +47017,7 @@
       "source_location": "L42"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "index_onsubmit",
       "label": "onSubmit()",
@@ -46912,7 +47026,7 @@
       "source_location": "L105"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -46921,7 +47035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "label": "index.tsx",
@@ -46930,7 +47044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
       "label": "PaymentView.tsx",
@@ -46939,7 +47053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "paymentview_handleaddpayment",
       "label": "handleAddPayment()",
@@ -46948,7 +47062,7 @@
       "source_location": "L189"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "paymentview_handleamountblur",
       "label": "handleAmountBlur()",
@@ -46957,7 +47071,7 @@
       "source_location": "L252"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "paymentview_handleamountchange",
       "label": "handleAmountChange()",
@@ -46966,7 +47080,7 @@
       "source_location": "L234"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "paymentview_handleclearall",
       "label": "handleClearAll()",
@@ -46975,7 +47089,7 @@
       "source_location": "L227"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
       "label": "PaymentsAddedList.tsx",
@@ -46984,7 +47098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "paymentsaddedlist_getpaymentmethodlabel",
       "label": "getPaymentMethodLabel()",
@@ -46993,7 +47107,7 @@
       "source_location": "L27"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "paymentsaddedlist_handlecanceledit",
       "label": "handleCancelEdit()",
@@ -47002,7 +47116,7 @@
       "source_location": "L104"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "paymentsaddedlist_handlesaveedit",
       "label": "handleSaveEdit()",
@@ -47011,7 +47125,7 @@
       "source_location": "L72"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "paymentsaddedlist_handlestartedit",
       "label": "handleStartEdit()",
@@ -47020,7 +47134,7 @@
       "source_location": "L67"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
       "label": "ReceivingView.tsx",
@@ -47029,7 +47143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "receivingview_builddefaultreceivedquantities",
       "label": "buildDefaultReceivedQuantities()",
@@ -47038,7 +47152,7 @@
       "source_location": "L35"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "receivingview_buildreceivedquantitiesaftersubmission",
       "label": "buildReceivedQuantitiesAfterSubmission()",
@@ -47047,7 +47161,7 @@
       "source_location": "L44"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "receivingview_buildsubmissionkey",
       "label": "buildSubmissionKey()",
@@ -47056,7 +47170,7 @@
       "source_location": "L31"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "receivingview_receivingview",
       "label": "ReceivingView()",
@@ -47065,7 +47179,7 @@
       "source_location": "L70"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -47074,7 +47188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -47083,7 +47197,7 @@
       "source_location": "L146"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -47092,7 +47206,7 @@
       "source_location": "L213"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -47101,58 +47215,13 @@
       "source_location": "L299"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
       "norm_label": "updateleaveareviewdiscountcode()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L351"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
-      "label": "ServiceAppointmentsView.tsx",
-      "norm_label": "serviceappointmentsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "serviceappointmentsview_formatdatetimelocal",
-      "label": "formatDateTimeLocal()",
-      "norm_label": "formatdatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "serviceappointmentsview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "serviceappointmentsview_parsedatetimelocal",
-      "label": "parseDateTimeLocal()",
-      "norm_label": "parsedatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "serviceappointmentsview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L472"
     },
     {
       "community": 157,
@@ -52660,7 +52729,7 @@
       "label": "buildServiceAppointment()",
       "norm_label": "buildserviceappointment()",
       "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L16"
+      "source_location": "L17"
     },
     {
       "community": 259,
@@ -52669,7 +52738,7 @@
       "label": "findOverlappingAppointment()",
       "norm_label": "findoverlappingappointment()",
       "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L42"
+      "source_location": "L61"
     },
     {
       "community": 259,
@@ -54082,7 +54151,7 @@
       "label": "chooseDateTime()",
       "norm_label": "choosedatetime()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
-      "source_location": "L58"
+      "source_location": "L59"
     },
     {
       "community": 292,
@@ -54091,7 +54160,7 @@
       "label": "chooseSelectOption()",
       "norm_label": "chooseselectoption()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
-      "source_location": "L49"
+      "source_location": "L50"
     },
     {
       "community": 293,
@@ -56868,101 +56937,101 @@
     {
       "community": 36,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "adjustments_applystockadjustmentbatchwithctx",
+      "label": "applyStockAdjustmentBatchWithCtx()",
+      "norm_label": "applystockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "adjustments_assertdistinctstockadjustmentlineitems",
+      "label": "assertDistinctStockAdjustmentLineItems()",
+      "norm_label": "assertdistinctstockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "adjustments_assertnormalizedlineitem",
+      "label": "assertNormalizedLineItem()",
+      "norm_label": "assertnormalizedlineitem()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "adjustments_buildresolvedstockadjustmentstatus",
+      "label": "buildResolvedStockAdjustmentStatus()",
+      "norm_label": "buildresolvedstockadjustmentstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L197"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "adjustments_buildstockadjustmentdecisioneventtype",
+      "label": "buildStockAdjustmentDecisionEventType()",
+      "norm_label": "buildstockadjustmentdecisioneventtype()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L187"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "adjustments_buildstockadjustmentsourceid",
+      "label": "buildStockAdjustmentSourceId()",
+      "norm_label": "buildstockadjustmentsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "adjustments_buildstockadjustmenttitle",
+      "label": "buildStockAdjustmentTitle()",
+      "norm_label": "buildstockadjustmenttitle()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
+      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
+      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L203"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "adjustments_submitstockadjustmentbatchwithctx",
+      "label": "submitStockAdjustmentBatchWithCtx()",
+      "norm_label": "submitstockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L337"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "adjustments_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "label": "adjustments.ts",
+      "norm_label": "adjustments.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
     },
     {
       "community": 360,
@@ -57237,100 +57306,100 @@
     {
       "community": 37,
       "file_type": "code",
-      "id": "adjustments_applystockadjustmentbatchwithctx",
-      "label": "applyStockAdjustmentBatchWithCtx()",
-      "norm_label": "applystockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L139"
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L16"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "adjustments_assertdistinctstockadjustmentlineitems",
-      "label": "assertDistinctStockAdjustmentLineItems()",
-      "norm_label": "assertdistinctstockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L63"
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "adjustments_assertnormalizedlineitem",
-      "label": "assertNormalizedLineItem()",
-      "norm_label": "assertnormalizedlineitem()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L93"
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "adjustments_buildresolvedstockadjustmentstatus",
-      "label": "buildResolvedStockAdjustmentStatus()",
-      "norm_label": "buildresolvedstockadjustmentstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L197"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmentdecisioneventtype",
-      "label": "buildStockAdjustmentDecisionEventType()",
-      "norm_label": "buildstockadjustmentdecisioneventtype()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L187"
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmentsourceid",
-      "label": "buildStockAdjustmentSourceId()",
-      "norm_label": "buildstockadjustmentsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L79"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmenttitle",
-      "label": "buildStockAdjustmentTitle()",
-      "norm_label": "buildstockadjustmenttitle()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L83"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
-      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
-      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L203"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchwithctx",
-      "label": "submitStockAdjustmentBatchWithCtx()",
-      "norm_label": "submitstockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L337"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "adjustments_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L58"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 37,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
-      "label": "adjustments.ts",
-      "norm_label": "adjustments.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
@@ -57597,100 +57666,100 @@
     {
       "community": 38,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L46"
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
     },
     {
       "community": 38,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L1"
     },
     {
@@ -57876,101 +57945,101 @@
     {
       "community": 39,
       "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 39,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 390,
@@ -65004,73 +65073,73 @@
     {
       "community": 63,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {
@@ -65256,74 +65325,74 @@
     {
       "community": 64,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L558"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L531"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L523"
     },
     {
       "community": 640,
@@ -65508,74 +65577,74 @@
     {
       "community": 65,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
       "source_location": "L1"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L225"
+      "id": "sessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L880"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L141"
+      "id": "sessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L874"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L104"
+      "id": "sessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L870"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L558"
+      "id": "sessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L890"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L217"
+      "id": "sessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L650"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L531"
+      "id": "sessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L727"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L523"
+      "id": "sessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L632"
     },
     {
       "community": 650,
@@ -65760,74 +65829,74 @@
     {
       "community": 66,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 66,
       "file_type": "code",
-      "id": "sessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L880"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L874"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L870"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L890"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L650"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L727"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L632"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 660,
@@ -70269,65 +70338,65 @@
     {
       "community": 88,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
-      "label": "WorkflowTraceView.tsx",
-      "norm_label": "workflowtraceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "label": "ServiceAppointmentsView.tsx",
+      "norm_label": "serviceappointmentsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "workflowtraceview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L44"
+      "id": "serviceappointmentsview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L129"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "workflowtraceview_formattracelabel",
-      "label": "formatTraceLabel()",
-      "norm_label": "formattracelabel()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L40"
+      "id": "serviceappointmentsview_async",
+      "label": "async()",
+      "norm_label": "async()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L392"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "workflowtraceview_getstatustone",
-      "label": "getStatusTone()",
-      "norm_label": "getstatustone()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L51"
+      "id": "serviceappointmentsview_formatdatetimelocal",
+      "label": "formatDateTimeLocal()",
+      "norm_label": "formatdatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L102"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "workflowtraceview_workflowtraceheader",
-      "label": "WorkflowTraceHeader()",
-      "norm_label": "workflowtraceheader()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L71"
+      "id": "serviceappointmentsview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L153"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "workflowtraceview_workflowtracetimeline",
-      "label": "WorkflowTraceTimeline()",
-      "norm_label": "workflowtracetimeline()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L124"
+      "id": "serviceappointmentsview_parsedatetimelocal",
+      "label": "parseDateTimeLocal()",
+      "norm_label": "parsedatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L97"
     },
     {
       "community": 88,
       "file_type": "code",
-      "id": "workflowtraceview_workflowtraceview",
-      "label": "WorkflowTraceView()",
-      "norm_label": "workflowtraceview()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L180"
+      "id": "serviceappointmentsview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L517"
     },
     {
       "community": 880,
@@ -70422,65 +70491,65 @@
     {
       "community": 89,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
-      "label": "session.ts",
-      "norm_label": "session.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
+      "label": "WorkflowTraceView.tsx",
+      "norm_label": "workflowtraceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
       "source_location": "L1"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "session_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L3"
+      "id": "workflowtraceview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L44"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "session_hasactiveregistersession",
-      "label": "hasActiveRegisterSession()",
-      "norm_label": "hasactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L33"
+      "id": "workflowtraceview_formattracelabel",
+      "label": "formatTraceLabel()",
+      "norm_label": "formattracelabel()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L40"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "session_hasresumableregistersession",
-      "label": "hasResumableRegisterSession()",
-      "norm_label": "hasresumableregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L39"
+      "id": "workflowtraceview_getstatustone",
+      "label": "getStatusTone()",
+      "norm_label": "getstatustone()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L51"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "session_isregisterreadytostart",
-      "label": "isRegisterReadyToStart()",
-      "norm_label": "isregisterreadytostart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L45"
+      "id": "workflowtraceview_workflowtraceheader",
+      "label": "WorkflowTraceHeader()",
+      "norm_label": "workflowtraceheader()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L71"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "session_requirescashier",
-      "label": "requiresCashier()",
-      "norm_label": "requirescashier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L29"
+      "id": "workflowtraceview_workflowtracetimeline",
+      "label": "WorkflowTraceTimeline()",
+      "norm_label": "workflowtracetimeline()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L124"
     },
     {
       "community": 89,
       "file_type": "code",
-      "id": "session_requiresterminal",
-      "label": "requiresTerminal()",
-      "norm_label": "requiresterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L25"
+      "id": "workflowtraceview_workflowtraceview",
+      "label": "WorkflowTraceView()",
+      "norm_label": "workflowtraceview()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L180"
     },
     {
       "community": 890,
@@ -70764,65 +70833,65 @@
     {
       "community": 90,
       "file_type": "code",
-      "id": "calculationservice_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "calculationservice_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "calculationservice_calculateitemtotal",
-      "label": "calculateItemTotal()",
-      "norm_label": "calculateitemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "calculationservice_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "calculationservice_geteffectiveprice",
-      "label": "getEffectivePrice()",
-      "norm_label": "geteffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "calculationservice_ispaymentsufficient",
-      "label": "isPaymentSufficient()",
-      "norm_label": "ispaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 90,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "label": "calculationService.ts",
-      "norm_label": "calculationservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "label": "session.ts",
+      "norm_label": "session.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "session_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "session_hasactiveregistersession",
+      "label": "hasActiveRegisterSession()",
+      "norm_label": "hasactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "session_hasresumableregistersession",
+      "label": "hasResumableRegisterSession()",
+      "norm_label": "hasresumableregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "session_isregisterreadytostart",
+      "label": "isRegisterReadyToStart()",
+      "norm_label": "isregisterreadytostart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "session_requirescashier",
+      "label": "requiresCashier()",
+      "norm_label": "requirescashier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 90,
+      "file_type": "code",
+      "id": "session_requiresterminal",
+      "label": "requiresTerminal()",
+      "norm_label": "requiresterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25"
     },
     {
       "community": 900,
@@ -70917,65 +70986,65 @@
     {
       "community": 91,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "calculationservice_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "calculationservice_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "calculationservice_calculateitemtotal",
+      "label": "calculateItemTotal()",
+      "norm_label": "calculateitemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "calculationservice_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "calculationservice_geteffectiveprice",
+      "label": "getEffectivePrice()",
+      "norm_label": "geteffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "calculationservice_ispaymentsufficient",
+      "label": "isPaymentSufficient()",
+      "norm_label": "ispaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 91,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
+      "label": "calculationService.ts",
+      "norm_label": "calculationservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 91,
-      "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
     },
     {
       "community": 910,
@@ -71070,65 +71139,65 @@
     {
       "community": 92,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 92,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 92,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 92,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 92,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 92,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 92,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 920,
@@ -71223,65 +71292,65 @@
     {
       "community": 93,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 930,
@@ -71376,65 +71445,65 @@
     {
       "community": 94,
       "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "label": "storefront-runtime-api.ts",
-      "norm_label": "storefront-runtime-api.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "storefront_runtime_api_emitsignal",
-      "label": "emitSignal()",
-      "norm_label": "emitsignal()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L195"
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "label": "handleCheckoutSessionFetch()",
-      "norm_label": "handlecheckoutsessionfetch()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L199"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "label": "handleCheckoutSessionUpdate()",
-      "norm_label": "handlecheckoutsessionupdate()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L221"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "storefront_runtime_api_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L186"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "storefront_runtime_api_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L394"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "storefront_runtime_api_withcorsheaders",
-      "label": "withCorsHeaders()",
-      "norm_label": "withcorsheaders()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L171"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 940,
@@ -71529,65 +71598,65 @@
     {
       "community": 95,
       "file_type": "code",
-      "id": "harness_janitor_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "label": "overwriteFreshGeneratedDocs()",
-      "norm_label": "overwritefreshgenerateddocs()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "label": "overwriteFreshGraphifyArtifacts()",
-      "norm_label": "overwritefreshgraphifyartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "harness_janitor_test_seedartifacts",
-      "label": "seedArtifacts()",
-      "norm_label": "seedartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "harness_janitor_test_sortpaths",
-      "label": "sortPaths()",
-      "norm_label": "sortpaths()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "harness_janitor_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "scripts_harness_janitor_test_ts",
-      "label": "harness-janitor.test.ts",
-      "norm_label": "harness-janitor.test.ts",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "label": "storefront-runtime-api.ts",
+      "norm_label": "storefront-runtime-api.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storefront_runtime_api_emitsignal",
+      "label": "emitSignal()",
+      "norm_label": "emitsignal()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L195"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "label": "handleCheckoutSessionFetch()",
+      "norm_label": "handlecheckoutsessionfetch()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L199"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "label": "handleCheckoutSessionUpdate()",
+      "norm_label": "handlecheckoutsessionupdate()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storefront_runtime_api_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storefront_runtime_api_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L394"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "storefront_runtime_api_withcorsheaders",
+      "label": "withCorsHeaders()",
+      "norm_label": "withcorsheaders()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L171"
     },
     {
       "community": 950,
@@ -71682,64 +71751,64 @@
     {
       "community": 96,
       "file_type": "code",
-      "id": "harness_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "harness_janitor_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgenerateddocs",
+      "label": "overwriteFreshGeneratedDocs()",
+      "norm_label": "overwritefreshgenerateddocs()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
+      "label": "overwriteFreshGraphifyArtifacts()",
+      "norm_label": "overwritefreshgraphifyartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "harness_janitor_test_seedartifacts",
+      "label": "seedArtifacts()",
+      "norm_label": "seedartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "harness_janitor_test_sortpaths",
+      "label": "sortPaths()",
+      "norm_label": "sortpaths()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "harness_janitor_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L23"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "harness_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "harness_review_test_initializegithistory",
-      "label": "initializeGitHistory()",
-      "norm_label": "initializegithistory()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L259"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "harness_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "harness_review_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L245"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "harness_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "scripts_harness_review_test_ts",
-      "label": "harness-review.test.ts",
-      "norm_label": "harness-review.test.ts",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "scripts_harness_janitor_test_ts",
+      "label": "harness-janitor.test.ts",
+      "norm_label": "harness-janitor.test.ts",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L1"
     },
     {
@@ -71835,55 +71904,64 @@
     {
       "community": 97,
       "file_type": "code",
-      "id": "index_valkeyclient",
-      "label": "ValkeyClient",
-      "norm_label": "valkeyclient",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L4"
+      "id": "harness_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L23"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "index_valkeyclient_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L11"
+      "id": "harness_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L290"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "index_valkeyclient_get",
-      "label": ".get()",
-      "norm_label": ".get()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L20"
+      "id": "harness_review_test_initializegithistory",
+      "label": "initializeGitHistory()",
+      "norm_label": "initializegithistory()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L259"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "index_valkeyclient_invalidate",
-      "label": ".invalidate()",
-      "norm_label": ".invalidate()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L75"
+      "id": "harness_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L289"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "index_valkeyclient_set",
-      "label": ".set()",
-      "norm_label": ".set()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L48"
+      "id": "harness_review_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L245"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cache_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "id": "harness_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 97,
+      "file_type": "code",
+      "id": "scripts_harness_review_test_ts",
+      "label": "harness-review.test.ts",
+      "norm_label": "harness-review.test.ts",
+      "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -71979,56 +72057,56 @@
     {
       "community": 98,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
-      "label": "paymentAllocationAttribution.ts",
-      "norm_label": "paymentallocationattribution.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L1"
+      "id": "index_valkeyclient",
+      "label": "ValkeyClient",
+      "norm_label": "valkeyclient",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L4"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "paymentallocationattribution_buildinstorepaymentallocations",
-      "label": "buildInStorePaymentAllocations()",
-      "norm_label": "buildinstorepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L48"
+      "id": "index_valkeyclient_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L11"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "paymentallocationattribution_isactiveregistersessionstatus",
-      "label": "isActiveRegisterSessionStatus()",
-      "norm_label": "isactiveregistersessionstatus()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "id": "index_valkeyclient_get",
+      "label": ".get()",
+      "norm_label": ".get()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L20"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "paymentallocationattribution_normalizeinstorepayments",
-      "label": "normalizeInStorePayments()",
-      "norm_label": "normalizeinstorepayments()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L24"
+      "id": "index_valkeyclient_invalidate",
+      "label": ".invalidate()",
+      "norm_label": ".invalidate()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L75"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
-      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
-      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L120"
+      "id": "index_valkeyclient_set",
+      "label": ".set()",
+      "norm_label": ".set()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L48"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "paymentallocationattribution_selectregistersessionforattribution",
-      "label": "selectRegisterSessionForAttribution()",
-      "norm_label": "selectregistersessionforattribution()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L83"
+      "id": "packages_athena_webapp_convex_cache_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L1"
     },
     {
       "community": 980,
@@ -72123,56 +72201,56 @@
     {
       "community": 99,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
+      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "label": "paymentAllocationAttribution.ts",
+      "norm_label": "paymentallocationattribution.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
       "source_location": "L1"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L42"
+      "id": "paymentallocationattribution_buildinstorepaymentallocations",
+      "label": "buildInStorePaymentAllocations()",
+      "norm_label": "buildinstorepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L48"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L27"
+      "id": "paymentallocationattribution_isactiveregistersessionstatus",
+      "label": "isActiveRegisterSessionStatus()",
+      "norm_label": "isactiveregistersessionstatus()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L20"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L65"
+      "id": "paymentallocationattribution_normalizeinstorepayments",
+      "label": "normalizeInStorePayments()",
+      "norm_label": "normalizeinstorepayments()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L24"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L31"
+      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
+      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L120"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
-      "source_location": "L76"
+      "id": "paymentallocationattribution_selectregistersessionforattribution",
+      "label": "selectRegisterSessionForAttribution()",
+      "norm_label": "selectregistersessionforattribution()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L83"
     },
     {
       "community": 990,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1484
-- Graph nodes: 3714
-- Graph edges: 3236
+- Graph nodes: 3716
+- Graph edges: 3241
 - Communities: 1399
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/serviceOps/appointments.ts
+++ b/packages/athena-webapp/convex/serviceOps/appointments.ts
@@ -6,6 +6,7 @@ import { v } from "convex/values";
 import { createOperationalWorkItemWithCtx } from "../operations/operationalWorkItems";
 import { recordOperationalEventWithCtx } from "../operations/operationalEvents";
 import { createServiceCaseWithCtx } from "./serviceCases";
+import { ok, userError, type CommandResult } from "../../shared/commandResult";
 
 const NON_BLOCKING_APPOINTMENT_STATUSES = new Set([
   "cancelled",
@@ -24,19 +25,37 @@ export function buildServiceAppointment(args: {
   serviceCaseId?: Id<"serviceCase">;
   startAt: number;
   storeId: Id<"store">;
-}) {
+}): CommandResult<{
+  assignedStaffProfileId: Id<"staffProfile">;
+  createdAt: number;
+  createdByUserId?: Id<"athenaUser">;
+  customerProfileId: Id<"customerProfile">;
+  durationMinutes: number;
+  endAt: number;
+  notes?: string;
+  organizationId?: Id<"organization">;
+  serviceCatalogId: Id<"serviceCatalog">;
+  serviceCaseId?: Id<"serviceCase">;
+  startAt: number;
+  status: "scheduled";
+  storeId: Id<"store">;
+  updatedAt: number;
+}> {
   if (args.durationMinutes <= 0) {
-    throw new Error("Service duration must be greater than zero");
+    return userError({
+      code: "validation_failed",
+      message: "Service duration must be greater than zero.",
+    });
   }
 
   const now = Date.now();
-  return {
+  return ok({
     ...args,
     createdAt: now,
     endAt: args.startAt + args.durationMinutes * 60_000,
     status: "scheduled" as const,
     updatedAt: now,
-  };
+  });
 }
 
 export function findOverlappingAppointment(
@@ -102,11 +121,17 @@ export const createAppointment = mutation({
     ]);
 
     if (!catalogItem || catalogItem.storeId !== args.storeId) {
-      throw new Error("Service catalog item not found for this store.");
+      return userError({
+        code: "not_found",
+        message: "Service catalog item not found for this store.",
+      });
     }
 
     if (!customerProfile || customerProfile.storeId !== args.storeId) {
-      throw new Error("Customer profile not found for this store.");
+      return userError({
+        code: "not_found",
+        message: "Customer profile not found for this store.",
+      });
     }
 
     if (
@@ -114,14 +139,22 @@ export const createAppointment = mutation({
       staffProfile.storeId !== args.storeId ||
       staffProfile.status !== "active"
     ) {
-      throw new Error("Assigned staff member is not available for this store.");
+      return userError({
+        code: "precondition_failed",
+        message: "Assigned staff member is not available for this store.",
+      });
     }
 
-    const appointment = buildServiceAppointment({
+    const appointmentResult = buildServiceAppointment({
       ...args,
       durationMinutes: catalogItem.durationMinutes,
       organizationId: catalogItem.organizationId,
     });
+    if (appointmentResult.kind === "user_error") {
+      return appointmentResult;
+    }
+
+    const appointment = appointmentResult.data;
 
     const existingAppointments = await ctx.db
       .query("serviceAppointment")
@@ -131,7 +164,10 @@ export const createAppointment = mutation({
       .collect();
 
     if (findOverlappingAppointment(existingAppointments, appointment)) {
-      throw new Error("Assigned staff member already has an appointment in this slot.");
+      return userError({
+        code: "conflict",
+        message: "Assigned staff member already has an appointment in this slot.",
+      });
     }
 
     const appointmentId = await ctx.db.insert("serviceAppointment", appointment);
@@ -147,7 +183,7 @@ export const createAppointment = mutation({
       subjectType: "service_appointment",
     });
 
-    return ctx.db.get("serviceAppointment", appointmentId);
+    return ok(await ctx.db.get("serviceAppointment", appointmentId));
   },
 });
 
@@ -161,19 +197,28 @@ export const rescheduleAppointment = mutation({
     const appointment = await ctx.db.get("serviceAppointment", args.appointmentId);
 
     if (!appointment) {
-      throw new Error("Appointment not found.");
+      return userError({
+        code: "not_found",
+        message: "Appointment not found.",
+      });
     }
 
     if (NON_BLOCKING_APPOINTMENT_STATUSES.has(appointment.status)) {
-      throw new Error("This appointment can no longer be rescheduled.");
+      return userError({
+        code: "precondition_failed",
+        message: "This appointment can no longer be rescheduled.",
+      });
     }
 
     const catalogItem = await ctx.db.get("serviceCatalog", appointment.serviceCatalogId);
     if (!catalogItem) {
-      throw new Error("Service catalog item not found.");
+      return userError({
+        code: "not_found",
+        message: "Service catalog item not found.",
+      });
     }
 
-    const candidateAppointment = buildServiceAppointment({
+    const candidateAppointmentResult = buildServiceAppointment({
       assignedStaffProfileId: appointment.assignedStaffProfileId,
       createdByUserId: appointment.createdByUserId,
       customerProfileId: appointment.customerProfileId,
@@ -185,6 +230,11 @@ export const rescheduleAppointment = mutation({
       startAt: args.startAt,
       storeId: appointment.storeId,
     });
+    if (candidateAppointmentResult.kind === "user_error") {
+      return candidateAppointmentResult;
+    }
+
+    const candidateAppointment = candidateAppointmentResult.data;
 
     const existingAppointments = await ctx.db
       .query("serviceAppointment")
@@ -201,7 +251,10 @@ export const rescheduleAppointment = mutation({
     );
 
     if (overlappingAppointment) {
-      throw new Error("Assigned staff member already has an appointment in this slot.");
+      return userError({
+        code: "conflict",
+        message: "Assigned staff member already has an appointment in this slot.",
+      });
     }
 
     await ctx.db.patch("serviceAppointment", appointment._id, {
@@ -221,7 +274,7 @@ export const rescheduleAppointment = mutation({
       subjectType: "service_appointment",
     });
 
-    return ctx.db.get("serviceAppointment", appointment._id);
+    return ok(await ctx.db.get("serviceAppointment", appointment._id));
   },
 });
 
@@ -234,7 +287,10 @@ export const cancelAppointment = mutation({
     const appointment = await ctx.db.get("serviceAppointment", args.appointmentId);
 
     if (!appointment) {
-      throw new Error("Appointment not found.");
+      return userError({
+        code: "not_found",
+        message: "Appointment not found.",
+      });
     }
 
     await ctx.db.patch("serviceAppointment", appointment._id, {
@@ -253,7 +309,7 @@ export const cancelAppointment = mutation({
       subjectType: "service_appointment",
     });
 
-    return ctx.db.get("serviceAppointment", appointment._id);
+    return ok(await ctx.db.get("serviceAppointment", appointment._id));
   },
 });
 
@@ -266,11 +322,17 @@ export const convertAppointmentToWalkIn = mutation({
     const appointment = await ctx.db.get("serviceAppointment", args.appointmentId);
 
     if (!appointment) {
-      throw new Error("Appointment not found.");
+      return userError({
+        code: "not_found",
+        message: "Appointment not found.",
+      });
     }
 
     if (appointment.serviceCaseId) {
-      throw new Error("Appointment already has a service case.");
+      return userError({
+        code: "conflict",
+        message: "Appointment already has a service case.",
+      });
     }
 
     const [catalogItem, customerProfile, store] = await Promise.all([
@@ -280,15 +342,24 @@ export const convertAppointmentToWalkIn = mutation({
     ]);
 
     if (!catalogItem) {
-      throw new Error("Service catalog item not found.");
+      return userError({
+        code: "not_found",
+        message: "Service catalog item not found.",
+      });
     }
 
     if (!customerProfile) {
-      throw new Error("Customer profile not found.");
+      return userError({
+        code: "not_found",
+        message: "Customer profile not found.",
+      });
     }
 
     if (!store) {
-      throw new Error("Store not found.");
+      return userError({
+        code: "not_found",
+        message: "Store not found.",
+      });
     }
 
     const createdByStaffProfile = args.createdByUserId
@@ -322,7 +393,10 @@ export const convertAppointmentToWalkIn = mutation({
     });
 
     if (!workItem) {
-      throw new Error("Unable to create an operational work item for this appointment.");
+      return userError({
+        code: "unavailable",
+        message: "Unable to create an operational work item for this appointment.",
+      });
     }
 
     const serviceCase = await createServiceCaseWithCtx(ctx, {
@@ -359,10 +433,10 @@ export const convertAppointmentToWalkIn = mutation({
       workItemId: workItem._id,
     });
 
-    return {
+    return ok({
       appointmentId: appointment._id,
       serviceCaseId: serviceCase._id,
       workItemId: workItem._id,
-    };
+    });
   },
 });

--- a/packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts
+++ b/packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts
@@ -69,6 +69,25 @@ describe("service catalog and appointment helpers", () => {
     });
   });
 
+  it("returns a validation_failed user_error for invalid appointment duration", () => {
+    expect(
+      buildServiceAppointment({
+        assignedStaffProfileId: "staff_1" as Id<"staffProfile">,
+        customerProfileId: "customer_1" as Id<"customerProfile">,
+        durationMinutes: 0,
+        serviceCatalogId: "catalog_1" as Id<"serviceCatalog">,
+        startAt: 1_000,
+        storeId: "store_1" as Id<"store">,
+      })
+    ).toEqual({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message: "Service duration must be greater than zero.",
+      },
+    });
+  });
+
   it("builds appointments with computed end times and default status", () => {
     expect(
       buildServiceAppointment({
@@ -80,8 +99,11 @@ describe("service catalog and appointment helpers", () => {
         storeId: "store_1" as Id<"store">,
       })
     ).toMatchObject({
-      endAt: 5_401_000,
-      status: "scheduled",
+      kind: "ok",
+      data: {
+        endAt: 5_401_000,
+        status: "scheduled",
+      },
     });
   });
 

--- a/packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GENERIC_UNEXPECTED_ERROR_MESSAGE, userError } from "~/shared/commandResult";
 import { ServiceAppointmentsViewContent } from "./ServiceAppointmentsView";
 
 const baseProps = {
@@ -31,10 +32,10 @@ const baseProps = {
   hasFullAdminAccess: true,
   isLoadingPermissions: false,
   isSaving: false,
-  onCancelAppointment: vi.fn().mockResolvedValue(undefined),
-  onConvertAppointment: vi.fn().mockResolvedValue(undefined),
-  onCreateAppointment: vi.fn().mockResolvedValue(undefined),
-  onRescheduleAppointment: vi.fn().mockResolvedValue(undefined),
+  onCancelAppointment: vi.fn().mockResolvedValue({ kind: "ok", data: null }),
+  onConvertAppointment: vi.fn().mockResolvedValue({ kind: "ok", data: null }),
+  onCreateAppointment: vi.fn().mockResolvedValue({ kind: "ok", data: null }),
+  onRescheduleAppointment: vi.fn().mockResolvedValue({ kind: "ok", data: null }),
   searchQuery: "",
   setSearchQuery: vi.fn(),
   staffOptions: [
@@ -93,7 +94,7 @@ describe("ServiceAppointmentsViewContent", () => {
 
   it("validates required appointment fields before scheduling", async () => {
     const user = userEvent.setup();
-    const onCreateAppointment = vi.fn().mockResolvedValue(undefined);
+    const onCreateAppointment = vi.fn().mockResolvedValue({ kind: "ok", data: null });
 
     render(
       <ServiceAppointmentsViewContent
@@ -113,7 +114,7 @@ describe("ServiceAppointmentsViewContent", () => {
 
   it("creates appointments from catalog and selected customers", async () => {
     const user = userEvent.setup();
-    const onCreateAppointment = vi.fn().mockResolvedValue(undefined);
+    const onCreateAppointment = vi.fn().mockResolvedValue({ kind: "ok", data: null });
 
     render(
       <ServiceAppointmentsViewContent
@@ -139,9 +140,9 @@ describe("ServiceAppointmentsViewContent", () => {
 
   it("reschedules, cancels, and converts appointments", async () => {
     const user = userEvent.setup();
-    const onCancelAppointment = vi.fn().mockResolvedValue(undefined);
-    const onConvertAppointment = vi.fn().mockResolvedValue(undefined);
-    const onRescheduleAppointment = vi.fn().mockResolvedValue(undefined);
+    const onCancelAppointment = vi.fn().mockResolvedValue({ kind: "ok", data: null });
+    const onConvertAppointment = vi.fn().mockResolvedValue({ kind: "ok", data: null });
+    const onRescheduleAppointment = vi.fn().mockResolvedValue({ kind: "ok", data: null });
 
     render(
       <ServiceAppointmentsViewContent
@@ -170,5 +171,98 @@ describe("ServiceAppointmentsViewContent", () => {
     expect(onConvertAppointment).toHaveBeenCalledWith({
       appointmentId: "appointment-1",
     });
+  });
+
+  it("renders safe user_error copy inline and clears stale errors before retry", async () => {
+    const user = userEvent.setup();
+    const onCreateAppointment = vi
+      .fn()
+      .mockResolvedValueOnce(
+        userError({
+          code: "conflict",
+          message: "Assigned staff member already has an appointment in this slot.",
+        }),
+      )
+      .mockResolvedValueOnce({ kind: "ok", data: null });
+
+    render(
+      <ServiceAppointmentsViewContent
+        {...baseProps}
+        onCreateAppointment={onCreateAppointment}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /use customer/i }));
+    await chooseSelectOption(user, /service catalog/i, /closure repair/i);
+    await chooseSelectOption(user, /assigned staff/i, /adjoa tetteh/i);
+    await chooseDateTime(user, /appointment start/i, "10", "00");
+    await user.click(screen.getByRole("button", { name: /schedule appointment/i }));
+
+    expect(
+      await screen.findByText(
+        "Assigned staff member already has an appointment in this slot.",
+      ),
+    ).toBeInTheDocument();
+
+    await chooseDateTime(user, /appointment start/i, "11", "15");
+    await user.click(screen.getByRole("button", { name: /schedule appointment/i }));
+
+    await waitFor(() => expect(onCreateAppointment).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(
+        screen.queryByText(
+          "Assigned staff member already has an appointment in this slot.",
+        ),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("renders generic fallback copy inline for unexpected failures", async () => {
+    const user = userEvent.setup();
+    const onCreateAppointment = vi.fn().mockResolvedValue({
+      kind: "unexpected_error",
+      error: {
+        title: "Something went wrong",
+        message: GENERIC_UNEXPECTED_ERROR_MESSAGE,
+      },
+    });
+
+    render(
+      <ServiceAppointmentsViewContent
+        {...baseProps}
+        onCreateAppointment={onCreateAppointment}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /use customer/i }));
+    await chooseSelectOption(user, /service catalog/i, /closure repair/i);
+    await chooseSelectOption(user, /assigned staff/i, /adjoa tetteh/i);
+    await chooseDateTime(user, /appointment start/i, "10", "00");
+    await user.click(screen.getByRole("button", { name: /schedule appointment/i }));
+
+    expect(await screen.findByText(GENERIC_UNEXPECTED_ERROR_MESSAGE)).toBeInTheDocument();
+  });
+
+  it("renders safe inline copy for convert failures", async () => {
+    const user = userEvent.setup();
+    const onConvertAppointment = vi.fn().mockResolvedValue(
+      userError({
+        code: "conflict",
+        message: "Appointment already has a service case.",
+      }),
+    );
+
+    render(
+      <ServiceAppointmentsViewContent
+        {...baseProps}
+        onConvertAppointment={onConvertAppointment}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /convert closure repair/i }));
+
+    expect(
+      await screen.findByText("Appointment already has a service case."),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx
@@ -18,6 +18,10 @@ import {
   SelectValue,
 } from "../ui/select";
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
+import {
+  type NormalizedCommandResult,
+  runCommand,
+} from "@/lib/errors/runCommand";
 import { api } from "~/convex/_generated/api";
 
 type CustomerResult = {
@@ -55,6 +59,8 @@ type CreateAppointmentArgs = {
   startAt: number;
 };
 
+type AppointmentCommandResult = NormalizedCommandResult<unknown>;
+
 type ServiceAppointmentsViewContentProps = {
   appointments: AppointmentItem[];
   catalogItems: CatalogItem[];
@@ -62,13 +68,19 @@ type ServiceAppointmentsViewContentProps = {
   hasFullAdminAccess: boolean;
   isLoadingPermissions: boolean;
   isSaving: boolean;
-  onCancelAppointment: (args: { appointmentId: string }) => Promise<void>;
-  onConvertAppointment: (args: { appointmentId: string }) => Promise<void>;
-  onCreateAppointment: (args: CreateAppointmentArgs) => Promise<void>;
+  onCancelAppointment: (
+    args: { appointmentId: string }
+  ) => Promise<AppointmentCommandResult>;
+  onConvertAppointment: (
+    args: { appointmentId: string }
+  ) => Promise<AppointmentCommandResult>;
+  onCreateAppointment: (
+    args: CreateAppointmentArgs
+  ) => Promise<AppointmentCommandResult>;
   onRescheduleAppointment: (args: {
     appointmentId: string;
     startAt: number;
-  }) => Promise<void>;
+  }) => Promise<AppointmentCommandResult>;
   searchQuery: string;
   setSearchQuery: (value: string) => void;
   staffOptions: StaffOption[];
@@ -114,6 +126,16 @@ export function ServiceAppointmentsViewContent({
   const [rescheduleTimes, setRescheduleTimes] = useState<Record<string, string>>({});
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
 
+  const applyCommandResult = (result: AppointmentCommandResult) => {
+    if (result.kind === "ok") {
+      setValidationErrors([]);
+      return true;
+    }
+
+    setValidationErrors([result.error.message]);
+    return false;
+  };
+
   if (isLoadingPermissions) {
     return (
       <View>
@@ -153,22 +175,22 @@ export function ServiceAppointmentsViewContent({
       return;
     }
 
-    try {
-      await onCreateAppointment({
-        assignedStaffProfileId: form.assignedStaffProfileId,
-        customerProfileId: form.selectedCustomerId,
-        notes: form.notes.trim() || undefined,
-        serviceCatalogId: form.serviceCatalogId,
-        startAt: parsedStartAt!,
-      });
-      setForm(initialFormState);
-      setValidationErrors([]);
-      setSearchQuery("");
-    } catch (error) {
-      toast.error("Failed to schedule appointment", {
-        description: (error as Error).message,
-      });
+    setValidationErrors([]);
+    const result = await onCreateAppointment({
+      assignedStaffProfileId: form.assignedStaffProfileId,
+      customerProfileId: form.selectedCustomerId,
+      notes: form.notes.trim() || undefined,
+      serviceCatalogId: form.serviceCatalogId,
+      startAt: parsedStartAt!,
+    });
+
+    if (!applyCommandResult(result)) {
+      return;
     }
+
+    setForm(initialFormState);
+    setSearchQuery("");
+    toast.success("Appointment scheduled");
   };
 
   return (
@@ -368,20 +390,33 @@ export function ServiceAppointmentsViewContent({
                 <div className="flex flex-wrap gap-2">
                   <Button
                     aria-label={`Reschedule ${appointment.serviceCatalogName ?? "appointment"}`}
-                    onClick={() => {
+                    onClick={async () => {
                       const parsedStartAt = parseDateTimeLocal(
                         rescheduleTimes[appointment._id] ?? ""
                       );
 
                       if (parsedStartAt === null) {
-                        toast.error("Choose a new start time before rescheduling.");
+                        setValidationErrors([
+                          "Choose a new start time before rescheduling.",
+                        ]);
                         return;
                       }
 
-                      onRescheduleAppointment({
+                      setValidationErrors([]);
+                      const result = await onRescheduleAppointment({
                         appointmentId: appointment._id,
                         startAt: parsedStartAt,
                       });
+
+                      if (!applyCommandResult(result)) {
+                        return;
+                      }
+
+                      setRescheduleTimes((current) => ({
+                        ...current,
+                        [appointment._id]: "",
+                      }));
+                      toast.success("Appointment rescheduled");
                     }}
                     size="sm"
                     type="button"
@@ -391,11 +426,18 @@ export function ServiceAppointmentsViewContent({
                   </Button>
                   <Button
                     aria-label={`Cancel ${appointment.serviceCatalogName ?? "appointment"}`}
-                    onClick={() =>
-                      onCancelAppointment({
+                    onClick={async () => {
+                      setValidationErrors([]);
+                      const result = await onCancelAppointment({
                         appointmentId: appointment._id,
-                      })
-                    }
+                      });
+
+                      if (!applyCommandResult(result)) {
+                        return;
+                      }
+
+                      toast.success("Appointment cancelled");
+                    }}
                     size="sm"
                     type="button"
                     variant="outline"
@@ -404,11 +446,18 @@ export function ServiceAppointmentsViewContent({
                   </Button>
                   <Button
                     aria-label={`Convert ${appointment.serviceCatalogName ?? "appointment"}`}
-                    onClick={() =>
-                      onConvertAppointment({
+                    onClick={async () => {
+                      setValidationErrors([]);
+                      const result = await onConvertAppointment({
                         appointmentId: appointment._id,
-                      })
-                    }
+                      });
+
+                      if (!applyCommandResult(result)) {
+                        return;
+                      }
+
+                      toast.success("Appointment converted to walk-in");
+                    }}
                     size="sm"
                     type="button"
                   >
@@ -469,10 +518,10 @@ export function ServiceAppointmentsView() {
     api.serviceOps.appointments.convertAppointmentToWalkIn
   );
 
-  const withSaveState = async (action: () => Promise<void>) => {
+  const withSaveState = async <T,>(action: () => Promise<T>) => {
     setIsSaving(true);
     try {
-      await action();
+      return await action();
     } finally {
       setIsSaving(false);
     }
@@ -520,41 +569,45 @@ export function ServiceAppointmentsView() {
       isLoadingPermissions={false}
       isSaving={isSaving}
       onCancelAppointment={(args) =>
-        withSaveState(async () => {
-          await cancelAppointment({
-            appointmentId: args.appointmentId as any,
-          });
-          toast.success("Appointment cancelled");
-        })
+        withSaveState(() =>
+          runCommand(() =>
+            cancelAppointment({
+              appointmentId: args.appointmentId as any,
+            })
+          )
+        )
       }
       onConvertAppointment={(args) =>
-        withSaveState(async () => {
-          await convertAppointmentToWalkIn({
-            appointmentId: args.appointmentId as any,
-          });
-          toast.success("Appointment converted to walk-in");
-        })
+        withSaveState(() =>
+          runCommand(() =>
+            convertAppointmentToWalkIn({
+              appointmentId: args.appointmentId as any,
+            })
+          )
+        )
       }
       onCreateAppointment={(args) =>
-        withSaveState(async () => {
-          await createAppointment({
-            ...args,
-            assignedStaffProfileId: args.assignedStaffProfileId as any,
-            customerProfileId: args.customerProfileId as any,
-            serviceCatalogId: args.serviceCatalogId as any,
-            storeId: activeStore._id,
-          });
-          toast.success("Appointment scheduled");
-        })
+        withSaveState(() =>
+          runCommand(() =>
+            createAppointment({
+              ...args,
+              assignedStaffProfileId: args.assignedStaffProfileId as any,
+              customerProfileId: args.customerProfileId as any,
+              serviceCatalogId: args.serviceCatalogId as any,
+              storeId: activeStore._id,
+            })
+          )
+        )
       }
       onRescheduleAppointment={(args) =>
-        withSaveState(async () => {
-          await rescheduleAppointment({
-            appointmentId: args.appointmentId as any,
-            startAt: args.startAt,
-          });
-          toast.success("Appointment rescheduled");
-        })
+        withSaveState(() =>
+          runCommand(() =>
+            rescheduleAppointment({
+              appointmentId: args.appointmentId as any,
+              startAt: args.startAt,
+            })
+          )
+        )
       }
       searchQuery={searchQuery}
       setSearchQuery={setSearchQuery}


### PR DESCRIPTION
## Summary
- migrate service appointment mutations to shared `CommandResult` / `user_error` handling for expected failures
- move the appointments UI onto `runCommand` with inline durable-surface errors for create, reschedule, cancel, and convert flows
- extend appointment helper/UI tests and refresh graphify artifacts

## Why
- appointment scheduling still leaked raw thrown backend text through a durable admin surface
- this aligns the appointment slice with the shared server/error foundation already used in adjacent Athena surfaces

## Validation
- `bun run --filter '@athena/webapp' test -- convex/serviceOps/catalogAppointments.test.ts src/components/services/ServiceAppointmentsView.test.tsx`
- `bun run --filter '@athena/webapp' test convex/serviceOps/serviceCases.test.ts convex/serviceOps/catalogAppointments.test.ts convex/serviceOps/moduleWiring.test.ts convex/operations/serviceIntake.test.ts src/components/services/ServiceIntakeView.test.tsx src/components/services/ServiceIntakeView.auth.test.tsx src/components/services/ServiceAppointmentsView.test.tsx src/components/services/ServiceCasesView.test.tsx src/components/services/ServiceCatalogView.test.tsx src/components/operations/OperationsQueueView.test.tsx`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run --filter '@athena/webapp' audit:convex`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run --filter '@athena/webapp' build`
- `git diff --check`
- `bun run graphify:rebuild`

Linear: https://linear.app/v26-labs/issue/V26-355/migrate-service-appointment-command-flows-to-the-shared-servererror
