### PR TITLE
[V26-356] Migrate service case command flows to the shared server/error foundation

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3716 nodes · 3241 edges · 1399 communities detected
+- 3718 nodes · 3244 edges · 1399 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1581,20 +1581,20 @@ Cohesion: 0.24
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
 ### Community 36 - "Community 36"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 37 - "Community 37"
 Cohesion: 0.36
 Nodes (9): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), resolveStockAdjustmentApprovalDecisionWithCtx(), submitStockAdjustmentBatchWithCtx() (+1 more)
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.18
 Nodes (0):
-
-### Community 39 - "Community 39"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 40 - "Community 40"
 Cohesion: 0.18
@@ -1690,19 +1690,19 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 63 - "Community 63"
 Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 64 - "Community 64"
 Cohesion: 0.43
-Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
 ### Community 65 - "Community 65"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.43
+Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
 ### Community 66 - "Community 66"
-Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 67 - "Community 67"
 Cohesion: 0.36
@@ -2293,16 +2293,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 214 - "Community 214"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 215 - "Community 215"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 216 - "Community 216"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 216 - "Community 216"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 217 - "Community 217"
 Cohesion: 0.5
@@ -2313,36 +2313,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 219 - "Community 219"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 220 - "Community 220"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.67
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 226 - "Community 226"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 227 - "Community 227"
 Cohesion: 0.5
@@ -2365,51 +2365,51 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 232 - "Community 232"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 233 - "Community 233"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 238 - "Community 238"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 239 - "Community 239"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 240 - "Community 240"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 241 - "Community 241"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 242 - "Community 242"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 243 - "Community 243"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 244 - "Community 244"
@@ -2425,12 +2425,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 247 - "Community 247"
-Cohesion: 1.0
-Nodes (2): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestWithCtx()
-
-### Community 248 - "Community 248"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 248 - "Community 248"
+Cohesion: 1.0
+Nodes (2): decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestWithCtx()
 
 ### Community 249 - "Community 249"
 Cohesion: 0.67
@@ -2441,76 +2441,76 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 251 - "Community 251"
-Cohesion: 1.0
-Nodes (2): mapOpenDrawerUserError(), openDrawer()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 252 - "Community 252"
 Cohesion: 1.0
-Nodes (2): buildRegisterState(), getRegisterState()
+Nodes (2): mapOpenDrawerUserError(), openDrawer()
 
 ### Community 253 - "Community 253"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildRegisterState(), getRegisterState()
 
 ### Community 254 - "Community 254"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 255 - "Community 255"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 256 - "Community 256"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 257 - "Community 257"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 258 - "Community 258"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 258 - "Community 258"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 259 - "Community 259"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 260 - "Community 260"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 261 - "Community 261"
 Cohesion: 1.0
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 262 - "Community 262"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 263 - "Community 263"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 264 - "Community 264"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 265 - "Community 265"
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 266 - "Community 266"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 267 - "Community 267"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 268 - "Community 268"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 269 - "Community 269"
 Cohesion: 0.67
@@ -2525,16 +2525,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 272 - "Community 272"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 273 - "Community 273"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 274 - "Community 274"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 275 - "Community 275"
 Cohesion: 0.67
@@ -2542,11 +2542,11 @@ Nodes (0):
 
 ### Community 276 - "Community 276"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 277 - "Community 277"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 278 - "Community 278"
 Cohesion: 0.67
@@ -2554,11 +2554,11 @@ Nodes (0):
 
 ### Community 279 - "Community 279"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 280 - "Community 280"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 281 - "Community 281"
 Cohesion: 0.67
@@ -2577,12 +2577,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 285 - "Community 285"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceLinkTarget(), WorkflowTraceLink()
-
-### Community 286 - "Community 286"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 286 - "Community 286"
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceLinkTarget(), WorkflowTraceLink()
 
 ### Community 287 - "Community 287"
 Cohesion: 0.67
@@ -2618,79 +2618,79 @@ Nodes (0):
 
 ### Community 295 - "Community 295"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 296 - "Community 296"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 297 - "Community 297"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 298 - "Community 298"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 299 - "Community 299"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 300 - "Community 300"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 301 - "Community 301"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 302 - "Community 302"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 303 - "Community 303"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 304 - "Community 304"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 305 - "Community 305"
+### Community 306 - "Community 306"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 306 - "Community 306"
+### Community 307 - "Community 307"
 Cohesion: 0.67
 Nodes (1): LoadingButton()
 
-### Community 307 - "Community 307"
+### Community 308 - "Community 308"
 Cohesion: 0.67
 Nodes (1): onChange()
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.67
 Nodes (1): AlertModal()
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.67
 Nodes (1): OverlayModal()
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.67
 Nodes (1): Skeleton()
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.67
 Nodes (1): Toaster()
 
-### Community 312 - "Community 312"
-Cohesion: 0.67
-Nodes (1): Spinner()
-
 ### Community 313 - "Community 313"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 314 - "Community 314"
 Cohesion: 0.67
@@ -2718,11 +2718,11 @@ Nodes (0):
 
 ### Community 320 - "Community 320"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 321 - "Community 321"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 322 - "Community 322"
 Cohesion: 0.67
@@ -2733,16 +2733,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 324 - "Community 324"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 325 - "Community 325"
 Cohesion: 1.0
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 325 - "Community 325"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 326 - "Community 326"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 327 - "Community 327"
 Cohesion: 0.67
@@ -2750,63 +2750,63 @@ Nodes (0):
 
 ### Community 328 - "Community 328"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 329 - "Community 329"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 330 - "Community 330"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 331 - "Community 331"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 332 - "Community 332"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 333 - "Community 333"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 333 - "Community 333"
+### Community 334 - "Community 334"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 334 - "Community 334"
+### Community 335 - "Community 335"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 335 - "Community 335"
-Cohesion: 0.67
-Nodes (1): manualChunks()
-
 ### Community 336 - "Community 336"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 337 - "Community 337"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 338 - "Community 338"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 339 - "Community 339"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 339 - "Community 339"
+### Community 340 - "Community 340"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 340 - "Community 340"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 341 - "Community 341"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 342 - "Community 342"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 343 - "Community 343"
 Cohesion: 0.67
@@ -2817,12 +2817,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 345 - "Community 345"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 346 - "Community 346"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 346 - "Community 346"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 347 - "Community 347"
 Cohesion: 0.67
@@ -2833,12 +2833,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 349 - "Community 349"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 350 - "Community 350"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 350 - "Community 350"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 351 - "Community 351"
 Cohesion: 0.67
@@ -2917,16 +2917,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 370 - "Community 370"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 371 - "Community 371"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 372 - "Community 372"
+### Community 371 - "Community 371"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 372 - "Community 372"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 373 - "Community 373"
 Cohesion: 1.0
@@ -2941,20 +2941,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 376 - "Community 376"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 377 - "Community 377"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 378 - "Community 378"
-Cohesion: 1.0
-Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 379 - "Community 379"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 380 - "Community 380"
 Cohesion: 1.0
@@ -7033,283 +7033,281 @@ Cohesion: 1.0
 Nodes (0):
 
 ## Knowledge Gaps
-- **Thin community `Community 379`** (2 nodes): `getSource()`, `closeouts.test.ts`
+- **Thin community `Community 380`** (2 nodes): `getSource()`, `closeouts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 381`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 382`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 383`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 384`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 385`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 386`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 387`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 388`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 389`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 390`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 391`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 392`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 393`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 394`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 395`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 396`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 397`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `registerSessionTracing.test.ts`, `buildSession()`
+- **Thin community `Community 398`** (2 nodes): `registerSessionTracing.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `staffProfiles.test.ts`, `createStaffProfilesMutationCtx()`
+- **Thin community `Community 399`** (2 nodes): `staffProfiles.test.ts`, `createStaffProfilesMutationCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 400`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
+- **Thin community `Community 401`** (2 nodes): `createInventoryHoldGateway()`, `inventoryHoldGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 402`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 403`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 404`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 405`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 406`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 407`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
+- **Thin community `Community 408`** (2 nodes): `purchaseOrders.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `receiving.test.ts`, `getSource()`
+- **Thin community `Community 409`** (2 nodes): `receiving.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `vendors.test.ts`, `getSource()`
+- **Thin community `Community 410`** (2 nodes): `vendors.test.ts`, `getSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 411`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 412`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 413`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 414`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 415`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 416`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 417`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 418`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 419`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 420`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 421`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 422`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 423`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 424`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `posSale.ts`, `buildPosSaleTraceSeed()`
+- **Thin community `Community 425`** (2 nodes): `posSale.ts`, `buildPosSaleTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 426`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 427`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 428`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 429`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 430`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 431`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 432`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 433`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 434`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 435`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 436`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 437`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 438`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 439`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 440`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 441`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 442`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 443`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 444`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 445`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 446`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 447`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 448`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 449`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 450`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 451`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 452`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 453`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 454`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 455`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 456`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 457`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 458`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 459`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 460`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 461`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 462`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 463`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 464`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 465`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 466`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 467`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 468`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 469`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 470`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 471`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 472`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 473`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 474`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 475`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 476`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 477`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
+- **Thin community `Community 478`** (2 nodes): `handleRefundOrder()`, `OrderView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 479`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 480`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 481`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 482`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 483`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `CashierView()`, `CashierView.tsx`
+- **Thin community `Community 484`** (2 nodes): `CashierView()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 485`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 486`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 487`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 488`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 489`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 490`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 491`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 492`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 493`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 494`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 495`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `RegisterDrawerGate.tsx`, `RegisterDrawerGate()`
+- **Thin community `Community 496`** (2 nodes): `RegisterDrawerGate.tsx`, `RegisterDrawerGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 497`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 498`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 499`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 500`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 501`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 502`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 503`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 504`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 505`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 506`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 507`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 508`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 509`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 510`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 511`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 512`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 513`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 514`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 515`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 516`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `ServiceCasesView.tsx`, `handleCreateCase()`
+- **Thin community `Community 517`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 518`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -11927,7 +11927,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L216",
+      "source_location": "L226",
       "target": "servicecases_assertvalidservicecasestatustransition",
       "weight": 1
     },
@@ -11939,7 +11939,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L225",
+      "source_location": "L240",
       "target": "servicecases_buildservicecase",
       "weight": 1
     },
@@ -11951,7 +11951,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L253",
+      "source_location": "L268",
       "target": "servicecases_buildservicecaselineitem",
       "weight": 1
     },
@@ -11963,7 +11963,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L275",
+      "source_location": "L304",
       "target": "servicecases_createservicecasewithctx",
       "weight": 1
     },
@@ -11975,7 +11975,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L86",
+      "source_location": "L87",
       "target": "servicecases_deriveservicecasepaymentstatus",
       "weight": 1
     },
@@ -11987,7 +11987,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L190",
+      "source_location": "L191",
       "target": "servicecases_getservicecasecontext",
       "weight": 1
     },
@@ -11999,7 +11999,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L143",
+      "source_location": "L144",
       "target": "servicecases_listpendingapprovalrequestswithctx",
       "weight": 1
     },
@@ -12011,7 +12011,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L130",
+      "source_location": "L131",
       "target": "servicecases_listservicecaseallocationswithctx",
       "weight": 1
     },
@@ -12023,7 +12023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L110",
+      "source_location": "L111",
       "target": "servicecases_listservicecaselineitemswithctx",
       "weight": 1
     },
@@ -12035,7 +12035,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L120",
+      "source_location": "L121",
       "target": "servicecases_listserviceinventoryusagewithctx",
       "weight": 1
     },
@@ -12047,7 +12047,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L70",
+      "source_location": "L71",
       "target": "servicecases_mapservicecasestatustoworkitemstatus",
       "weight": 1
     },
@@ -12059,7 +12059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_serviceops_servicecases_ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L155",
+      "source_location": "L156",
       "target": "servicecases_syncservicecasefinancialswithctx",
       "weight": 1
     },
@@ -19259,8 +19259,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
-      "source_location": "L62",
+      "source_location": "L63",
       "target": "servicecasesview_test_chooseselectoption",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
+      "_tgt": "servicecasesview_applycommandresult",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L173",
+      "target": "servicecasesview_applycommandresult",
       "weight": 1
     },
     {
@@ -19271,8 +19283,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L178",
+      "source_location": "L200",
       "target": "servicecasesview_handlecreatecase",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
+      "_tgt": "servicecasesview_withsavestate",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L778",
+      "target": "servicecasesview_withsavestate",
       "weight": 1
     },
     {
@@ -36023,7 +36047,7 @@
       "relation": "calls",
       "source": "servicecases_buildservicecase",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L290",
+      "source_location": "L319",
       "target": "servicecases_createservicecasewithctx",
       "weight": 1
     },
@@ -36035,7 +36059,7 @@
       "relation": "calls",
       "source": "servicecases_deriveservicecasepaymentstatus",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L174",
+      "source_location": "L175",
       "target": "servicecases_syncservicecasefinancialswithctx",
       "weight": 1
     },
@@ -36047,7 +36071,7 @@
       "relation": "calls",
       "source": "servicecases_listservicecaseallocationswithctx",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L165",
+      "source_location": "L166",
       "target": "servicecases_syncservicecasefinancialswithctx",
       "weight": 1
     },
@@ -36059,7 +36083,7 @@
       "relation": "calls",
       "source": "servicecases_listservicecaselineitemswithctx",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L164",
+      "source_location": "L165",
       "target": "servicecases_syncservicecasefinancialswithctx",
       "weight": 1
     },
@@ -36073,6 +36097,18 @@
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
       "source_location": "L24",
       "target": "servicecases_test_expectindex",
+      "weight": 1
+    },
+    {
+      "_src": "servicecasesview_handlecreatecase",
+      "_tgt": "servicecasesview_applycommandresult",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "servicecasesview_applycommandresult",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L232",
+      "target": "servicecasesview_handlecreatecase",
       "weight": 1
     },
     {
@@ -50673,6 +50709,42 @@
     {
       "community": 214,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
+      "label": "ServiceCasesView.tsx",
+      "norm_label": "servicecasesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 214,
+      "file_type": "code",
+      "id": "servicecasesview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L173"
+    },
+    {
+      "community": 214,
+      "file_type": "code",
+      "id": "servicecasesview_handlecreatecase",
+      "label": "handleCreateCase()",
+      "norm_label": "handlecreatecase()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L200"
+    },
+    {
+      "community": 214,
+      "file_type": "code",
+      "id": "servicecasesview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L778"
+    },
+    {
+      "community": 215,
+      "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
       "norm_label": "formatlastactivity()",
@@ -50680,7 +50752,7 @@
       "source_location": "L75"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -50689,7 +50761,7 @@
       "source_location": "L82"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -50698,7 +50770,7 @@
       "source_location": "L93"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -50707,7 +50779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -50716,7 +50788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -50725,7 +50797,7 @@
       "source_location": "L15"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -50734,7 +50806,7 @@
       "source_location": "L28"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -50743,7 +50815,7 @@
       "source_location": "L54"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -50752,7 +50824,7 @@
       "source_location": "L66"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -50761,7 +50833,7 @@
       "source_location": "L121"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -50770,7 +50842,7 @@
       "source_location": "L74"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -50779,7 +50851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -50788,7 +50860,7 @@
       "source_location": "L51"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -50797,7 +50869,7 @@
       "source_location": "L92"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -50806,7 +50878,7 @@
       "source_location": "L16"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -50815,7 +50887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -50824,7 +50896,7 @@
       "source_location": "L16"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -50833,7 +50905,7 @@
       "source_location": "L6"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -50842,49 +50914,13 @@
       "source_location": "L46"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
       "norm_label": "customergateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
-      "label": "sessionGateway.mapper.ts",
-      "norm_label": "sessiongateway.mapper.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapactivesessiondto",
-      "label": "mapActiveSessionDto()",
-      "norm_label": "mapactivesessiondto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapheldsessionsdto",
-      "label": "mapHeldSessionsDto()",
-      "norm_label": "mapheldsessionsdto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_normalizecartitems",
-      "label": "normalizeCartItems()",
-      "norm_label": "normalizecartitems()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L79"
     },
     {
       "community": 22,
@@ -51042,6 +51078,42 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
+      "label": "sessionGateway.mapper.ts",
+      "norm_label": "sessiongateway.mapper.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapactivesessiondto",
+      "label": "mapActiveSessionDto()",
+      "norm_label": "mapactivesessiondto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapheldsessionsdto",
+      "label": "mapHeldSessionsDto()",
+      "norm_label": "mapheldsessionsdto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_normalizecartitems",
+      "label": "normalizeCartItems()",
+      "norm_label": "normalizecartitems()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
       "norm_label": "sessiongateway.ts",
@@ -51049,7 +51121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -51058,7 +51130,7 @@
       "source_location": "L25"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -51067,7 +51139,7 @@
       "source_location": "L52"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -51076,7 +51148,7 @@
       "source_location": "L78"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -51085,7 +51157,7 @@
       "source_location": "L4"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -51094,7 +51166,7 @@
       "source_location": "L20"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -51103,7 +51175,7 @@
       "source_location": "L42"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -51112,7 +51184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -51121,7 +51193,7 @@
       "source_location": "L101"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -51130,7 +51202,7 @@
       "source_location": "L68"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -51139,7 +51211,7 @@
       "source_location": "L42"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -51148,7 +51220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -51157,7 +51229,7 @@
       "source_location": "L13"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -51166,7 +51238,7 @@
       "source_location": "L46"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -51175,7 +51247,7 @@
       "source_location": "L21"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -51184,7 +51256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -51193,7 +51265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -51202,7 +51274,7 @@
       "source_location": "L8"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -51211,7 +51283,7 @@
       "source_location": "L5"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -51220,7 +51292,7 @@
       "source_location": "L20"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -51229,7 +51301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -51238,7 +51310,7 @@
       "source_location": "L11"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -51247,7 +51319,7 @@
       "source_location": "L9"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -51256,7 +51328,7 @@
       "source_location": "L25"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -51265,7 +51337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -51274,7 +51346,7 @@
       "source_location": "L50"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -51283,7 +51355,7 @@
       "source_location": "L92"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -51292,7 +51364,7 @@
       "source_location": "L74"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -51301,7 +51373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -51310,7 +51382,7 @@
       "source_location": "L62"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -51319,7 +51391,7 @@
       "source_location": "L109"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -51328,7 +51400,7 @@
       "source_location": "L177"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -51337,7 +51409,7 @@
       "source_location": "L18"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -51346,7 +51418,7 @@
       "source_location": "L52"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -51355,48 +51427,12 @@
       "source_location": "L68"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
       "norm_label": "billingdetailssection.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "hooks_usegetshopsearchparams",
-      "label": "useGetShopSearchParams()",
-      "norm_label": "usegetshopsearchparams()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "hooks_usegetstorecategories",
-      "label": "useGetStoreCategories()",
-      "norm_label": "usegetstorecategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "hooks_usegetstoresubcategories",
-      "label": "useGetStoreSubcategories()",
-      "norm_label": "usegetstoresubcategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1"
     },
     {
@@ -51546,6 +51582,42 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "hooks_usegetshopsearchparams",
+      "label": "useGetShopSearchParams()",
+      "norm_label": "usegetshopsearchparams()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "hooks_usegetstorecategories",
+      "label": "useGetStoreCategories()",
+      "norm_label": "usegetstorecategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "hooks_usegetstoresubcategories",
+      "label": "useGetStoreSubcategories()",
+      "norm_label": "usegetstoresubcategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
       "norm_label": "productdetails.tsx",
@@ -51553,7 +51625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -51562,7 +51634,7 @@
       "source_location": "L43"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -51571,7 +51643,7 @@
       "source_location": "L13"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -51580,7 +51652,7 @@
       "source_location": "L88"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -51589,7 +51661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -51598,7 +51670,7 @@
       "source_location": "L111"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -51607,7 +51679,7 @@
       "source_location": "L66"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -51616,7 +51688,7 @@
       "source_location": "L127"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -51625,7 +51697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -51634,7 +51706,7 @@
       "source_location": "L115"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -51643,7 +51715,7 @@
       "source_location": "L105"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -51652,7 +51724,7 @@
       "source_location": "L110"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -51661,7 +51733,7 @@
       "source_location": "L121"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -51670,7 +51742,7 @@
       "source_location": "L26"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -51679,7 +51751,7 @@
       "source_location": "L71"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -51688,7 +51760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -51697,7 +51769,7 @@
       "source_location": "L46"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -51706,7 +51778,7 @@
       "source_location": "L24"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -51715,7 +51787,7 @@
       "source_location": "L20"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -51724,7 +51796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
@@ -51733,7 +51805,7 @@
       "source_location": "L33"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -51742,7 +51814,7 @@
       "source_location": "L6"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -51751,7 +51823,7 @@
       "source_location": "L25"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -51760,7 +51832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -51769,7 +51841,7 @@
       "source_location": "L17"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -51778,7 +51850,7 @@
       "source_location": "L11"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -51787,7 +51859,7 @@
       "source_location": "L24"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -51796,7 +51868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -51805,7 +51877,7 @@
       "source_location": "L20"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -51814,7 +51886,7 @@
       "source_location": "L65"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -51823,7 +51895,7 @@
       "source_location": "L14"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -51832,7 +51904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -51841,7 +51913,7 @@
       "source_location": "L126"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -51850,7 +51922,7 @@
       "source_location": "L130"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -51859,49 +51931,13 @@
       "source_location": "L749"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
       "norm_label": "harness-app-registry.ts",
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
-      "label": "valkey-runtime-app.ts",
-      "norm_label": "valkey-runtime-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "valkey_runtime_app_createvalkeyruntimeserver",
-      "label": "createValkeyRuntimeServer()",
-      "norm_label": "createvalkeyruntimeserver()",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "valkey_runtime_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "valkey_runtime_app_stopvalkeyruntimeserver",
-      "label": "stopValkeyRuntimeServer()",
-      "norm_label": "stopvalkeyruntimeserver()",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
-      "source_location": "L61"
     },
     {
       "community": 24,
@@ -52050,6 +52086,42 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
+      "label": "valkey-runtime-app.ts",
+      "norm_label": "valkey-runtime-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "valkey_runtime_app_createvalkeyruntimeserver",
+      "label": "createValkeyRuntimeServer()",
+      "norm_label": "createvalkeyruntimeserver()",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "valkey_runtime_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "valkey_runtime_app_stopvalkeyruntimeserver",
+      "label": "stopValkeyRuntimeServer()",
+      "norm_label": "stopvalkeyruntimeserver()",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
       "norm_label": "createfixturerepo()",
@@ -52057,7 +52129,7 @@
       "source_location": "L49"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -52066,7 +52138,7 @@
       "source_location": "L17"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -52075,7 +52147,7 @@
       "source_location": "L11"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -52084,7 +52156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -52093,7 +52165,7 @@
       "source_location": "L26"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -52102,7 +52174,7 @@
       "source_location": "L72"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -52111,7 +52183,7 @@
       "source_location": "L36"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -52120,7 +52192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -52129,7 +52201,7 @@
       "source_location": "L96"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -52138,7 +52210,7 @@
       "source_location": "L94"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -52147,7 +52219,7 @@
       "source_location": "L95"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -52156,7 +52228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -52165,7 +52237,7 @@
       "source_location": "L98"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -52174,7 +52246,7 @@
       "source_location": "L33"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -52183,7 +52255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -52192,7 +52264,7 @@
       "source_location": "L85"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -52201,7 +52273,7 @@
       "source_location": "L31"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -52210,7 +52282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -52219,7 +52291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -52228,7 +52300,7 @@
       "source_location": "L5"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -52237,7 +52309,7 @@
       "source_location": "L12"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -52246,7 +52318,7 @@
       "source_location": "L43"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -52255,7 +52327,7 @@
       "source_location": "L11"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -52264,7 +52336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
       "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
@@ -52273,7 +52345,7 @@
       "source_location": "L75"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "approvalrequests_decideapprovalrequestwithctx",
       "label": "decideApprovalRequestWithCtx()",
@@ -52282,7 +52354,7 @@
       "source_location": "L25"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
       "label": "approvalRequests.ts",
@@ -52291,7 +52363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -52300,7 +52372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -52309,40 +52381,13 @@
       "source_location": "L22"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
       "source_location": "L99"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffroles_ts",
-      "label": "staffRoles.ts",
-      "norm_label": "staffroles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "staffroles_derivedefaultoperationalroles",
-      "label": "deriveDefaultOperationalRoles()",
-      "norm_label": "derivedefaultoperationalroles()",
-      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "staffroles_uniqueoperationalroles",
-      "label": "uniqueOperationalRoles()",
-      "norm_label": "uniqueoperationalroles()",
-      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
-      "source_location": "L31"
     },
     {
       "community": 25,
@@ -52482,6 +52527,33 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffroles_ts",
+      "label": "staffRoles.ts",
+      "norm_label": "staffroles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "staffroles_derivedefaultoperationalroles",
+      "label": "deriveDefaultOperationalRoles()",
+      "norm_label": "derivedefaultoperationalroles()",
+      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "staffroles_uniqueoperationalroles",
+      "label": "uniqueOperationalRoles()",
+      "norm_label": "uniqueoperationalroles()",
+      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
       "norm_label": "listtransactions()",
@@ -52489,7 +52561,7 @@
       "source_location": "L7"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -52498,7 +52570,7 @@
       "source_location": "L109"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -52507,7 +52579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
@@ -52516,7 +52588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -52525,7 +52597,7 @@
       "source_location": "L20"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -52534,7 +52606,7 @@
       "source_location": "L38"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -52543,7 +52615,7 @@
       "source_location": "L17"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -52552,7 +52624,7 @@
       "source_location": "L37"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -52561,7 +52633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -52570,7 +52642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -52579,7 +52651,7 @@
       "source_location": "L18"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -52588,7 +52660,7 @@
       "source_location": "L9"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -52597,7 +52669,7 @@
       "source_location": "L8"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -52606,7 +52678,7 @@
       "source_location": "L9"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -52615,7 +52687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -52624,7 +52696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -52633,7 +52705,7 @@
       "source_location": "L7"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -52642,7 +52714,7 @@
       "source_location": "L29"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -52651,7 +52723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -52660,7 +52732,7 @@
       "source_location": "L13"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -52669,7 +52741,7 @@
       "source_location": "L45"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -52678,7 +52750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -52687,7 +52759,7 @@
       "source_location": "L33"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -52696,7 +52768,7 @@
       "source_location": "L13"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -52705,7 +52777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -52714,40 +52786,13 @@
       "source_location": "L13"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
       "norm_label": "parsevalidator()",
       "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
       "source_location": "L17"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "appointments_buildserviceappointment",
-      "label": "buildServiceAppointment()",
-      "norm_label": "buildserviceappointment()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "appointments_findoverlappingappointment",
-      "label": "findOverlappingAppointment()",
-      "norm_label": "findoverlappingappointment()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
-      "label": "appointments.ts",
-      "norm_label": "appointments.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L1"
     },
     {
       "community": 26,
@@ -52887,6 +52932,33 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "appointments_buildserviceappointment",
+      "label": "buildServiceAppointment()",
+      "norm_label": "buildserviceappointment()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "appointments_findoverlappingappointment",
+      "label": "findOverlappingAppointment()",
+      "norm_label": "findoverlappingappointment()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
+      "label": "appointments.ts",
+      "norm_label": "appointments.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
       "norm_label": "servicecases.test.ts",
@@ -52894,7 +52966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -52903,7 +52975,7 @@
       "source_location": "L23"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -52912,7 +52984,7 @@
       "source_location": "L16"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -52921,7 +52993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -52930,7 +53002,7 @@
       "source_location": "L12"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -52939,7 +53011,7 @@
       "source_location": "L7"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -52948,7 +53020,7 @@
       "source_location": "L7"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -52957,7 +53029,7 @@
       "source_location": "L14"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -52966,7 +53038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -52975,7 +53047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -52984,7 +53056,7 @@
       "source_location": "L45"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -52993,7 +53065,7 @@
       "source_location": "L37"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -53002,7 +53074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -53011,7 +53083,7 @@
       "source_location": "L10"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -53020,7 +53092,7 @@
       "source_location": "L44"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -53029,7 +53101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -53038,7 +53110,7 @@
       "source_location": "L86"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -53047,7 +53119,7 @@
       "source_location": "L102"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -53056,7 +53128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -53065,7 +53137,7 @@
       "source_location": "L35"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -53074,7 +53146,7 @@
       "source_location": "L25"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -53083,7 +53155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -53092,7 +53164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -53101,7 +53173,7 @@
       "source_location": "L4"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -53110,7 +53182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -53119,40 +53191,13 @@
       "source_location": "L18"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
       "norm_label": "productavailabilityview()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
-      "label": "SheetProvider.tsx",
-      "norm_label": "sheetprovider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "sheetprovider_sheetprovider",
-      "label": "SheetProvider()",
-      "norm_label": "sheetprovider()",
-      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "sheetprovider_usesheet",
-      "label": "useSheet()",
-      "norm_label": "usesheet()",
-      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
-      "source_location": "L11"
     },
     {
       "community": 27,
@@ -53292,6 +53337,33 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
+      "label": "SheetProvider.tsx",
+      "norm_label": "sheetprovider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "sheetprovider_sheetprovider",
+      "label": "SheetProvider()",
+      "norm_label": "sheetprovider()",
+      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "sheetprovider_usesheet",
+      "label": "useSheet()",
+      "norm_label": "usesheet()",
+      "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
       "norm_label": "wigtype.tsx",
@@ -53299,7 +53371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -53308,7 +53380,7 @@
       "source_location": "L21"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -53317,7 +53389,7 @@
       "source_location": "L8"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -53326,7 +53398,7 @@
       "source_location": "L21"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -53335,7 +53407,7 @@
       "source_location": "L13"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -53344,7 +53416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -53353,7 +53425,7 @@
       "source_location": "L100"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -53362,7 +53434,7 @@
       "source_location": "L10"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -53371,7 +53443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -53380,7 +53452,7 @@
       "source_location": "L100"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -53389,7 +53461,7 @@
       "source_location": "L10"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -53398,7 +53470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -53407,7 +53479,7 @@
       "source_location": "L15"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -53416,7 +53488,7 @@
       "source_location": "L39"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -53425,7 +53497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -53434,7 +53506,7 @@
       "source_location": "L43"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -53443,7 +53515,7 @@
       "source_location": "L51"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -53452,7 +53524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -53461,7 +53533,7 @@
       "source_location": "L3"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -53470,7 +53542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -53479,7 +53551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -53488,7 +53560,7 @@
       "source_location": "L53"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -53497,7 +53569,7 @@
       "source_location": "L65"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -53506,7 +53578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -53515,7 +53587,7 @@
       "source_location": "L47"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -53524,40 +53596,13 @@
       "source_location": "L53"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
       "norm_label": "featuredsection.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
-      "label": "VideoPlayer.tsx",
-      "norm_label": "videoplayer.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
-      "label": "VideoPlayer.tsx",
-      "norm_label": "videoplayer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "videoplayer_videoplayer",
-      "label": "VideoPlayer()",
-      "norm_label": "videoplayer()",
-      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
-      "source_location": "L9"
     },
     {
       "community": 28,
@@ -53688,6 +53733,33 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
+      "label": "VideoPlayer.tsx",
+      "norm_label": "videoplayer.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
+      "label": "VideoPlayer.tsx",
+      "norm_label": "videoplayer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "videoplayer_videoplayer",
+      "label": "VideoPlayer()",
+      "norm_label": "videoplayer()",
+      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "operationsqueueview_handledecideapprovalrequest",
       "label": "handleDecideApprovalRequest()",
       "norm_label": "handledecideapprovalrequest()",
@@ -53695,7 +53767,7 @@
       "source_location": "L294"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "operationsqueueview_handlesubmitstockbatch",
       "label": "handleSubmitStockBatch()",
@@ -53704,7 +53776,7 @@
       "source_location": "L284"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_tsx",
       "label": "OperationsQueueView.tsx",
@@ -53713,7 +53785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -53722,7 +53794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -53731,7 +53803,7 @@
       "source_location": "L67"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -53740,7 +53812,7 @@
       "source_location": "L9"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "organization_switcher_handlesignout",
       "label": "handleSignOut()",
@@ -53749,7 +53821,7 @@
       "source_location": "L100"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "organization_switcher_onorganizationselect",
       "label": "onOrganizationSelect()",
@@ -53758,7 +53830,7 @@
       "source_location": "L95"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -53767,7 +53839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -53776,7 +53848,7 @@
       "source_location": "L36"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -53785,7 +53857,7 @@
       "source_location": "L32"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -53794,7 +53866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -53803,7 +53875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -53812,7 +53884,7 @@
       "source_location": "L20"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -53821,7 +53893,7 @@
       "source_location": "L26"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_workflowtracelink_tsx",
       "label": "WorkflowTraceLink.tsx",
@@ -53830,7 +53902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "workflowtracelink_getworkflowtracelinktarget",
       "label": "getWorkflowTraceLinkTarget()",
@@ -53839,7 +53911,7 @@
       "source_location": "L25"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "workflowtracelink_workflowtracelink",
       "label": "WorkflowTraceLink()",
@@ -53848,7 +53920,7 @@
       "source_location": "L36"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -53857,7 +53929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -53866,7 +53938,7 @@
       "source_location": "L65"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -53875,7 +53947,7 @@
       "source_location": "L20"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -53884,7 +53956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -53893,7 +53965,7 @@
       "source_location": "L16"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -53902,7 +53974,7 @@
       "source_location": "L60"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -53911,7 +53983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -53920,40 +53992,13 @@
       "source_location": "L45"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
       "norm_label": "productactionstogglegroup()",
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L19"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "addcomplimentaryproduct_addcomplimentaryproduct",
-      "label": "AddComplimentaryProduct()",
-      "norm_label": "addcomplimentaryproduct()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
-      "source_location": "L128"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
-      "label": "handleAddComplimentaryProducts()",
-      "norm_label": "handleaddcomplimentaryproducts()",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
-      "source_location": "L40"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
-      "label": "AddComplimentaryProduct.tsx",
-      "norm_label": "addcomplimentaryproduct.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
-      "source_location": "L1"
     },
     {
       "community": 29,
@@ -54084,6 +54129,33 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "addcomplimentaryproduct_addcomplimentaryproduct",
+      "label": "AddComplimentaryProduct()",
+      "norm_label": "addcomplimentaryproduct()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
+      "source_location": "L128"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
+      "label": "handleAddComplimentaryProducts()",
+      "norm_label": "handleaddcomplimentaryproducts()",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
+      "label": "AddComplimentaryProduct.tsx",
+      "norm_label": "addcomplimentaryproduct.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
       "norm_label": "handleblur()",
@@ -54091,7 +54163,7 @@
       "source_location": "L24"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -54100,7 +54172,7 @@
       "source_location": "L20"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -54109,7 +54181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -54118,7 +54190,7 @@
       "source_location": "L25"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -54127,7 +54199,7 @@
       "source_location": "L17"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -54136,7 +54208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -54145,7 +54217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -54154,7 +54226,7 @@
       "source_location": "L59"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -54163,7 +54235,7 @@
       "source_location": "L50"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -54172,7 +54244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -54181,7 +54253,7 @@
       "source_location": "L225"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -54190,7 +54262,7 @@
       "source_location": "L79"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "label": "StaffManagement.test.tsx",
@@ -54199,7 +54271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "staffmanagement_test_chooserole",
       "label": "chooseRole()",
@@ -54208,7 +54280,7 @@
       "source_location": "L125"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "staffmanagement_test_mockconvex",
       "label": "mockConvex()",
@@ -54217,7 +54289,7 @@
       "source_location": "L69"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -54226,7 +54298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -54235,7 +54307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -54244,7 +54316,7 @@
       "source_location": "L3"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -54253,7 +54325,7 @@
       "source_location": "L9"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -54262,7 +54334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -54271,7 +54343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -54280,7 +54352,7 @@
       "source_location": "L3"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -54289,7 +54361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -54298,7 +54370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -54307,7 +54379,7 @@
       "source_location": "L3"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -54316,40 +54388,13 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
       "norm_label": "dashboard-skeleton.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
-      "label": "table-skeleton.tsx",
-      "norm_label": "table-skeleton.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/loading/table-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
-      "label": "table-skeleton.tsx",
-      "norm_label": "table-skeleton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "table_skeleton_tableskeleton",
-      "label": "TableSkeleton()",
-      "norm_label": "tableskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
-      "source_location": "L3"
     },
     {
       "community": 3,
@@ -54759,6 +54804,33 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
+      "label": "table-skeleton.tsx",
+      "norm_label": "table-skeleton.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/loading/table-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
+      "label": "table-skeleton.tsx",
+      "norm_label": "table-skeleton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "table_skeleton_tableskeleton",
+      "label": "TableSkeleton()",
+      "norm_label": "tableskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
       "norm_label": "transactions-skeleton.tsx",
@@ -54766,7 +54838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -54775,7 +54847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -54784,7 +54856,7 @@
       "source_location": "L3"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -54793,7 +54865,7 @@
       "source_location": "L4"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -54802,7 +54874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -54811,7 +54883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -54820,7 +54892,7 @@
       "source_location": "L104"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -54829,7 +54901,7 @@
       "source_location": "L36"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -54838,7 +54910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
       "label": "WorkflowTraceRouteLink.tsx",
@@ -54847,7 +54919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
       "label": "getWorkflowTraceRouteTarget()",
@@ -54856,7 +54928,7 @@
       "source_location": "L23"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "workflowtraceroutelink_workflowtraceroutelink",
       "label": "WorkflowTraceRouteLink()",
@@ -54865,7 +54937,7 @@
       "source_location": "L41"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -54874,7 +54946,7 @@
       "source_location": "L20"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -54883,7 +54955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -54892,7 +54964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -54901,7 +54973,7 @@
       "source_location": "L30"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -54910,7 +54982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -54919,7 +54991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -54928,7 +55000,7 @@
       "source_location": "L9"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -54937,7 +55009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -54946,7 +55018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -54955,7 +55027,7 @@
       "source_location": "L38"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -54964,7 +55036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -54973,7 +55045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -54982,7 +55054,7 @@
       "source_location": "L20"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -54991,39 +55063,12 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
       "norm_label": "alert-modal.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "overlay_modal_overlaymodal",
-      "label": "OverlayModal()",
-      "norm_label": "overlaymodal()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
-      "label": "overlay-modal.tsx",
-      "norm_label": "overlay-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/overlay-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
-      "label": "overlay-modal.tsx",
-      "norm_label": "overlay-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -55042,7 +55087,7 @@
       "label": "assertValidServiceCaseStatusTransition()",
       "norm_label": "assertvalidservicecasestatustransition()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L216"
+      "source_location": "L226"
     },
     {
       "community": 31,
@@ -55051,7 +55096,7 @@
       "label": "buildServiceCase()",
       "norm_label": "buildservicecase()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L225"
+      "source_location": "L240"
     },
     {
       "community": 31,
@@ -55060,7 +55105,7 @@
       "label": "buildServiceCaseLineItem()",
       "norm_label": "buildservicecaselineitem()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L253"
+      "source_location": "L268"
     },
     {
       "community": 31,
@@ -55069,7 +55114,7 @@
       "label": "createServiceCaseWithCtx()",
       "norm_label": "createservicecasewithctx()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L275"
+      "source_location": "L304"
     },
     {
       "community": 31,
@@ -55078,7 +55123,7 @@
       "label": "deriveServiceCasePaymentStatus()",
       "norm_label": "deriveservicecasepaymentstatus()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L86"
+      "source_location": "L87"
     },
     {
       "community": 31,
@@ -55087,7 +55132,7 @@
       "label": "getServiceCaseContext()",
       "norm_label": "getservicecasecontext()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L190"
+      "source_location": "L191"
     },
     {
       "community": 31,
@@ -55096,7 +55141,7 @@
       "label": "listPendingApprovalRequestsWithCtx()",
       "norm_label": "listpendingapprovalrequestswithctx()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L143"
+      "source_location": "L144"
     },
     {
       "community": 31,
@@ -55105,7 +55150,7 @@
       "label": "listServiceCaseAllocationsWithCtx()",
       "norm_label": "listservicecaseallocationswithctx()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L130"
+      "source_location": "L131"
     },
     {
       "community": 31,
@@ -55114,7 +55159,7 @@
       "label": "listServiceCaseLineItemsWithCtx()",
       "norm_label": "listservicecaselineitemswithctx()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L110"
+      "source_location": "L111"
     },
     {
       "community": 31,
@@ -55123,7 +55168,7 @@
       "label": "listServiceInventoryUsageWithCtx()",
       "norm_label": "listserviceinventoryusagewithctx()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L120"
+      "source_location": "L121"
     },
     {
       "community": 31,
@@ -55132,7 +55177,7 @@
       "label": "mapServiceCaseStatusToWorkItemStatus()",
       "norm_label": "mapservicecasestatustoworkitemstatus()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L70"
+      "source_location": "L71"
     },
     {
       "community": 31,
@@ -55141,10 +55186,37 @@
       "label": "syncServiceCaseFinancialsWithCtx()",
       "norm_label": "syncservicecasefinancialswithctx()",
       "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L155"
+      "source_location": "L156"
     },
     {
       "community": 310,
+      "file_type": "code",
+      "id": "overlay_modal_overlaymodal",
+      "label": "OverlayModal()",
+      "norm_label": "overlaymodal()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
+      "label": "overlay-modal.tsx",
+      "norm_label": "overlay-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/overlay-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
+      "label": "overlay-modal.tsx",
+      "norm_label": "overlay-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -55153,7 +55225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -55162,7 +55234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -55171,7 +55243,7 @@
       "source_location": "L3"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -55180,7 +55252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -55189,7 +55261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -55198,7 +55270,7 @@
       "source_location": "L6"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -55207,7 +55279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -55216,7 +55288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -55225,7 +55297,7 @@
       "source_location": "L3"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -55234,7 +55306,7 @@
       "source_location": "L44"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -55243,7 +55315,7 @@
       "source_location": "L19"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -55252,7 +55324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -55261,7 +55333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -55270,7 +55342,7 @@
       "source_location": "L159"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -55279,7 +55351,7 @@
       "source_location": "L195"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -55288,7 +55360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -55297,7 +55369,7 @@
       "source_location": "L22"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -55306,7 +55378,7 @@
       "source_location": "L45"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -55315,7 +55387,7 @@
       "source_location": "L24"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -55324,7 +55396,7 @@
       "source_location": "L38"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -55333,7 +55405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -55342,7 +55414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -55351,7 +55423,7 @@
       "source_location": "L23"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -55360,7 +55432,7 @@
       "source_location": "L51"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -55369,7 +55441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -55378,40 +55450,13 @@
       "source_location": "L54"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
       "norm_label": "useproduct()",
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L282"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
-      "label": "UserContext.tsx",
-      "norm_label": "usercontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "usercontext_userprovider",
-      "label": "UserProvider()",
-      "norm_label": "userprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "usercontext_useusercontext",
-      "label": "useUserContext()",
-      "norm_label": "useusercontext()",
-      "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
-      "source_location": "L37"
     },
     {
       "community": 32,
@@ -55533,6 +55578,33 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
+      "label": "UserContext.tsx",
+      "norm_label": "usercontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "usercontext_userprovider",
+      "label": "UserProvider()",
+      "norm_label": "userprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "usercontext_useusercontext",
+      "label": "useUserContext()",
+      "norm_label": "useusercontext()",
+      "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
       "norm_label": "useauth.ts",
@@ -55540,7 +55612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -55549,7 +55621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -55558,7 +55630,7 @@
       "source_location": "L4"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -55567,7 +55639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -55576,7 +55648,7 @@
       "source_location": "L9"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -55585,7 +55657,7 @@
       "source_location": "L50"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -55594,7 +55666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -55603,7 +55675,7 @@
       "source_location": "L6"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -55612,7 +55684,7 @@
       "source_location": "L31"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -55621,7 +55693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -55630,7 +55702,7 @@
       "source_location": "L5"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -55639,7 +55711,7 @@
       "source_location": "L31"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -55648,7 +55720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -55657,7 +55729,7 @@
       "source_location": "L18"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -55666,7 +55738,7 @@
       "source_location": "L26"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
@@ -55675,7 +55747,7 @@
       "source_location": "L7"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -55684,7 +55756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -55693,7 +55765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -55702,7 +55774,7 @@
       "source_location": "L3"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -55711,7 +55783,7 @@
       "source_location": "L10"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -55720,7 +55792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -55729,7 +55801,7 @@
       "source_location": "L18"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -55738,7 +55810,7 @@
       "source_location": "L59"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -55747,7 +55819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -55756,7 +55828,7 @@
       "source_location": "L31"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -55765,40 +55837,13 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
       "norm_label": "main.tsx",
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
-      "label": "routeTree.browser-boundary.test.ts",
-      "norm_label": "routetree.browser-boundary.test.ts",
-      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "routetree_browser_boundary_test_collectsourcefiles",
-      "label": "collectSourceFiles()",
-      "norm_label": "collectsourcefiles()",
-      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "routetree_browser_boundary_test_findillegalconveximports",
-      "label": "findIllegalConvexImports()",
-      "norm_label": "findillegalconveximports()",
-      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
-      "source_location": "L46"
     },
     {
       "community": 33,
@@ -55920,6 +55965,33 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
+      "label": "routeTree.browser-boundary.test.ts",
+      "norm_label": "routetree.browser-boundary.test.ts",
+      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "routetree_browser_boundary_test_collectsourcefiles",
+      "label": "collectSourceFiles()",
+      "norm_label": "collectsourcefiles()",
+      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "routetree_browser_boundary_test_findillegalconveximports",
+      "label": "findIllegalConvexImports()",
+      "norm_label": "findillegalconveximports()",
+      "source_file": "packages/athena-webapp/src/routeTree.browser-boundary.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
       "norm_label": "authedcomponent()",
@@ -55927,7 +55999,7 @@
       "source_location": "L18"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -55936,7 +56008,7 @@
       "source_location": "L28"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -55945,7 +56017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -55954,7 +56026,7 @@
       "source_location": "L127"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -55963,7 +56035,7 @@
       "source_location": "L106"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -55972,7 +56044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -55981,7 +56053,7 @@
       "source_location": "L66"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -55990,7 +56062,7 @@
       "source_location": "L20"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -55999,7 +56071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -56008,7 +56080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -56017,7 +56089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -56026,7 +56098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -56035,7 +56107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -56044,7 +56116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -56053,7 +56125,7 @@
       "source_location": "L16"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -56062,7 +56134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -56071,7 +56143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -56080,7 +56152,7 @@
       "source_location": "L19"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -56089,7 +56161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "vitest_setup_pointercapturestub",
       "label": "pointerCaptureStub()",
@@ -56098,7 +56170,7 @@
       "source_location": "L23"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "vitest_setup_pointerreleasestub",
       "label": "pointerReleaseStub()",
@@ -56107,7 +56179,7 @@
       "source_location": "L24"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -56116,7 +56188,7 @@
       "source_location": "L32"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -56125,7 +56197,7 @@
       "source_location": "L3"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -56134,7 +56206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -56143,7 +56215,7 @@
       "source_location": "L7"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -56152,39 +56224,12 @@
       "source_location": "L5"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
       "norm_label": "color.ts",
       "source_file": "packages/storefront-webapp/src/api/color.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "organization_getallorganizations",
-      "label": "getAllOrganizations()",
-      "norm_label": "getallorganizations()",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "organization_getorganization",
-      "label": "getOrganization()",
-      "norm_label": "getorganization()",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L1"
     },
     {
@@ -56298,6 +56343,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "organization_getallorganizations",
+      "label": "getAllOrganizations()",
+      "norm_label": "getallorganizations()",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "organization_getorganization",
+      "label": "getOrganization()",
+      "norm_label": "getorganization()",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/storefront-webapp/src/api/organization.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
       "norm_label": "upsells.ts",
@@ -56305,7 +56377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -56314,7 +56386,7 @@
       "source_location": "L3"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -56323,7 +56395,7 @@
       "source_location": "L5"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -56332,7 +56404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -56341,7 +56413,7 @@
       "source_location": "L18"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -56350,7 +56422,7 @@
       "source_location": "L23"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -56359,7 +56431,7 @@
       "source_location": "L22"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -56368,7 +56440,7 @@
       "source_location": "L55"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -56377,7 +56449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -56386,7 +56458,7 @@
       "source_location": "L77"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -56395,7 +56467,7 @@
       "source_location": "L11"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -56404,7 +56476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -56413,7 +56485,7 @@
       "source_location": "L11"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -56422,7 +56494,7 @@
       "source_location": "L22"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -56431,7 +56503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -56440,7 +56512,7 @@
       "source_location": "L110"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -56449,7 +56521,7 @@
       "source_location": "L89"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -56458,7 +56530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -56467,7 +56539,7 @@
       "source_location": "L4"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -56476,7 +56548,7 @@
       "source_location": "L24"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -56485,7 +56557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -56494,7 +56566,7 @@
       "source_location": "L131"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -56503,7 +56575,7 @@
       "source_location": "L12"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -56512,7 +56584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -56521,7 +56593,7 @@
       "source_location": "L20"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -56530,40 +56602,13 @@
       "source_location": "L46"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
       "norm_label": "featuredproductssection.tsx",
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
-      "label": "PromoAlert.tsx",
-      "norm_label": "promoalert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "promoalert_getpromoalertcopy",
-      "label": "getPromoAlertCopy()",
-      "norm_label": "getpromoalertcopy()",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "promoalert_promoalert",
-      "label": "PromoAlert()",
-      "norm_label": "promoalert()",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L59"
     },
     {
       "community": 35,
@@ -56667,6 +56712,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
+      "label": "PromoAlert.tsx",
+      "norm_label": "promoalert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "promoalert_getpromoalertcopy",
+      "label": "getPromoAlertCopy()",
+      "norm_label": "getpromoalertcopy()",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "promoalert_promoalert",
+      "label": "PromoAlert()",
+      "norm_label": "promoalert()",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
       "norm_label": "rewardsalert.tsx",
@@ -56674,7 +56746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -56683,7 +56755,7 @@
       "source_location": "L25"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -56692,7 +56764,7 @@
       "source_location": "L20"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -56701,7 +56773,7 @@
       "source_location": "L30"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -56710,7 +56782,7 @@
       "source_location": "L95"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -56719,7 +56791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -56728,7 +56800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -56737,7 +56809,7 @@
       "source_location": "L61"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -56746,7 +56818,7 @@
       "source_location": "L65"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -56755,7 +56827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -56764,7 +56836,7 @@
       "source_location": "L150"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -56773,7 +56845,7 @@
       "source_location": "L157"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -56782,7 +56854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -56791,7 +56863,7 @@
       "source_location": "L63"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -56800,7 +56872,7 @@
       "source_location": "L48"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -56809,7 +56881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -56818,7 +56890,7 @@
       "source_location": "L63"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -56827,7 +56899,7 @@
       "source_location": "L76"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -56836,7 +56908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -56845,7 +56917,7 @@
       "source_location": "L51"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -56854,7 +56926,7 @@
       "source_location": "L36"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -56863,7 +56935,7 @@
       "source_location": "L16"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -56872,7 +56944,7 @@
       "source_location": "L39"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -56881,7 +56953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -56890,7 +56962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -56899,7 +56971,7 @@
       "source_location": "L25"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -56908,1042 +56980,7 @@
       "source_location": "L82"
     },
     {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
-      "label": "StorefrontObservabilityProvider.tsx",
-      "norm_label": "storefrontobservabilityprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "label": "StorefrontObservabilityProvider()",
-      "norm_label": "storefrontobservabilityprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "label": "useStorefrontObservability()",
-      "norm_label": "usestorefrontobservability()",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
-      "source_location": "L55"
-    },
-    {
       "community": 36,
-      "file_type": "code",
-      "id": "adjustments_applystockadjustmentbatchwithctx",
-      "label": "applyStockAdjustmentBatchWithCtx()",
-      "norm_label": "applystockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_assertdistinctstockadjustmentlineitems",
-      "label": "assertDistinctStockAdjustmentLineItems()",
-      "norm_label": "assertdistinctstockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_assertnormalizedlineitem",
-      "label": "assertNormalizedLineItem()",
-      "norm_label": "assertnormalizedlineitem()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_buildresolvedstockadjustmentstatus",
-      "label": "buildResolvedStockAdjustmentStatus()",
-      "norm_label": "buildresolvedstockadjustmentstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L197"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmentdecisioneventtype",
-      "label": "buildStockAdjustmentDecisionEventType()",
-      "norm_label": "buildstockadjustmentdecisioneventtype()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L187"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmentsourceid",
-      "label": "buildStockAdjustmentSourceId()",
-      "norm_label": "buildstockadjustmentsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmenttitle",
-      "label": "buildStockAdjustmentTitle()",
-      "norm_label": "buildstockadjustmenttitle()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
-      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
-      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L203"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchwithctx",
-      "label": "submitStockAdjustmentBatchWithCtx()",
-      "norm_label": "submitstockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L337"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "adjustments_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
-      "label": "adjustments.ts",
-      "norm_label": "adjustments.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 360,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
-      "label": "useProductDiscount.ts",
-      "norm_label": "useproductdiscount.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 360,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscount",
-      "label": "useProductDiscount()",
-      "norm_label": "useproductdiscount()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 360,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscounts",
-      "label": "useProductDiscounts()",
-      "norm_label": "useproductdiscounts()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 361,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
-      "label": "useShoppingBag.ts",
-      "norm_label": "useshoppingbag.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 361,
-      "file_type": "code",
-      "id": "useshoppingbag_isunavailableproductlist",
-      "label": "isUnavailableProductList()",
-      "norm_label": "isunavailableproductlist()",
-      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
-      "source_location": "L556"
-    },
-    {
-      "community": 361,
-      "file_type": "code",
-      "id": "useshoppingbag_useshoppingbag",
-      "label": "useShoppingBag()",
-      "norm_label": "useshoppingbag()",
-      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 362,
-      "file_type": "code",
-      "id": "index_getordermessage",
-      "label": "getOrderMessage()",
-      "norm_label": "getordermessage()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L429"
-    },
-    {
-      "community": 362,
-      "file_type": "code",
-      "id": "index_getpaymenttext",
-      "label": "getPaymentText()",
-      "norm_label": "getpaymenttext()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 362,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 363,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
-      "label": "review.tsx",
-      "norm_label": "review.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 363,
-      "file_type": "code",
-      "id": "review_getordermessage",
-      "label": "getOrderMessage()",
-      "norm_label": "getordermessage()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L250"
-    },
-    {
-      "community": 363,
-      "file_type": "code",
-      "id": "review_ordernavigation",
-      "label": "OrderNavigation()",
-      "norm_label": "ordernavigation()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 364,
-      "file_type": "code",
-      "id": "account_accountbeforeload",
-      "label": "accountBeforeLoad()",
-      "norm_label": "accountbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 364,
-      "file_type": "code",
-      "id": "account_handleonsubmitform",
-      "label": "handleOnSubmitForm()",
-      "norm_label": "handleonsubmitform()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 364,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
-      "label": "account.tsx",
-      "norm_label": "account.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 365,
-      "file_type": "code",
-      "id": "login_loginbeforeload",
-      "label": "loginBeforeLoad()",
-      "norm_label": "loginbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 365,
-      "file_type": "code",
-      "id": "login_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 365,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "label": "login.tsx",
-      "norm_label": "login.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 366,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
-      "label": "verify.index.tsx",
-      "norm_label": "verify.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 366,
-      "file_type": "code",
-      "id": "verify_index_verify",
-      "label": "Verify()",
-      "norm_label": "verify()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 366,
-      "file_type": "code",
-      "id": "verify_index_verifycheckoutsessionpayment",
-      "label": "VerifyCheckoutSessionPayment()",
-      "norm_label": "verifycheckoutsessionpayment()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L107"
-    },
-    {
-      "community": 367,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_signup_tsx",
-      "label": "signup.tsx",
-      "norm_label": "signup.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 367,
-      "file_type": "code",
-      "id": "signup_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 367,
-      "file_type": "code",
-      "id": "signup_signupbeforeload",
-      "label": "signupBeforeLoad()",
-      "norm_label": "signupbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "env_optionalnumberenv",
-      "label": "optionalNumberEnv()",
-      "norm_label": "optionalnumberenv()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "env_requireenv",
-      "label": "requireEnv()",
-      "norm_label": "requireenv()",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
-      "label": "env.ts",
-      "norm_label": "env.ts",
-      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "graphify_wiki_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "graphify_wiki_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "scripts_graphify_wiki_test_ts",
-      "label": "graphify-wiki.test.ts",
-      "norm_label": "graphify-wiki.test.ts",
-      "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 37,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 370,
-      "file_type": "code",
-      "id": "harness_audit_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 370,
-      "file_type": "code",
-      "id": "harness_audit_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 370,
-      "file_type": "code",
-      "id": "scripts_harness_audit_test_ts",
-      "label": "harness-audit.test.ts",
-      "norm_label": "harness-audit.test.ts",
-      "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 371,
-      "file_type": "code",
-      "id": "harness_behavior_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 371,
-      "file_type": "code",
-      "id": "harness_behavior_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 371,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_test_ts",
-      "label": "harness-behavior.test.ts",
-      "norm_label": "harness-behavior.test.ts",
-      "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 372,
-      "file_type": "code",
-      "id": "harness_check_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-check.test.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 372,
-      "file_type": "code",
-      "id": "harness_check_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-check.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 372,
-      "file_type": "code",
-      "id": "scripts_harness_check_test_ts",
-      "label": "harness-check.test.ts",
-      "norm_label": "harness-check.test.ts",
-      "source_file": "scripts/harness-check.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 373,
-      "file_type": "code",
-      "id": "harness_generate_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-generate.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 373,
-      "file_type": "code",
-      "id": "harness_generate_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-generate.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 373,
-      "file_type": "code",
-      "id": "scripts_harness_generate_test_ts",
-      "label": "harness-generate.test.ts",
-      "norm_label": "harness-generate.test.ts",
-      "source_file": "scripts/harness-generate.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 374,
-      "file_type": "code",
-      "id": "harness_inferential_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 374,
-      "file_type": "code",
-      "id": "harness_inferential_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 374,
-      "file_type": "code",
-      "id": "scripts_harness_inferential_review_test_ts",
-      "label": "harness-inferential-review.test.ts",
-      "norm_label": "harness-inferential-review.test.ts",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 375,
-      "file_type": "code",
-      "id": "harness_self_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 375,
-      "file_type": "code",
-      "id": "harness_self_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 375,
-      "file_type": "code",
-      "id": "scripts_harness_self_review_test_ts",
-      "label": "harness-self-review.test.ts",
-      "norm_label": "harness-self-review.test.ts",
-      "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 376,
-      "file_type": "code",
-      "id": "harness_test_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 376,
-      "file_type": "code",
-      "id": "harness_test_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 376,
-      "file_type": "code",
-      "id": "scripts_harness_test_test_ts",
-      "label": "harness-test.test.ts",
-      "norm_label": "harness-test.test.ts",
-      "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 377,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 377,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 377,
-      "file_type": "code",
-      "id": "scripts_pre_commit_generated_artifacts_test_ts",
-      "label": "pre-commit-generated-artifacts.test.ts",
-      "norm_label": "pre-commit-generated-artifacts.test.ts",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
-      "label": "runPreCommitGeneratedArtifacts()",
-      "norm_label": "runprecommitgeneratedartifacts()",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
-      "label": "stageTrackedGraphifyArtifacts()",
-      "norm_label": "stagetrackedgraphifyartifacts()",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "scripts_pre_commit_generated_artifacts_ts",
-      "label": "pre-commit-generated-artifacts.ts",
-      "norm_label": "pre-commit-generated-artifacts.ts",
-      "source_file": "scripts/pre-commit-generated-artifacts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "closeouts_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
-      "label": "closeouts.test.ts",
-      "norm_label": "closeouts.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 38,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 380,
-      "file_type": "code",
-      "id": "deposits_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 380,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
-      "label": "deposits.test.ts",
-      "norm_label": "deposits.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 381,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
-      "label": "paymentAllocationAttribution.test.ts",
-      "norm_label": "paymentallocationattribution.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 381,
-      "file_type": "code",
-      "id": "paymentallocationattribution_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 382,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
-      "label": "stream.ts",
-      "norm_label": "stream.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 382,
-      "file_type": "code",
-      "id": "stream_getcloudflareconfig",
-      "label": "getCloudflareConfig()",
-      "norm_label": "getcloudflareconfig()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 383,
-      "file_type": "code",
-      "id": "convexauditscript_test_createcommandshimbin",
-      "label": "createCommandShimBin()",
-      "norm_label": "createcommandshimbin()",
-      "source_file": "packages/athena-webapp/convex/convexAuditScript.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 383,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
-      "label": "convexAuditScript.test.ts",
-      "norm_label": "convexauditscript.test.ts",
-      "source_file": "packages/athena-webapp/convex/convexAuditScript.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 384,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
-      "label": "VerificationCode.tsx",
-      "norm_label": "verificationcode.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 384,
-      "file_type": "code",
-      "id": "verificationcode_verificationcode",
-      "label": "VerificationCode()",
-      "norm_label": "verificationcode()",
-      "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 385,
-      "file_type": "code",
-      "id": "mtnmomo_handlecollectionnotification",
-      "label": "handleCollectionNotification()",
-      "norm_label": "handlecollectionnotification()",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 385,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
-      "label": "mtnMomo.ts",
-      "norm_label": "mtnmomo.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 386,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
-      "label": "routerComposition.test.ts",
-      "norm_label": "routercomposition.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 386,
-      "file_type": "code",
-      "id": "routercomposition_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 387,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
-      "label": "posQueryCleanup.test.ts",
-      "norm_label": "posquerycleanup.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 387,
-      "file_type": "code",
-      "id": "posquerycleanup_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
-      "label": "sessionQueryIndexes.test.ts",
-      "norm_label": "sessionqueryindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "sessionqueryindexes_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "stores_tov2onlyconfig",
-      "label": "toV2OnlyConfig()",
-      "norm_label": "tov2onlyconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 39,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_utils_ts",
       "label": "utils.ts",
@@ -57952,7 +56989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 39,
+      "community": 36,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_ts",
       "label": "utils.ts",
@@ -57961,7 +56998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 39,
+      "community": 36,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
       "label": "utils.ts",
@@ -57970,7 +57007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 39,
+      "community": 36,
       "file_type": "code",
       "id": "utils_formatdeliveryaddress",
       "label": "formatDeliveryAddress()",
@@ -57979,7 +57016,7 @@
       "source_location": "L74"
     },
     {
-      "community": 39,
+      "community": 36,
       "file_type": "code",
       "id": "utils_getamountpaidfororder",
       "label": "getAmountPaidForOrder()",
@@ -57988,7 +57025,7 @@
       "source_location": "L128"
     },
     {
-      "community": 39,
+      "community": 36,
       "file_type": "code",
       "id": "utils_getdiscountvalue",
       "label": "getDiscountValue()",
@@ -57997,7 +57034,7 @@
       "source_location": "L17"
     },
     {
-      "community": 39,
+      "community": 36,
       "file_type": "code",
       "id": "utils_getorderamount",
       "label": "getOrderAmount()",
@@ -58006,7 +57043,7 @@
       "source_location": "L51"
     },
     {
-      "community": 39,
+      "community": 36,
       "file_type": "code",
       "id": "utils_getorderstate",
       "label": "getOrderState()",
@@ -58015,7 +57052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 39,
+      "community": 36,
       "file_type": "code",
       "id": "utils_getpickupactionstate",
       "label": "getPickupActionState()",
@@ -58024,7 +57061,7 @@
       "source_location": "L61"
     },
     {
-      "community": 39,
+      "community": 36,
       "file_type": "code",
       "id": "utils_getpotentialpoints",
       "label": "getPotentialPoints()",
@@ -58033,7 +57070,7 @@
       "source_location": "L107"
     },
     {
-      "community": 39,
+      "community": 36,
       "file_type": "code",
       "id": "utils_getproductdiscountvalue",
       "label": "getProductDiscountValue()",
@@ -58042,7 +57079,1042 @@
       "source_location": "L75"
     },
     {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
+      "label": "StorefrontObservabilityProvider.tsx",
+      "norm_label": "storefrontobservabilityprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
+      "label": "StorefrontObservabilityProvider()",
+      "norm_label": "storefrontobservabilityprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "storefrontobservabilityprovider_usestorefrontobservability",
+      "label": "useStorefrontObservability()",
+      "norm_label": "usestorefrontobservability()",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
+      "label": "useProductDiscount.ts",
+      "norm_label": "useproductdiscount.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscount",
+      "label": "useProductDiscount()",
+      "norm_label": "useproductdiscount()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscounts",
+      "label": "useProductDiscounts()",
+      "norm_label": "useproductdiscounts()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
+      "label": "useShoppingBag.ts",
+      "norm_label": "useshoppingbag.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
+      "id": "useshoppingbag_isunavailableproductlist",
+      "label": "isUnavailableProductList()",
+      "norm_label": "isunavailableproductlist()",
+      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
+      "source_location": "L556"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
+      "id": "useshoppingbag_useshoppingbag",
+      "label": "useShoppingBag()",
+      "norm_label": "useshoppingbag()",
+      "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 363,
+      "file_type": "code",
+      "id": "index_getordermessage",
+      "label": "getOrderMessage()",
+      "norm_label": "getordermessage()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L429"
+    },
+    {
+      "community": 363,
+      "file_type": "code",
+      "id": "index_getpaymenttext",
+      "label": "getPaymentText()",
+      "norm_label": "getpaymenttext()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 363,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 364,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
+      "label": "review.tsx",
+      "norm_label": "review.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 364,
+      "file_type": "code",
+      "id": "review_getordermessage",
+      "label": "getOrderMessage()",
+      "norm_label": "getordermessage()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L250"
+    },
+    {
+      "community": 364,
+      "file_type": "code",
+      "id": "review_ordernavigation",
+      "label": "OrderNavigation()",
+      "norm_label": "ordernavigation()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 365,
+      "file_type": "code",
+      "id": "account_accountbeforeload",
+      "label": "accountBeforeLoad()",
+      "norm_label": "accountbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 365,
+      "file_type": "code",
+      "id": "account_handleonsubmitform",
+      "label": "handleOnSubmitForm()",
+      "norm_label": "handleonsubmitform()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 365,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
+      "label": "account.tsx",
+      "norm_label": "account.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 366,
+      "file_type": "code",
+      "id": "login_loginbeforeload",
+      "label": "loginBeforeLoad()",
+      "norm_label": "loginbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 366,
+      "file_type": "code",
+      "id": "login_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 366,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_login_tsx",
+      "label": "login.tsx",
+      "norm_label": "login.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 367,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
+      "label": "verify.index.tsx",
+      "norm_label": "verify.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 367,
+      "file_type": "code",
+      "id": "verify_index_verify",
+      "label": "Verify()",
+      "norm_label": "verify()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 367,
+      "file_type": "code",
+      "id": "verify_index_verifycheckoutsessionpayment",
+      "label": "VerifyCheckoutSessionPayment()",
+      "norm_label": "verifycheckoutsessionpayment()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L107"
+    },
+    {
+      "community": 368,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_signup_tsx",
+      "label": "signup.tsx",
+      "norm_label": "signup.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 368,
+      "file_type": "code",
+      "id": "signup_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 368,
+      "file_type": "code",
+      "id": "signup_signupbeforeload",
+      "label": "signupBeforeLoad()",
+      "norm_label": "signupbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 369,
+      "file_type": "code",
+      "id": "env_optionalnumberenv",
+      "label": "optionalNumberEnv()",
+      "norm_label": "optionalnumberenv()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 369,
+      "file_type": "code",
+      "id": "env_requireenv",
+      "label": "requireEnv()",
+      "norm_label": "requireenv()",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 369,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
+      "label": "env.ts",
+      "norm_label": "env.ts",
+      "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "adjustments_applystockadjustmentbatchwithctx",
+      "label": "applyStockAdjustmentBatchWithCtx()",
+      "norm_label": "applystockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "adjustments_assertdistinctstockadjustmentlineitems",
+      "label": "assertDistinctStockAdjustmentLineItems()",
+      "norm_label": "assertdistinctstockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "adjustments_assertnormalizedlineitem",
+      "label": "assertNormalizedLineItem()",
+      "norm_label": "assertnormalizedlineitem()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "adjustments_buildresolvedstockadjustmentstatus",
+      "label": "buildResolvedStockAdjustmentStatus()",
+      "norm_label": "buildresolvedstockadjustmentstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L197"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "adjustments_buildstockadjustmentdecisioneventtype",
+      "label": "buildStockAdjustmentDecisionEventType()",
+      "norm_label": "buildstockadjustmentdecisioneventtype()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L187"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "adjustments_buildstockadjustmentsourceid",
+      "label": "buildStockAdjustmentSourceId()",
+      "norm_label": "buildstockadjustmentsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "adjustments_buildstockadjustmenttitle",
+      "label": "buildStockAdjustmentTitle()",
+      "norm_label": "buildstockadjustmenttitle()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
+      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
+      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L203"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "adjustments_submitstockadjustmentbatchwithctx",
+      "label": "submitStockAdjustmentBatchWithCtx()",
+      "norm_label": "submitstockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L337"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "adjustments_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 37,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "label": "adjustments.ts",
+      "norm_label": "adjustments.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "graphify_wiki_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "graphify_wiki_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "scripts_graphify_wiki_test_ts",
+      "label": "graphify-wiki.test.ts",
+      "norm_label": "graphify-wiki.test.ts",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "harness_audit_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "harness_audit_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "scripts_harness_audit_test_ts",
+      "label": "harness-audit.test.ts",
+      "norm_label": "harness-audit.test.ts",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
+      "id": "harness_behavior_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
+      "id": "harness_behavior_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_test_ts",
+      "label": "harness-behavior.test.ts",
+      "norm_label": "harness-behavior.test.ts",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 373,
+      "file_type": "code",
+      "id": "harness_check_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-check.test.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 373,
+      "file_type": "code",
+      "id": "harness_check_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-check.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 373,
+      "file_type": "code",
+      "id": "scripts_harness_check_test_ts",
+      "label": "harness-check.test.ts",
+      "norm_label": "harness-check.test.ts",
+      "source_file": "scripts/harness-check.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 374,
+      "file_type": "code",
+      "id": "harness_generate_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 374,
+      "file_type": "code",
+      "id": "harness_generate_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 374,
+      "file_type": "code",
+      "id": "scripts_harness_generate_test_ts",
+      "label": "harness-generate.test.ts",
+      "norm_label": "harness-generate.test.ts",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 375,
+      "file_type": "code",
+      "id": "harness_inferential_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 375,
+      "file_type": "code",
+      "id": "harness_inferential_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 375,
+      "file_type": "code",
+      "id": "scripts_harness_inferential_review_test_ts",
+      "label": "harness-inferential-review.test.ts",
+      "norm_label": "harness-inferential-review.test.ts",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 376,
+      "file_type": "code",
+      "id": "harness_self_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 376,
+      "file_type": "code",
+      "id": "harness_self_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 376,
+      "file_type": "code",
+      "id": "scripts_harness_self_review_test_ts",
+      "label": "harness-self-review.test.ts",
+      "norm_label": "harness-self-review.test.ts",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 377,
+      "file_type": "code",
+      "id": "harness_test_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 377,
+      "file_type": "code",
+      "id": "harness_test_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 377,
+      "file_type": "code",
+      "id": "scripts_harness_test_test_ts",
+      "label": "harness-test.test.ts",
+      "norm_label": "harness-test.test.ts",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 378,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 378,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 378,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_test_ts",
+      "label": "pre-commit-generated-artifacts.test.ts",
+      "norm_label": "pre-commit-generated-artifacts.test.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 379,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
+      "label": "runPreCommitGeneratedArtifacts()",
+      "norm_label": "runprecommitgeneratedartifacts()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 379,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
+      "label": "stageTrackedGraphifyArtifacts()",
+      "norm_label": "stagetrackedgraphifyartifacts()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 379,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_ts",
+      "label": "pre-commit-generated-artifacts.ts",
+      "norm_label": "pre-commit-generated-artifacts.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 38,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "closeouts_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
+      "label": "closeouts.test.ts",
+      "norm_label": "closeouts.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "deposits_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
+      "label": "deposits.test.ts",
+      "norm_label": "deposits.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/deposits.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
+      "label": "paymentAllocationAttribution.test.ts",
+      "norm_label": "paymentallocationattribution.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
+      "id": "paymentallocationattribution_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 383,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
+      "label": "stream.ts",
+      "norm_label": "stream.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 383,
+      "file_type": "code",
+      "id": "stream_getcloudflareconfig",
+      "label": "getCloudflareConfig()",
+      "norm_label": "getcloudflareconfig()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 384,
+      "file_type": "code",
+      "id": "convexauditscript_test_createcommandshimbin",
+      "label": "createCommandShimBin()",
+      "norm_label": "createcommandshimbin()",
+      "source_file": "packages/athena-webapp/convex/convexAuditScript.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 384,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
+      "label": "convexAuditScript.test.ts",
+      "norm_label": "convexauditscript.test.ts",
+      "source_file": "packages/athena-webapp/convex/convexAuditScript.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 385,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
+      "label": "VerificationCode.tsx",
+      "norm_label": "verificationcode.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 385,
+      "file_type": "code",
+      "id": "verificationcode_verificationcode",
+      "label": "VerificationCode()",
+      "norm_label": "verificationcode()",
+      "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 386,
+      "file_type": "code",
+      "id": "mtnmomo_handlecollectionnotification",
+      "label": "handleCollectionNotification()",
+      "norm_label": "handlecollectionnotification()",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 386,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
+      "label": "mtnMomo.ts",
+      "norm_label": "mtnmomo.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 387,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
+      "label": "routerComposition.test.ts",
+      "norm_label": "routercomposition.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 387,
+      "file_type": "code",
+      "id": "routercomposition_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 388,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
+      "label": "posQueryCleanup.test.ts",
+      "norm_label": "posquerycleanup.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 388,
+      "file_type": "code",
+      "id": "posquerycleanup_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 389,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
+      "label": "sessionQueryIndexes.test.ts",
+      "norm_label": "sessionqueryindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 389,
+      "file_type": "code",
+      "id": "sessionqueryindexes_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
+    },
+    {
+      "community": 39,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L1"
+    },
+    {
       "community": 390,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "stores_tov2onlyconfig",
+      "label": "toV2OnlyConfig()",
+      "norm_label": "tov2onlyconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 391,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -58051,7 +58123,7 @@
       "source_location": "L4"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -58060,7 +58132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -58069,7 +58141,7 @@
       "source_location": "L3"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -58078,7 +58150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -58087,7 +58159,7 @@
       "source_location": "L3"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -58096,7 +58168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -58105,7 +58177,7 @@
       "source_location": "L6"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -58114,7 +58186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -58123,7 +58195,7 @@
       "source_location": "L3"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -58132,7 +58204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -58141,7 +58213,7 @@
       "source_location": "L18"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -58150,7 +58222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -58159,7 +58231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -58168,7 +58240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -58177,7 +58249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -58186,7 +58258,7 @@
       "source_location": "L17"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -58195,31 +58267,13 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "staffprofiles_test_createstaffprofilesmutationctx",
       "label": "createStaffProfilesMutationCtx()",
       "norm_label": "createstaffprofilesmutationctx()",
       "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
       "source_location": "L15"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "emailotp_formatvalidtime",
-      "label": "formatValidTime()",
-      "norm_label": "formatvalidtime()",
-      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_otp_emailotp_ts",
-      "label": "EmailOTP.ts",
-      "norm_label": "emailotp.ts",
-      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
-      "source_location": "L1"
     },
     {
       "community": 4,
@@ -58575,6 +58629,24 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "emailotp_formatvalidtime",
+      "label": "formatValidTime()",
+      "norm_label": "formatvalidtime()",
+      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_otp_emailotp_ts",
+      "label": "EmailOTP.ts",
+      "norm_label": "emailotp.ts",
+      "source_file": "packages/athena-webapp/convex/otp/EmailOTP.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
       "norm_label": "createinventoryholdgateway()",
@@ -58582,7 +58654,7 @@
       "source_location": "L31"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
@@ -58591,7 +58663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -58600,7 +58672,7 @@
       "source_location": "L6"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -58609,7 +58681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -58618,7 +58690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -58627,7 +58699,7 @@
       "source_location": "L88"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -58636,7 +58708,7 @@
       "source_location": "L9"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -58645,7 +58717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -58654,7 +58726,7 @@
       "source_location": "L4"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -58663,7 +58735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -58672,7 +58744,7 @@
       "source_location": "L15"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
@@ -58681,7 +58753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
@@ -58690,7 +58762,7 @@
       "source_location": "L7"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -58699,7 +58771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -58708,7 +58780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -58717,7 +58789,7 @@
       "source_location": "L8"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -58726,31 +58798,13 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
       "norm_label": "getsource()",
       "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
       "source_location": "L13"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
-      "label": "vendors.test.ts",
-      "norm_label": "vendors.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "vendors_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
-      "source_location": "L5"
     },
     {
       "community": 41,
@@ -58845,6 +58899,24 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
+      "label": "vendors.test.ts",
+      "norm_label": "vendors.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "vendors_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
       "norm_label": "getstorefrontactorbyid()",
@@ -58852,7 +58924,7 @@
       "source_location": "L15"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -58861,7 +58933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -58870,7 +58942,7 @@
       "source_location": "L8"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -58879,7 +58951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -58888,7 +58960,7 @@
       "source_location": "L17"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -58897,7 +58969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -58906,7 +58978,7 @@
       "source_location": "L6"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -58915,7 +58987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -58924,7 +58996,7 @@
       "source_location": "L5"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -58933,7 +59005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -58942,7 +59014,7 @@
       "source_location": "L25"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -58951,7 +59023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -58960,7 +59032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -58969,7 +59041,7 @@
       "source_location": "L17"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -58978,7 +59050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -58987,7 +59059,7 @@
       "source_location": "L7"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -58996,31 +59068,13 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
       "norm_label": "listsavedbagitems()",
       "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
       "source_location": "L14"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
-      "label": "storefrontObservabilityReport.test.ts",
-      "norm_label": "storefrontobservabilityreport.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_test_createanalyticsevent",
-      "label": "createAnalyticsEvent()",
-      "norm_label": "createanalyticsevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
-      "source_location": "L8"
     },
     {
       "community": 42,
@@ -59115,6 +59169,24 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
+      "label": "storefrontObservabilityReport.test.ts",
+      "norm_label": "storefrontobservabilityreport.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_test_createanalyticsevent",
+      "label": "createAnalyticsEvent()",
+      "norm_label": "createanalyticsevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
       "norm_label": "syntheticmonitor.ts",
@@ -59122,7 +59194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -59131,7 +59203,7 @@
       "source_location": "L3"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -59140,7 +59212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -59149,7 +59221,7 @@
       "source_location": "L5"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -59158,7 +59230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -59167,7 +59239,7 @@
       "source_location": "L16"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -59176,7 +59248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -59185,7 +59257,7 @@
       "source_location": "L30"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possale_ts",
       "label": "posSale.ts",
@@ -59194,7 +59266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "possale_buildpossaletraceseed",
       "label": "buildPosSaleTraceSeed()",
@@ -59203,7 +59275,7 @@
       "source_location": "L43"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
@@ -59212,7 +59284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
@@ -59221,7 +59293,7 @@
       "source_location": "L43"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
       "label": "presentation.ts",
@@ -59230,7 +59302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "presentation_buildworkflowtraceviewmodel",
       "label": "buildWorkflowTraceViewModel()",
@@ -59239,7 +59311,7 @@
       "source_location": "L31"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
@@ -59248,7 +59320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -59257,7 +59329,7 @@
       "source_location": "L5"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -59266,30 +59338,12 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
       "norm_label": "validateserviceintakeinput()",
       "source_file": "packages/athena-webapp/shared/serviceIntake.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "organizationview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organizationview_tsx",
-      "label": "OrganizationView.tsx",
-      "norm_label": "organizationview.tsx",
-      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
       "source_location": "L1"
     },
     {
@@ -59385,6 +59439,24 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "organizationview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organizationview_tsx",
+      "label": "OrganizationView.tsx",
+      "norm_label": "organizationview.tsx",
+      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
@@ -59392,7 +59464,7 @@
       "source_location": "L12"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -59401,7 +59473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -59410,7 +59482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -59419,7 +59491,7 @@
       "source_location": "L11"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -59428,7 +59500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -59437,7 +59509,7 @@
       "source_location": "L11"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -59446,7 +59518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -59455,7 +59527,7 @@
       "source_location": "L3"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -59464,7 +59536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -59473,7 +59545,7 @@
       "source_location": "L12"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -59482,7 +59554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -59491,7 +59563,7 @@
       "source_location": "L42"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -59500,7 +59572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -59509,7 +59581,7 @@
       "source_location": "L13"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -59518,7 +59590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -59527,7 +59599,7 @@
       "source_location": "L42"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -59536,31 +59608,13 @@
       "source_location": "L31"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
       "norm_label": "barcodeqrviewer.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
-      "label": "ProcessingFees.tsx",
-      "norm_label": "processingfees.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "processingfees_processingfeesview",
-      "label": "ProcessingFeesView()",
-      "norm_label": "processingfeesview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
-      "source_location": "L10"
     },
     {
       "community": 44,
@@ -59655,6 +59709,24 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
+      "label": "ProcessingFees.tsx",
+      "norm_label": "processingfees.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "processingfees_processingfeesview",
+      "label": "ProcessingFeesView()",
+      "norm_label": "processingfeesview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
       "norm_label": "productattributes.tsx",
@@ -59662,7 +59734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -59671,7 +59743,7 @@
       "source_location": "L14"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -59680,7 +59752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -59689,7 +59761,7 @@
       "source_location": "L5"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -59698,7 +59770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -59707,7 +59779,7 @@
       "source_location": "L10"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -59716,7 +59788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -59725,7 +59797,7 @@
       "source_location": "L15"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -59734,7 +59806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -59743,7 +59815,7 @@
       "source_location": "L13"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -59752,7 +59824,7 @@
       "source_location": "L116"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -59761,7 +59833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -59770,7 +59842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -59779,7 +59851,7 @@
       "source_location": "L47"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -59788,7 +59860,7 @@
       "source_location": "L151"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -59797,7 +59869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -59806,30 +59878,12 @@
       "source_location": "L6"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
       "norm_label": "analyticsitems.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "analyticsproducts_analyticsproducts",
-      "label": "AnalyticsProducts()",
-      "norm_label": "analyticsproducts()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
-      "label": "AnalyticsProducts.tsx",
-      "norm_label": "analyticsproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
       "source_location": "L1"
     },
     {
@@ -59925,6 +59979,24 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "analyticsproducts_analyticsproducts",
+      "label": "AnalyticsProducts()",
+      "norm_label": "analyticsproducts()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
+      "label": "AnalyticsProducts.tsx",
+      "norm_label": "analyticsproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
       "norm_label": "analyticsusers()",
@@ -59932,7 +60004,7 @@
       "source_location": "L7"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -59941,7 +60013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -59950,7 +60022,7 @@
       "source_location": "L42"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -59959,7 +60031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -59968,7 +60040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -59977,7 +60049,7 @@
       "source_location": "L66"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -59986,7 +60058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -59995,7 +60067,7 @@
       "source_location": "L18"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -60004,7 +60076,7 @@
       "source_location": "L6"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -60013,7 +60085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -60022,7 +60094,7 @@
       "source_location": "L10"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -60031,7 +60103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -60040,7 +60112,7 @@
       "source_location": "L27"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -60049,7 +60121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -60058,7 +60130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -60067,7 +60139,7 @@
       "source_location": "L12"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -60076,30 +60148,12 @@
       "source_location": "L3"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
       "norm_label": "auth.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "index_login",
-      "label": "Login()",
-      "norm_label": "login()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
       "source_location": "L1"
     },
     {
@@ -60195,6 +60249,24 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "index_login",
+      "label": "Login()",
+      "norm_label": "login()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
       "norm_label": "handleloadproducts()",
@@ -60202,7 +60274,7 @@
       "source_location": "L49"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -60211,7 +60283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -60220,7 +60292,7 @@
       "source_location": "L23"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -60229,7 +60301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -60238,7 +60310,7 @@
       "source_location": "L50"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -60247,7 +60319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -60256,7 +60328,7 @@
       "source_location": "L13"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -60265,7 +60337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -60274,7 +60346,7 @@
       "source_location": "L11"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -60283,7 +60355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -60292,7 +60364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -60301,7 +60373,7 @@
       "source_location": "L7"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
@@ -60310,7 +60382,7 @@
       "source_location": "L32"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -60319,7 +60391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -60328,7 +60400,7 @@
       "source_location": "L29"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -60337,7 +60409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -60346,30 +60418,12 @@
       "source_location": "L37"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
       "norm_label": "featuredsectiondialog.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "home_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_home_tsx",
-      "label": "Home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
       "source_location": "L1"
     },
     {
@@ -60465,6 +60519,24 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "home_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_home_tsx",
+      "label": "Home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
       "norm_label": "handleupdateconfig()",
@@ -60472,7 +60544,7 @@
       "source_location": "L83"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -60481,7 +60553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -60490,7 +60562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -60499,7 +60571,7 @@
       "source_location": "L35"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -60508,7 +60580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -60517,7 +60589,7 @@
       "source_location": "L28"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -60526,7 +60598,7 @@
       "source_location": "L11"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -60535,7 +60607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -60544,7 +60616,7 @@
       "source_location": "L13"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -60553,7 +60625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -60562,7 +60634,7 @@
       "source_location": "L41"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -60571,7 +60643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -60580,7 +60652,7 @@
       "source_location": "L33"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -60589,7 +60661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -60598,7 +60670,7 @@
       "source_location": "L68"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -60607,7 +60679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -60616,31 +60688,13 @@
       "source_location": "L35"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
       "norm_label": "ordersview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
-      "label": "RefundsView.tsx",
-      "norm_label": "refundsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "refundsview_handlerefundorder",
-      "label": "handleRefundOrder()",
-      "norm_label": "handlerefundorder()",
-      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
-      "source_location": "L79"
     },
     {
       "community": 48,
@@ -60735,6 +60789,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
+      "label": "RefundsView.tsx",
+      "norm_label": "refundsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "refundsview_handlerefundorder",
+      "label": "handleRefundOrder()",
+      "norm_label": "handlerefundorder()",
+      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
+      "source_location": "L79"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
       "norm_label": "usegetactiveonlineorder.ts",
@@ -60742,7 +60814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -60751,7 +60823,7 @@
       "source_location": "L6"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -60760,7 +60832,7 @@
       "source_location": "L34"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -60769,7 +60841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -60778,7 +60850,7 @@
       "source_location": "L89"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -60787,7 +60859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "cashierview_cashierview",
       "label": "CashierView()",
@@ -60796,7 +60868,7 @@
       "source_location": "L8"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -60805,7 +60877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -60814,7 +60886,7 @@
       "source_location": "L5"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -60823,7 +60895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -60832,7 +60904,7 @@
       "source_location": "L7"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -60841,7 +60913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -60850,7 +60922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -60859,7 +60931,7 @@
       "source_location": "L13"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -60868,7 +60940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
@@ -60877,7 +60949,7 @@
       "source_location": "L35"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -60886,31 +60958,13 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
       "norm_label": "printinstructions()",
       "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
-      "label": "ProductCard.tsx",
-      "norm_label": "productcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "productcard_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
-      "source_location": "L14"
     },
     {
       "community": 49,
@@ -61005,6 +61059,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
+      "label": "ProductCard.tsx",
+      "norm_label": "productcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "productcard_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
       "norm_label": "productentry.tsx",
@@ -61012,7 +61084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -61021,7 +61093,7 @@
       "source_location": "L86"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -61030,7 +61102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -61039,7 +61111,7 @@
       "source_location": "L15"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -61048,7 +61120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "totalsdisplay_totalsdisplay",
       "label": "TotalsDisplay()",
@@ -61057,7 +61129,7 @@
       "source_location": "L14"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -61066,7 +61138,7 @@
       "source_location": "L18"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -61075,7 +61147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -61084,7 +61156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -61093,7 +61165,7 @@
       "source_location": "L8"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -61102,7 +61174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "registerdrawergate_registerdrawergate",
       "label": "RegisterDrawerGate()",
@@ -61111,7 +61183,7 @@
       "source_location": "L8"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -61120,7 +61192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
@@ -61129,7 +61201,7 @@
       "source_location": "L8"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
       "label": "transactionColumns.test.tsx",
@@ -61138,7 +61210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "transactioncolumns_test_rendertransactioncell",
       "label": "renderTransactionCell()",
@@ -61147,7 +61219,7 @@
       "source_location": "L46"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -61156,31 +61228,13 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
       "norm_label": "getpaymentmethodicon()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L27"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "barcodeview_barcodeview",
-      "label": "BarcodeView()",
-      "norm_label": "barcodeview()",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
-      "label": "BarcodeView.tsx",
-      "norm_label": "barcodeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 5,
@@ -61527,6 +61581,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "barcodeview_barcodeview",
+      "label": "BarcodeView()",
+      "norm_label": "barcodeview()",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
+      "label": "BarcodeView.tsx",
+      "norm_label": "barcodeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
       "norm_label": "categorizationview()",
@@ -61534,7 +61606,7 @@
       "source_location": "L6"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -61543,7 +61615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -61552,7 +61624,7 @@
       "source_location": "L38"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -61561,7 +61633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -61570,7 +61642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -61579,7 +61651,7 @@
       "source_location": "L10"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -61588,7 +61660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -61597,7 +61669,7 @@
       "source_location": "L6"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -61606,7 +61678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -61615,7 +61687,7 @@
       "source_location": "L5"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -61624,7 +61696,7 @@
       "source_location": "L17"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -61633,7 +61705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -61642,7 +61714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -61651,7 +61723,7 @@
       "source_location": "L4"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -61660,7 +61732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -61669,7 +61741,7 @@
       "source_location": "L84"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -61678,31 +61750,13 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
       "norm_label": "handledeletepromocode()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
       "source_location": "L22"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
-      "label": "PromoCodesView.tsx",
-      "norm_label": "promocodesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "promocodesview_promocodesview",
-      "label": "PromoCodesView()",
-      "norm_label": "promocodesview()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
-      "source_location": "L9"
     },
     {
       "community": 51,
@@ -61797,6 +61851,24 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
+      "label": "PromoCodesView.tsx",
+      "norm_label": "promocodesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "promocodesview_promocodesview",
+      "label": "PromoCodesView()",
+      "norm_label": "promocodesview()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
       "norm_label": "selectablecategories.tsx",
@@ -61804,7 +61876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -61813,7 +61885,7 @@
       "source_location": "L23"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -61822,7 +61894,7 @@
       "source_location": "L5"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -61831,7 +61903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -61840,7 +61912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -61849,7 +61921,7 @@
       "source_location": "L4"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -61858,7 +61930,7 @@
       "source_location": "L13"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -61867,7 +61939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -61876,7 +61948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -61885,7 +61957,7 @@
       "source_location": "L29"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -61894,7 +61966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -61903,7 +61975,7 @@
       "source_location": "L20"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -61912,31 +61984,13 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
       "norm_label": "chooseselectoption()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
-      "label": "ServiceCasesView.tsx",
-      "norm_label": "servicecasesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "servicecasesview_handlecreatecase",
-      "label": "handleCreateCase()",
-      "norm_label": "handlecreatecase()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L178"
+      "source_location": "L63"
     },
     {
       "community": 518,
@@ -65073,73 +65127,73 @@
     {
       "community": 63,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L43"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L1"
     },
     {
@@ -65325,74 +65379,74 @@
     {
       "community": 64,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L558"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L531"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L523"
     },
     {
       "community": 640,
@@ -65577,74 +65631,74 @@
     {
       "community": 65,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
       "source_location": "L1"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "sessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L880"
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L225"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L874"
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L141"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L870"
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L104"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L890"
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L558"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L650"
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L217"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L727"
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L531"
     },
     {
       "community": 65,
       "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L632"
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L523"
     },
     {
       "community": 650,
@@ -65829,74 +65883,74 @@
     {
       "community": 66,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
       "source_location": "L1"
     },
     {
       "community": 66,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
+      "id": "sessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L880"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L874"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L870"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "sessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L890"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "sessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L650"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "sessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L727"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "sessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L632"
     },
     {
       "community": 660,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -19271,7 +19271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L173",
+      "source_location": "L177",
       "target": "servicecasesview_applycommandresult",
       "weight": 1
     },
@@ -19283,7 +19283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L200",
+      "source_location": "L204",
       "target": "servicecasesview_handlecreatecase",
       "weight": 1
     },
@@ -19295,7 +19295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L778",
+      "source_location": "L782",
       "target": "servicecasesview_withsavestate",
       "weight": 1
     },
@@ -36107,7 +36107,7 @@
       "relation": "calls",
       "source": "servicecasesview_applycommandresult",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L232",
+      "source_location": "L236",
       "target": "servicecasesview_handlecreatecase",
       "weight": 1
     },
@@ -50722,7 +50722,7 @@
       "label": "applyCommandResult()",
       "norm_label": "applycommandresult()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L173"
+      "source_location": "L177"
     },
     {
       "community": 214,
@@ -50731,7 +50731,7 @@
       "label": "handleCreateCase()",
       "norm_label": "handlecreatecase()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L200"
+      "source_location": "L204"
     },
     {
       "community": 214,
@@ -50740,7 +50740,7 @@
       "label": "withSaveState()",
       "norm_label": "withsavestate()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L778"
+      "source_location": "L782"
     },
     {
       "community": 215,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1484
-- Graph nodes: 3716
-- Graph edges: 3241
+- Graph nodes: 3718
+- Graph edges: 3244
 - Communities: 1399
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (11 edges, Community 34) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (3 edges, Community 235) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (3 edges, Community 236) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `deleteKeysIndividually()` (3 edges, Community 34) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (3 edges, Community 34) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (3 edges, Community 34) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/operations/serviceIntake.ts
+++ b/packages/athena-webapp/convex/operations/serviceIntake.ts
@@ -326,6 +326,11 @@ export const createServiceIntake = mutation({
       serviceMode: "same_day",
       storeId: args.storeId,
     });
+    if (serviceCase.kind === "user_error") {
+      return serviceCase;
+    }
+
+    const createdServiceCase = serviceCase.data;
 
     const approvalRequest = hasDeposit
       ? await (async () => {
@@ -345,7 +350,7 @@ export const createServiceIntake = mutation({
               requestedByStaffProfileId: createdByStaffProfile?._id,
               requestedByUserId: args.createdByUserId,
               storeId: args.storeId,
-              subjectId: serviceCase._id,
+              subjectId: createdServiceCase._id,
               subjectType: "service_case",
               workItemId: workItem._id,
             })
@@ -368,7 +373,7 @@ export const createServiceIntake = mutation({
       organizationId: store.organizationId,
       quantityDelta: 1,
       reasonCode: "service_item_checkin",
-      sourceId: serviceCase._id,
+      sourceId: createdServiceCase._id,
       sourceType: "service_case",
       storeId: args.storeId,
       workItemId: workItem._id,
@@ -387,7 +392,7 @@ export const createServiceIntake = mutation({
             organizationId: store.organizationId,
             registerSessionId: resolvedRegisterSessionId,
             storeId: args.storeId,
-            targetId: serviceCase._id,
+            targetId: createdServiceCase._id,
             targetType: "service_case",
             workItemId: workItem._id,
           })
@@ -409,7 +414,7 @@ export const createServiceIntake = mutation({
       paymentAllocationId: paymentAllocation?._id,
       registerSessionId: resolvedRegisterSessionId,
       storeId: args.storeId,
-      subjectId: serviceCase._id,
+      subjectId: createdServiceCase._id,
       subjectLabel: workItem.title,
       subjectType: "service_case",
       workItemId: workItem._id,
@@ -418,7 +423,7 @@ export const createServiceIntake = mutation({
     return ok({
       approvalRequestId: approvalRequest?._id,
       customerProfileId: customerProfile._id,
-      serviceCaseId: serviceCase._id,
+      serviceCaseId: createdServiceCase._id,
       workItemId: workItem._id,
     });
   },

--- a/packages/athena-webapp/convex/serviceOps/appointments.ts
+++ b/packages/athena-webapp/convex/serviceOps/appointments.ts
@@ -412,10 +412,15 @@ export const convertAppointmentToWalkIn = mutation({
       serviceMode: catalogItem.serviceMode,
       storeId: appointment.storeId,
     });
+    if (serviceCase.kind === "user_error") {
+      return serviceCase;
+    }
+
+    const createdServiceCase = serviceCase.data;
 
     await ctx.db.patch("serviceAppointment", appointment._id, {
       convertedAt: Date.now(),
-      serviceCaseId: serviceCase._id,
+      serviceCaseId: createdServiceCase._id,
       status: "converted_to_walk_in",
       updatedAt: Date.now(),
     });
@@ -435,7 +440,7 @@ export const convertAppointmentToWalkIn = mutation({
 
     return ok({
       appointmentId: appointment._id,
-      serviceCaseId: serviceCase._id,
+      serviceCaseId: createdServiceCase._id,
       workItemId: workItem._id,
     });
   },

--- a/packages/athena-webapp/convex/serviceOps/serviceCases.test.ts
+++ b/packages/athena-webapp/convex/serviceOps/serviceCases.test.ts
@@ -64,18 +64,30 @@ describe("service ops schema foundations", () => {
   });
 
   it("allows only supported service-case transitions", () => {
-    expect(() =>
+    expect(
       assertValidServiceCaseStatusTransition("intake", "in_progress")
-    ).not.toThrow();
-    expect(() =>
+    ).toEqual({ kind: "ok", data: null });
+    expect(
       assertValidServiceCaseStatusTransition("in_progress", "awaiting_pickup")
-    ).not.toThrow();
-    expect(() =>
+    ).toEqual({ kind: "ok", data: null });
+    expect(
       assertValidServiceCaseStatusTransition("completed", "in_progress")
-    ).toThrow("Invalid service case status transition");
-    expect(() =>
+    ).toEqual({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message: "Invalid service case status transition.",
+      },
+    });
+    expect(
       assertValidServiceCaseStatusTransition("cancelled", "completed")
-    ).toThrow("Invalid service case status transition");
+    ).toEqual({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message: "Invalid service case status transition.",
+      },
+    });
   });
 
   it("shapes service cases and line items with persistence-safe defaults", () => {
@@ -96,7 +108,7 @@ describe("service ops schema foundations", () => {
       status: "intake",
     });
 
-    expect(() =>
+    expect(
       buildServiceCaseLineItem({
         description: "Closure repair mesh",
         lineType: "material",
@@ -104,7 +116,13 @@ describe("service ops schema foundations", () => {
         serviceCaseId: "case_1" as Id<"serviceCase">,
         unitPrice: 50,
       })
-    ).toThrow("Line item quantity must be greater than zero");
+    ).toEqual({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message: "Line item quantity must be greater than zero.",
+      },
+    });
 
     expect(
       buildServiceCaseLineItem({
@@ -115,9 +133,12 @@ describe("service ops schema foundations", () => {
         unitPrice: 150,
       })
     ).toMatchObject({
-      amount: 300,
-      quantity: 2,
-      unitPrice: 150,
+      kind: "ok",
+      data: {
+        amount: 300,
+        quantity: 2,
+        unitPrice: 150,
+      },
     });
   });
 });

--- a/packages/athena-webapp/convex/serviceOps/serviceCases.ts
+++ b/packages/athena-webapp/convex/serviceOps/serviceCases.ts
@@ -17,6 +17,7 @@ import {
   recordPaymentAllocationWithCtx,
   summarizePaymentAllocations,
 } from "../operations/paymentAllocations";
+import { ok, userError, type CommandResult } from "../../shared/commandResult";
 
 export const SERVICE_CASE_STATUSES = [
   "intake",
@@ -194,7 +195,10 @@ async function getServiceCaseContext(
   const serviceCase = await ctx.db.get("serviceCase", serviceCaseId);
 
   if (!serviceCase) {
-    throw new Error("Service case not found.");
+    return userError({
+      code: "not_found",
+      message: "Service case not found.",
+    });
   }
 
   const [workItem, store] = await Promise.all([
@@ -203,23 +207,34 @@ async function getServiceCaseContext(
   ]);
 
   if (!workItem) {
-    throw new Error("Operational work item not found for service case.");
+    return userError({
+      code: "not_found",
+      message: "Operational work item not found for service case.",
+    });
   }
 
   if (!store) {
-    throw new Error("Store not found.");
+    return userError({
+      code: "not_found",
+      message: "Store not found.",
+    });
   }
 
-  return { serviceCase, store, workItem };
+  return ok({ serviceCase, store, workItem });
 }
 
 export function assertValidServiceCaseStatusTransition(
   currentStatus: ServiceCaseStatus,
   nextStatus: ServiceCaseStatus
-) {
+): CommandResult<null> {
   if (!SERVICE_CASE_STATUS_TRANSITIONS[currentStatus].includes(nextStatus)) {
-    throw new Error("Invalid service case status transition");
+    return userError({
+      code: "validation_failed",
+      message: "Invalid service case status transition.",
+    });
   }
+
+  return ok(null);
 }
 
 export function buildServiceCase(args: {
@@ -256,20 +271,34 @@ export function buildServiceCaseLineItem(args: {
   quantity: number;
   serviceCaseId: Id<"serviceCase">;
   unitPrice: number;
-}) {
+}): CommandResult<{
+  amount: number;
+  createdAt: number;
+  description: string;
+  lineType: ServiceCaseLineType;
+  quantity: number;
+  serviceCaseId: Id<"serviceCase">;
+  unitPrice: number;
+}> {
   if (args.quantity <= 0) {
-    throw new Error("Line item quantity must be greater than zero");
+    return userError({
+      code: "validation_failed",
+      message: "Line item quantity must be greater than zero.",
+    });
   }
 
   if (args.unitPrice < 0) {
-    throw new Error("Line item unit price cannot be negative");
+    return userError({
+      code: "validation_failed",
+      message: "Line item unit price cannot be negative.",
+    });
   }
 
-  return {
+  return ok({
     ...args,
     amount: args.quantity * args.unitPrice,
     createdAt: Date.now(),
-  };
+  });
 }
 
 export async function createServiceCaseWithCtx(
@@ -284,14 +313,17 @@ export async function createServiceCaseWithCtx(
     .first();
 
   if (existingServiceCase) {
-    return existingServiceCase;
+    return ok(existingServiceCase);
   }
 
   const serviceCaseId = await ctx.db.insert("serviceCase", buildServiceCase(args));
   const serviceCase = await ctx.db.get("serviceCase", serviceCaseId);
 
   if (!serviceCase) {
-    throw new Error("Unable to create the service case.");
+    return userError({
+      code: "unavailable",
+      message: "Unable to create the service case.",
+    });
   }
 
   const workItem = await ctx.db.get("operationalWorkItem", args.operationalWorkItemId);
@@ -318,7 +350,7 @@ export async function createServiceCaseWithCtx(
     workItemId: args.operationalWorkItemId,
   });
 
-  return serviceCase;
+  return ok(serviceCase);
 }
 
 export const createServiceCase = mutation({
@@ -342,12 +374,18 @@ export const createServiceCase = mutation({
   handler: async (ctx, args) => {
     const store = await ctx.db.get("store", args.storeId);
     if (!store) {
-      throw new Error("Store not found.");
+      return userError({
+        code: "not_found",
+        message: "Store not found.",
+      });
     }
 
     const workItem = await ctx.db.get("operationalWorkItem", args.operationalWorkItemId);
     if (!workItem || workItem.storeId !== args.storeId) {
-      throw new Error("Operational work item not found for this store.");
+      return userError({
+        code: "not_found",
+        message: "Operational work item not found for this store.",
+      });
     }
 
     return createServiceCaseWithCtx(ctx, {
@@ -464,11 +502,20 @@ export const addServiceCaseLineItem = mutation({
     unitPrice: v.number(),
   },
   handler: async (ctx, args) => {
-    const { serviceCase, workItem } = await getServiceCaseContext(ctx, args.serviceCaseId);
+    const serviceCaseContext = await getServiceCaseContext(ctx, args.serviceCaseId);
+    if (serviceCaseContext.kind === "user_error") {
+      return serviceCaseContext;
+    }
+
+    const { serviceCase, workItem } = serviceCaseContext.data;
+    const lineItemResult = buildServiceCaseLineItem(args);
+    if (lineItemResult.kind === "user_error") {
+      return lineItemResult;
+    }
 
     const lineItemId = await ctx.db.insert(
       "serviceCaseLineItem",
-      buildServiceCaseLineItem(args)
+      lineItemResult.data
     );
 
     const nextServiceCase = await syncServiceCaseFinancialsWithCtx(ctx, serviceCase);
@@ -483,10 +530,10 @@ export const addServiceCaseLineItem = mutation({
       workItemId: workItem._id,
     });
 
-    return {
+    return ok({
       lineItem: await ctx.db.get("serviceCaseLineItem", lineItemId),
       serviceCase: nextServiceCase,
-    };
+    });
   },
 });
 
@@ -504,10 +551,18 @@ export const recordServiceInventoryUsage = mutation({
   },
   handler: async (ctx, args) => {
     if (args.quantity <= 0) {
-      throw new Error("Inventory usage quantity must be greater than zero.");
+      return userError({
+        code: "validation_failed",
+        message: "Inventory usage quantity must be greater than zero.",
+      });
     }
 
-    const { serviceCase, workItem } = await getServiceCaseContext(ctx, args.serviceCaseId);
+    const serviceCaseContext = await getServiceCaseContext(ctx, args.serviceCaseId);
+    if (serviceCaseContext.kind === "user_error") {
+      return serviceCaseContext;
+    }
+
+    const { serviceCase, workItem } = serviceCaseContext.data;
     const usageType = args.usageType ?? "consumed";
     const usageId = await ctx.db.insert("serviceInventoryUsage", {
       createdAt: Date.now(),
@@ -564,7 +619,7 @@ export const recordServiceInventoryUsage = mutation({
       workItemId: workItem._id,
     });
 
-    return ctx.db.get("serviceInventoryUsage", usageId);
+    return ok(await ctx.db.get("serviceInventoryUsage", usageId));
   },
 });
 
@@ -581,7 +636,12 @@ export const recordServicePayment = mutation({
     serviceCaseId: v.id("serviceCase"),
   },
   handler: async (ctx, args) => {
-    const { serviceCase, workItem } = await getServiceCaseContext(ctx, args.serviceCaseId);
+    const serviceCaseContext = await getServiceCaseContext(ctx, args.serviceCaseId);
+    if (serviceCaseContext.kind === "user_error") {
+      return serviceCaseContext;
+    }
+
+    const { serviceCase, workItem } = serviceCaseContext.data;
     const collectedInStore = args.collectedInStore ?? true;
     const resolvedRegisterSessionId = collectedInStore
       ? await resolveRegisterSessionForInStoreCollectionWithCtx(ctx, {
@@ -626,7 +686,7 @@ export const recordServicePayment = mutation({
       workItemId: workItem._id,
     });
 
-    return nextServiceCase;
+    return ok(nextServiceCase);
   },
 });
 
@@ -645,9 +705,20 @@ export const updateServiceCaseStatus = mutation({
     ),
   },
   handler: async (ctx, args) => {
-    const { serviceCase, workItem } = await getServiceCaseContext(ctx, args.serviceCaseId);
+    const serviceCaseContext = await getServiceCaseContext(ctx, args.serviceCaseId);
+    if (serviceCaseContext.kind === "user_error") {
+      return serviceCaseContext;
+    }
 
-    assertValidServiceCaseStatusTransition(serviceCase.status, args.status);
+    const { serviceCase, workItem } = serviceCaseContext.data;
+
+    const statusTransitionResult = assertValidServiceCaseStatusTransition(
+      serviceCase.status,
+      args.status
+    );
+    if (statusTransitionResult.kind === "user_error") {
+      return statusTransitionResult;
+    }
 
     const [currentServiceCase, pendingApprovals, paymentAllocations] = await Promise.all([
       syncServiceCaseFinancialsWithCtx(ctx, serviceCase),
@@ -658,15 +729,24 @@ export const updateServiceCaseStatus = mutation({
     const paymentSummary = summarizePaymentAllocations(paymentAllocations);
 
     if ((currentServiceCase?.balanceDueAmount ?? 0) > 0 && args.status === "completed") {
-      throw new Error("Cannot complete a service case with an outstanding balance.");
+      return userError({
+        code: "precondition_failed",
+        message: "Cannot complete a service case with an outstanding balance.",
+      });
     }
 
     if (args.status === "completed" && pendingApprovals.length > 0) {
-      throw new Error("Resolve pending approvals before completing the service case.");
+      return userError({
+        code: "precondition_failed",
+        message: "Resolve pending approvals before completing the service case.",
+      });
     }
 
     if (args.status === "cancelled" && paymentSummary.netAmount > 0) {
-      throw new Error("Refund service payments before cancelling the case.");
+      return userError({
+        code: "precondition_failed",
+        message: "Refund service payments before cancelling the case.",
+      });
     }
 
     await ctx.db.patch("serviceCase", serviceCase._id, {
@@ -700,7 +780,7 @@ export const updateServiceCaseStatus = mutation({
       workItemId: workItem._id,
     });
 
-    return ctx.db.get("serviceCase", serviceCase._id);
+    return ok(await ctx.db.get("serviceCase", serviceCase._id));
   },
 });
 
@@ -725,7 +805,10 @@ export const createWalkInServiceCase = mutation({
     const store = await ctx.db.get("store", args.storeId);
 
     if (!store) {
-      throw new Error("Store not found.");
+      return userError({
+        code: "not_found",
+        message: "Store not found.",
+      });
     }
 
     const createdByStaffProfile = args.createdByUserId
@@ -752,7 +835,10 @@ export const createWalkInServiceCase = mutation({
     });
 
     if (!workItem) {
-      throw new Error("Unable to create the service work item.");
+      return userError({
+        code: "unavailable",
+        message: "Unable to create the service work item.",
+      });
     }
 
     return createServiceCaseWithCtx(ctx, {

--- a/packages/athena-webapp/convex/serviceOps/serviceCases.ts
+++ b/packages/athena-webapp/convex/serviceOps/serviceCases.ts
@@ -320,10 +320,7 @@ export async function createServiceCaseWithCtx(
   const serviceCase = await ctx.db.get("serviceCase", serviceCaseId);
 
   if (!serviceCase) {
-    return userError({
-      code: "unavailable",
-      message: "Unable to create the service case.",
-    });
+    throw new Error("Unable to create the service case.");
   }
 
   const workItem = await ctx.db.get("operationalWorkItem", args.operationalWorkItemId);
@@ -720,15 +717,20 @@ export const updateServiceCaseStatus = mutation({
       return statusTransitionResult;
     }
 
-    const [currentServiceCase, pendingApprovals, paymentAllocations] = await Promise.all([
-      syncServiceCaseFinancialsWithCtx(ctx, serviceCase),
+    const [lineItems, pendingApprovals, paymentAllocations] = await Promise.all([
+      listServiceCaseLineItemsWithCtx(ctx, serviceCase._id),
       listPendingApprovalRequestsWithCtx(ctx, workItem._id),
       listServiceCaseAllocationsWithCtx(ctx, serviceCase.storeId, serviceCase._id),
     ]);
 
+    const totalAmount =
+      lineItems.length > 0
+        ? lineItems.reduce((sum, lineItem) => sum + lineItem.amount, 0)
+        : serviceCase.quotedAmount ?? 0;
     const paymentSummary = summarizePaymentAllocations(paymentAllocations);
+    const balanceDueAmount = Math.max(totalAmount - paymentSummary.netAmount, 0);
 
-    if ((currentServiceCase?.balanceDueAmount ?? 0) > 0 && args.status === "completed") {
+    if (balanceDueAmount > 0 && args.status === "completed") {
       return userError({
         code: "precondition_failed",
         message: "Cannot complete a service case with an outstanding balance.",
@@ -748,6 +750,8 @@ export const updateServiceCaseStatus = mutation({
         message: "Refund service payments before cancelling the case.",
       });
     }
+
+    await syncServiceCaseFinancialsWithCtx(ctx, serviceCase);
 
     await ctx.db.patch("serviceCase", serviceCase._id, {
       cancelledAt: args.status === "cancelled" ? Date.now() : undefined,

--- a/packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx
@@ -245,4 +245,77 @@ describe("ServiceCasesViewContent", () => {
       await screen.findByText("Refund service payments before cancelling the case."),
     ).toBeInTheDocument();
   });
+
+  it("clears detail errors when switching to a different case", async () => {
+    const user = userEvent.setup();
+    const onUpdateStatus = vi.fn().mockResolvedValueOnce(
+      userError({
+        code: "precondition_failed",
+        message: "Refund service payments before cancelling the case.",
+      }),
+    );
+
+    const { rerender } = render(
+      <ServiceCasesViewContent
+        {...baseProps}
+        onUpdateStatus={onUpdateStatus}
+        serviceCases={[
+          ...baseProps.serviceCases,
+          {
+            _id: "case-2",
+            balanceDueAmount: 0,
+            customerName: "Kojo Mensimah",
+            paymentStatus: "paid",
+            pendingApprovalCount: 0,
+            serviceCatalogName: "Revamp",
+            staffName: "Adjoa Tetteh",
+            status: "awaiting_pickup",
+          },
+        ]}
+      />,
+    );
+
+    await chooseSelectOption(user, /case status/i, /cancelled/i);
+    await user.click(screen.getByRole("button", { name: /update status/i }));
+
+    expect(
+      await screen.findByText("Refund service payments before cancelling the case."),
+    ).toBeInTheDocument();
+
+    rerender(
+      <ServiceCasesViewContent
+        {...baseProps}
+        onUpdateStatus={onUpdateStatus}
+        selectedCaseDetails={{
+          _id: "case-2",
+          balanceDueAmount: 0,
+          lineItems: [],
+          paymentAllocations: [],
+          paymentStatus: "paid",
+          pendingApprovals: [],
+          status: "awaiting_pickup",
+        }}
+        selectedCaseId="case-2"
+        serviceCases={[
+          ...baseProps.serviceCases,
+          {
+            _id: "case-2",
+            balanceDueAmount: 0,
+            customerName: "Kojo Mensimah",
+            paymentStatus: "paid",
+            pendingApprovalCount: 0,
+            serviceCatalogName: "Revamp",
+            staffName: "Adjoa Tetteh",
+            status: "awaiting_pickup",
+          },
+        ]}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Refund service payments before cancelling the case."),
+      ).not.toBeInTheDocument(),
+    );
+  });
 });

--- a/packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GENERIC_UNEXPECTED_ERROR_MESSAGE, userError } from "~/shared/commandResult";
 import { ServiceCasesViewContent } from "./ServiceCasesView";
 
 const baseProps = {
@@ -20,11 +21,11 @@ const baseProps = {
   hasFullAdminAccess: true,
   isLoadingPermissions: false,
   isSaving: false,
-  onAddLineItem: vi.fn().mockResolvedValue(undefined),
-  onCreateCase: vi.fn().mockResolvedValue(undefined),
-  onRecordInventoryUsage: vi.fn().mockResolvedValue(undefined),
-  onRecordPayment: vi.fn().mockResolvedValue(undefined),
-  onUpdateStatus: vi.fn().mockResolvedValue(undefined),
+  onAddLineItem: vi.fn().mockResolvedValue({ kind: "ok", data: null }),
+  onCreateCase: vi.fn().mockResolvedValue({ kind: "ok", data: null }),
+  onRecordInventoryUsage: vi.fn().mockResolvedValue({ kind: "ok", data: null }),
+  onRecordPayment: vi.fn().mockResolvedValue({ kind: "ok", data: null }),
+  onUpdateStatus: vi.fn().mockResolvedValue({ kind: "ok", data: null }),
   searchQuery: "",
   selectedCaseDetails: {
     _id: "case-1",
@@ -76,7 +77,7 @@ describe("ServiceCasesViewContent", () => {
 
   it("validates required walk-in case fields before creating", async () => {
     const user = userEvent.setup();
-    const onCreateCase = vi.fn().mockResolvedValue(undefined);
+    const onCreateCase = vi.fn().mockResolvedValue({ kind: "ok", data: null });
 
     render(<ServiceCasesViewContent {...baseProps} onCreateCase={onCreateCase} />);
 
@@ -90,7 +91,7 @@ describe("ServiceCasesViewContent", () => {
 
   it("creates walk-in service cases from selected customers and catalog items", async () => {
     const user = userEvent.setup();
-    const onCreateCase = vi.fn().mockResolvedValue(undefined);
+    const onCreateCase = vi.fn().mockResolvedValue({ kind: "ok", data: null });
 
     render(<ServiceCasesViewContent {...baseProps} onCreateCase={onCreateCase} />);
 
@@ -115,10 +116,10 @@ describe("ServiceCasesViewContent", () => {
 
   it("renders case details and dispatches payment, inventory, line-item, and status actions", async () => {
     const user = userEvent.setup();
-    const onAddLineItem = vi.fn().mockResolvedValue(undefined);
-    const onRecordInventoryUsage = vi.fn().mockResolvedValue(undefined);
-    const onRecordPayment = vi.fn().mockResolvedValue(undefined);
-    const onUpdateStatus = vi.fn().mockResolvedValue(undefined);
+    const onAddLineItem = vi.fn().mockResolvedValue({ kind: "ok", data: null });
+    const onRecordInventoryUsage = vi.fn().mockResolvedValue({ kind: "ok", data: null });
+    const onRecordPayment = vi.fn().mockResolvedValue({ kind: "ok", data: null });
+    const onUpdateStatus = vi.fn().mockResolvedValue({ kind: "ok", data: null });
 
     render(
       <ServiceCasesViewContent
@@ -169,5 +170,79 @@ describe("ServiceCasesViewContent", () => {
       serviceCaseId: "case-1",
       status: "awaiting_pickup",
     });
+  });
+
+  it("renders safe user_error copy inline for create failures and clears stale errors before retry", async () => {
+    const user = userEvent.setup();
+    const onCreateCase = vi
+      .fn()
+      .mockResolvedValueOnce(
+        userError({
+          code: "precondition_failed",
+          message: "Assigned staff member is not available for this store.",
+        }),
+      )
+      .mockResolvedValueOnce({ kind: "ok", data: null });
+
+    render(<ServiceCasesViewContent {...baseProps} onCreateCase={onCreateCase} />);
+
+    await user.click(screen.getByRole("button", { name: /use customer/i }));
+    await user.type(screen.getByLabelText(/service title/i), "Closure Repair");
+    await chooseSelectOption(user, /assigned staff/i, /adjoa tetteh/i);
+    await user.click(screen.getByRole("button", { name: /create service case/i }));
+
+    expect(
+      await screen.findByText("Assigned staff member is not available for this store."),
+    ).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText(/service title/i));
+    await user.type(screen.getByLabelText(/service title/i), "Revamp");
+    await user.click(screen.getByRole("button", { name: /create service case/i }));
+
+    await waitFor(() => expect(onCreateCase).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Assigned staff member is not available for this store."),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("renders generic fallback copy inline for unexpected create failures", async () => {
+    const user = userEvent.setup();
+    const onCreateCase = vi.fn().mockResolvedValue({
+      kind: "unexpected_error",
+      error: {
+        title: "Something went wrong",
+        message: GENERIC_UNEXPECTED_ERROR_MESSAGE,
+      },
+    });
+
+    render(<ServiceCasesViewContent {...baseProps} onCreateCase={onCreateCase} />);
+
+    await user.click(screen.getByRole("button", { name: /use customer/i }));
+    await user.type(screen.getByLabelText(/service title/i), "Closure Repair");
+    await chooseSelectOption(user, /assigned staff/i, /adjoa tetteh/i);
+    await user.click(screen.getByRole("button", { name: /create service case/i }));
+
+    expect(await screen.findByText(GENERIC_UNEXPECTED_ERROR_MESSAGE)).toBeInTheDocument();
+  });
+
+  it("renders safe inline copy for status update failures", async () => {
+    const user = userEvent.setup();
+    const onUpdateStatus = vi.fn().mockResolvedValue(
+      userError({
+        code: "precondition_failed",
+        message: "Refund service payments before cancelling the case.",
+      }),
+    );
+
+    render(<ServiceCasesViewContent {...baseProps} onUpdateStatus={onUpdateStatus} />);
+
+    await chooseSelectOption(user, /case status/i, /cancelled/i);
+    await user.click(screen.getByRole("button", { name: /update status/i }));
+
+    expect(
+      await screen.findByText("Refund service payments before cancelling the case."),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/services/ServiceCasesView.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCasesView.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useMemo, useState } from "react";
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { toast } from "sonner";
 import View from "../View";
@@ -169,6 +169,10 @@ export function ServiceCasesViewContent({
     () => serviceCases.find((serviceCase) => serviceCase._id === selectedCaseId) ?? null,
     [selectedCaseId, serviceCases]
   );
+
+  useEffect(() => {
+    setDetailErrors([]);
+  }, [selectedCaseId]);
 
   const applyCommandResult = (
     result: ServiceCaseCommandResult,

--- a/packages/athena-webapp/src/components/services/ServiceCasesView.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCasesView.tsx
@@ -17,6 +17,10 @@ import {
   SelectValue,
 } from "../ui/select";
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
+import {
+  type NormalizedCommandResult,
+  runCommand,
+} from "@/lib/errors/runCommand";
 import { api } from "~/convex/_generated/api";
 
 type CustomerResult = {
@@ -66,6 +70,8 @@ type CreateServiceCaseArgs = {
   title: string;
 };
 
+type ServiceCaseCommandResult = NormalizedCommandResult<unknown>;
+
 type ServiceCasesViewContentProps = {
   catalogItems: CatalogItem[];
   customerResults: CustomerResult[];
@@ -78,23 +84,25 @@ type ServiceCasesViewContentProps = {
     quantity: number;
     serviceCaseId: string;
     unitPrice: number;
-  }) => Promise<void>;
-  onCreateCase: (args: CreateServiceCaseArgs) => Promise<void>;
+  }) => Promise<ServiceCaseCommandResult>;
+  onCreateCase: (
+    args: CreateServiceCaseArgs
+  ) => Promise<ServiceCaseCommandResult>;
   onRecordInventoryUsage: (args: {
     productSkuId: string;
     quantity: number;
     serviceCaseId: string;
     usageType: "consumed";
-  }) => Promise<void>;
+  }) => Promise<ServiceCaseCommandResult>;
   onRecordPayment: (args: {
     amount: number;
     method: string;
     serviceCaseId: string;
-  }) => Promise<void>;
+  }) => Promise<ServiceCaseCommandResult>;
   onUpdateStatus: (args: {
     serviceCaseId: string;
     status: string;
-  }) => Promise<void>;
+  }) => Promise<ServiceCaseCommandResult>;
   searchQuery: string;
   selectedCaseDetails: ServiceCaseDetails | null;
   selectedCaseId: string | null;
@@ -154,12 +162,26 @@ export function ServiceCasesViewContent({
   const [inventoryForm, setInventoryForm] = useState(initialInventoryForm);
   const [paymentForm, setPaymentForm] = useState(initialPaymentForm);
   const [statusValue, setStatusValue] = useState("in_progress");
-  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+  const [createErrors, setCreateErrors] = useState<string[]>([]);
+  const [detailErrors, setDetailErrors] = useState<string[]>([]);
 
   const selectedCaseSummary = useMemo(
     () => serviceCases.find((serviceCase) => serviceCase._id === selectedCaseId) ?? null,
     [selectedCaseId, serviceCases]
   );
+
+  const applyCommandResult = (
+    result: ServiceCaseCommandResult,
+    setErrors: (errors: string[]) => void
+  ) => {
+    if (result.kind === "ok") {
+      setErrors([]);
+      return true;
+    }
+
+    setErrors([result.error.message]);
+    return false;
+  };
 
   if (isLoadingPermissions) {
     return (
@@ -191,29 +213,29 @@ export function ServiceCasesViewContent({
     }
 
     if (errors.length > 0) {
-      setValidationErrors(errors);
+      setCreateErrors(errors);
       return;
     }
 
-    try {
-      await onCreateCase({
-        assignedStaffProfileId: createForm.assignedStaffProfileId,
-        customerProfileId: createForm.selectedCustomerId,
-        quotedAmount: createForm.quotedAmount.trim()
-          ? Number(createForm.quotedAmount)
-          : undefined,
-        serviceCatalogId: createForm.serviceCatalogId || undefined,
-        serviceMode: createForm.serviceMode,
-        title: createForm.title.trim(),
-      });
-      setCreateForm(initialCreateForm);
-      setSearchQuery("");
-      setValidationErrors([]);
-    } catch (error) {
-      toast.error("Failed to create service case", {
-        description: (error as Error).message,
-      });
+    setCreateErrors([]);
+    const result = await onCreateCase({
+      assignedStaffProfileId: createForm.assignedStaffProfileId,
+      customerProfileId: createForm.selectedCustomerId,
+      quotedAmount: createForm.quotedAmount.trim()
+        ? Number(createForm.quotedAmount)
+        : undefined,
+      serviceCatalogId: createForm.serviceCatalogId || undefined,
+      serviceMode: createForm.serviceMode,
+      title: createForm.title.trim(),
+    });
+
+    if (!applyCommandResult(result, setCreateErrors)) {
+      return;
     }
+
+    setCreateForm(initialCreateForm);
+    setSearchQuery("");
+    toast.success("Service case created");
   };
 
   const activeServiceCaseId = selectedCaseDetails?._id ?? selectedCaseId;
@@ -237,10 +259,10 @@ export function ServiceCasesViewContent({
             </p>
           </div>
 
-          {validationErrors.length > 0 ? (
+          {createErrors.length > 0 ? (
             <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
               <ul className="list-disc pl-5">
-                {validationErrors.map((error) => (
+                {createErrors.map((error) => (
                   <li key={error}>{error}</li>
                 ))}
               </ul>
@@ -432,6 +454,16 @@ export function ServiceCasesViewContent({
               />
             ) : (
               <>
+                {detailErrors.length > 0 ? (
+                  <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                    <ul className="list-disc pl-5">
+                      {detailErrors.map((error) => (
+                        <li key={error}>{error}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+
                 <div>
                   <h3 className="text-base font-medium">
                     {selectedCaseSummary.serviceCatalogName ?? "Service case"}
@@ -487,13 +519,21 @@ export function ServiceCasesViewContent({
                       </Select>
                     </div>
                     <Button
-                      onClick={() =>
-                        onRecordPayment({
+                      onClick={async () => {
+                        setDetailErrors([]);
+                        const result = await onRecordPayment({
                           amount: Number(paymentForm.amount),
                           method: paymentForm.method,
                           serviceCaseId: activeServiceCaseId,
-                        })
-                      }
+                        });
+
+                        if (!applyCommandResult(result, setDetailErrors)) {
+                          return;
+                        }
+
+                        setPaymentForm(initialPaymentForm);
+                        toast.success("Payment recorded");
+                      }}
                       type="button"
                       variant="outline"
                     >
@@ -523,12 +563,19 @@ export function ServiceCasesViewContent({
                       </Select>
                     </div>
                     <Button
-                      onClick={() =>
-                        onUpdateStatus({
+                      onClick={async () => {
+                        setDetailErrors([]);
+                        const result = await onUpdateStatus({
                           serviceCaseId: activeServiceCaseId,
                           status: statusValue,
-                        })
-                      }
+                        });
+
+                        if (!applyCommandResult(result, setDetailErrors)) {
+                          return;
+                        }
+
+                        toast.success("Service case updated");
+                      }}
                       type="button"
                       variant="outline"
                     >
@@ -582,15 +629,23 @@ export function ServiceCasesViewContent({
                       </div>
                     </div>
                     <Button
-                      onClick={() =>
-                        onAddLineItem({
+                      onClick={async () => {
+                        setDetailErrors([]);
+                        const result = await onAddLineItem({
                           description: lineItemForm.description,
                           lineType: lineItemForm.lineType,
                           quantity: Number(lineItemForm.quantity),
                           serviceCaseId: activeServiceCaseId,
                           unitPrice: Number(lineItemForm.unitPrice),
-                        })
-                      }
+                        });
+
+                        if (!applyCommandResult(result, setDetailErrors)) {
+                          return;
+                        }
+
+                        setLineItemForm(initialLineItemForm);
+                        toast.success("Line item added");
+                      }}
                       type="button"
                       variant="outline"
                     >
@@ -628,14 +683,22 @@ export function ServiceCasesViewContent({
                       />
                     </div>
                     <Button
-                      onClick={() =>
-                        onRecordInventoryUsage({
+                      onClick={async () => {
+                        setDetailErrors([]);
+                        const result = await onRecordInventoryUsage({
                           productSkuId: inventoryForm.productSkuId,
                           quantity: Number(inventoryForm.quantity),
                           serviceCaseId: activeServiceCaseId,
                           usageType: "consumed",
-                        })
-                      }
+                        });
+
+                        if (!applyCommandResult(result, setDetailErrors)) {
+                          return;
+                        }
+
+                        setInventoryForm(initialInventoryForm);
+                        toast.success("Material usage recorded");
+                      }}
                       type="button"
                       variant="outline"
                     >
@@ -712,10 +775,10 @@ export function ServiceCasesView() {
     api.serviceOps.serviceCases.updateServiceCaseStatus
   );
 
-  const withSaveState = async (action: () => Promise<void>) => {
+  const withSaveState = async <T,>(action: () => Promise<T>) => {
     setIsSaving(true);
     try {
-      await action();
+      return await action();
     } finally {
       setIsSaving(false);
     }
@@ -765,57 +828,67 @@ export function ServiceCasesView() {
       isLoadingPermissions={false}
       isSaving={isSaving}
       onAddLineItem={(args) =>
-        withSaveState(async () => {
-          await addServiceCaseLineItem({
-            ...args,
-            serviceCaseId: args.serviceCaseId as any,
-          });
-          toast.success("Line item added");
-        })
+        withSaveState(() =>
+          runCommand(() =>
+            addServiceCaseLineItem({
+              ...args,
+              serviceCaseId: args.serviceCaseId as any,
+            })
+          )
+        )
       }
       onCreateCase={(args) =>
         withSaveState(async () => {
-          const createdCase = await createWalkInServiceCase({
-            ...args,
-            assignedStaffProfileId: args.assignedStaffProfileId as any,
-            customerProfileId: args.customerProfileId as any,
-            serviceCatalogId: args.serviceCatalogId
-              ? (args.serviceCatalogId as any)
-              : undefined,
-            storeId: activeStore._id,
-          });
-          setSelectedCaseId((createdCase as any)?._id ?? null);
-          toast.success("Service case created");
+          const result = await runCommand(() =>
+            createWalkInServiceCase({
+              ...args,
+              assignedStaffProfileId: args.assignedStaffProfileId as any,
+              customerProfileId: args.customerProfileId as any,
+              serviceCatalogId: args.serviceCatalogId
+                ? (args.serviceCatalogId as any)
+                : undefined,
+              storeId: activeStore._id,
+            })
+          );
+
+          if (result.kind === "ok") {
+            setSelectedCaseId((result.data as any)?._id ?? null);
+          }
+
+          return result;
         })
       }
       onRecordInventoryUsage={(args) =>
-        withSaveState(async () => {
-          await recordServiceInventoryUsage({
-            ...args,
-            productSkuId: args.productSkuId as any,
-            serviceCaseId: args.serviceCaseId as any,
-          });
-          toast.success("Material usage recorded");
-        })
+        withSaveState(() =>
+          runCommand(() =>
+            recordServiceInventoryUsage({
+              ...args,
+              productSkuId: args.productSkuId as any,
+              serviceCaseId: args.serviceCaseId as any,
+            })
+          )
+        )
       }
       onRecordPayment={(args) =>
-        withSaveState(async () => {
-          await recordServicePayment({
-            ...args,
-            serviceCaseId: args.serviceCaseId as any,
-          });
-          toast.success("Payment recorded");
-        })
+        withSaveState(() =>
+          runCommand(() =>
+            recordServicePayment({
+              ...args,
+              serviceCaseId: args.serviceCaseId as any,
+            })
+          )
+        )
       }
       onUpdateStatus={(args) =>
-        withSaveState(async () => {
-          await updateServiceCaseStatus({
-            ...args,
-            serviceCaseId: args.serviceCaseId as any,
-            status: args.status as any,
-          });
-          toast.success("Service case updated");
-        })
+        withSaveState(() =>
+          runCommand(() =>
+            updateServiceCaseStatus({
+              ...args,
+              serviceCaseId: args.serviceCaseId as any,
+              status: args.status as any,
+            })
+          )
+        )
       }
       searchQuery={searchQuery}
       selectedCaseDetails={selectedCaseDetails ?? null}


### PR DESCRIPTION
## Summary\n- migrate service case server mutations to CommandResult/user_error responses\n- move service case UI actions onto runCommand with inline durable-surface error handling\n- update service case tests and rebuild graphify after the migration\n\n## Verification\n- bun run --filter '@athena/webapp' test -- convex/serviceOps/serviceCases.test.ts src/components/services/ServiceCasesView.test.tsx\n- bun run --filter '@athena/webapp' test convex/serviceOps/serviceCases.test.ts convex/serviceOps/catalogAppointments.test.ts convex/serviceOps/moduleWiring.test.ts convex/operations/serviceIntake.test.ts src/components/services/ServiceIntakeView.test.tsx src/components/services/ServiceIntakeView.auth.test.tsx src/components/services/ServiceAppointmentsView.test.tsx src/components/services/ServiceCasesView.test.tsx src/components/services/ServiceCatalogView.test.tsx src/components/operations/OperationsQueueView.test.tsx\n- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json\n- bun run --filter '@athena/webapp' audit:convex\n- bun run --filter '@athena/webapp' lint:convex:changed\n- bun run --filter '@athena/webapp' build\n- git diff --check\n- bun run graphify:rebuild